### PR TITLE
nv2a: Replace some non-critical assertions with debug macros

### DIFF
--- a/hw/xbox/nv2a/nv2a_debug.h
+++ b/hw/xbox/nv2a/nv2a_debug.h
@@ -62,4 +62,30 @@ void gl_debug_frame_terminator(void);
 # define NV2A_GL_DFRAME_TERMINATOR()               do { } while (0)
 #endif
 
+/* Debug prints to identify when unimplemented or unconfirmed features
+ * are being exercised. These cases likely result in graphical problems of
+ * varying degree, but should otherwise not crash the system. Enable this
+ * macro for debugging.
+ */
+// #define DEBUG_NV2A_FEATURES 1
+
+#ifdef DEBUG_NV2A_FEATURES
+
+/* Feature which has not yet been confirmed */
+#define NV2A_UNCONFIRMED(format, ...) do { \
+    fprintf(stderr, "nv2a: Warning unconfirmed feature: " format "\n", ## __VA_ARGS__); \
+} while (0)
+
+/* Feature which is not implemented */
+#define NV2A_UNIMPLEMENTED(format, ...) do { \
+    fprintf(stderr, "nv2a: Warning unimplemented feature: " format "\n", ## __VA_ARGS__); \
+} while (0)
+
+#else
+
+#define NV2A_UNCONFIRMED(...) do {} while (0)
+#define NV2A_UNIMPLEMENTED(...) do {} while (0)
+
+#endif
+
 #endif

--- a/hw/xbox/nv2a/nv2a_pgraph.c
+++ b/hw/xbox/nv2a/nv2a_pgraph.c
@@ -1866,7 +1866,7 @@ static void pgraph_method(NV2AState *d,
 
             } else {
                 NV2A_GL_DPRINTF(true, "EMPTY NV097_SET_BEGIN_END");
-                assert(false);
+                NV2A_UNCONFIRMED("EMPTY NV097_SET_BEGIN_END");
             }
 
             /* End of visibility testing */
@@ -3650,10 +3650,10 @@ static void pgraph_bind_textures(NV2AState *d)
         }
 
         /* Check for unsupported features */
-        assert(!(filter & NV_PGRAPH_TEXFILTER0_ASIGNED));
-        assert(!(filter & NV_PGRAPH_TEXFILTER0_RSIGNED));
-        assert(!(filter & NV_PGRAPH_TEXFILTER0_GSIGNED));
-        assert(!(filter & NV_PGRAPH_TEXFILTER0_BSIGNED));
+        if (filter & NV_PGRAPH_TEXFILTER0_ASIGNED) NV2A_UNIMPLEMENTED("NV_PGRAPH_TEXFILTER0_ASIGNED");
+        if (filter & NV_PGRAPH_TEXFILTER0_RSIGNED) NV2A_UNIMPLEMENTED("NV_PGRAPH_TEXFILTER0_RSIGNED");
+        if (filter & NV_PGRAPH_TEXFILTER0_GSIGNED) NV2A_UNIMPLEMENTED("NV_PGRAPH_TEXFILTER0_GSIGNED");
+        if (filter & NV_PGRAPH_TEXFILTER0_BSIGNED) NV2A_UNIMPLEMENTED("NV_PGRAPH_TEXFILTER0_BSIGNED");
 
         glActiveTexture(GL_TEXTURE0 + i);
         if (!enabled) {

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -647,37 +647,37 @@ static QString* psh_convert(struct PixelShader *ps)
         case PS_TEXTUREMODES_BRDF:
             qstring_append_fmt(vars, "vec4 t%d = vec4(0.0); /* PS_TEXTUREMODES_BRDF */\n",
                                i);
-            assert(false); /* Unimplemented */
+            NV2A_UNIMPLEMENTED("PS_TEXTUREMODES_BRDF");
             break;
         case PS_TEXTUREMODES_DOT_ST:
             qstring_append_fmt(vars, "vec4 t%d = vec4(0.0); /* PS_TEXTUREMODES_DOT_ST */\n",
                                i);
-            assert(false); /* Unimplemented */
+            NV2A_UNIMPLEMENTED("PS_TEXTUREMODES_DOT_ST");
             break;
         case PS_TEXTUREMODES_DOT_ZW:
             qstring_append_fmt(vars, "vec4 t%d = vec4(0.0); /* PS_TEXTUREMODES_DOT_ZW */\n",
                                i);
-            assert(false); /* Unimplemented */
+            NV2A_UNIMPLEMENTED("PS_TEXTUREMODES_DOT_ZW");
             break;
         case PS_TEXTUREMODES_DOT_RFLCT_DIFF:
             qstring_append_fmt(vars, "vec4 t%d = vec4(0.0); /* PS_TEXTUREMODES_DOT_RFLCT_DIFF */\n",
                                i);
-            assert(false); /* Unimplemented */
+            NV2A_UNIMPLEMENTED("PS_TEXTUREMODES_DOT_RFLCT_DIFF");
             break;
         case PS_TEXTUREMODES_DOT_RFLCT_SPEC:
             qstring_append_fmt(vars, "vec4 t%d = vec4(0.0); /* PS_TEXTUREMODES_DOT_RFLCT_SPEC */\n",
                                i);
-            assert(false); /* Unimplemented */
+            NV2A_UNIMPLEMENTED("PS_TEXTUREMODES_DOT_RFLCT_SPEC");
             break;
         case PS_TEXTUREMODES_DOT_STR_3D:
             qstring_append_fmt(vars, "vec4 t%d = vec4(0.0); /* PS_TEXTUREMODES_DOT_STR_3D */\n",
                                i);
-            assert(false); /* Unimplemented */
+            NV2A_UNIMPLEMENTED("PS_TEXTUREMODES_DOT_STR_3D");
             break;
         case PS_TEXTUREMODES_DOT_STR_CUBE:
             qstring_append_fmt(vars, "vec4 t%d = vec4(0.0); /* PS_TEXTUREMODES_DOT_STR_CUBE */\n",
                                i);
-            assert(false); /* Unimplemented */
+            NV2A_UNIMPLEMENTED("PS_TEXTUREMODES_DOT_STR_CUBE");
             break;
         case PS_TEXTUREMODES_DPNDNT_AR:
             assert(!ps->state.rect_tex[i]);
@@ -698,7 +698,7 @@ static QString* psh_convert(struct PixelShader *ps)
         case PS_TEXTUREMODES_DOT_RFLCT_SPEC_CONST:
             qstring_append_fmt(vars, "vec4 t%d = vec4(0.0); /* PS_TEXTUREMODES_DOT_RFLCT_SPEC_CONST */\n",
                                i);
-            assert(false); /* Unimplemented */
+            NV2A_UNIMPLEMENTED("PS_TEXTUREMODES_DOT_RFLCT_SPEC_CONST");
             break;
         default:
             fprintf(stderr, "Unknown ps tex mode: 0x%x\n", ps->tex_modes[i]);

--- a/hw/xbox/nv2a/nv2a_shaders.c
+++ b/hw/xbox/nv2a/nv2a_shaders.c
@@ -20,7 +20,6 @@
 
 #include "qemu/osdep.h"
 #include "qemu-common.h"
-#include "nv2a_debug.h"
 #include "nv2a_shaders_common.h"
 #include "nv2a_shaders.h"
 

--- a/hw/xbox/nv2a/nv2a_shaders_common.h
+++ b/hw/xbox/nv2a/nv2a_shaders_common.h
@@ -21,6 +21,8 @@
 #ifndef HW_NV2A_SHADERS_COMMON_H
 #define HW_NV2A_SHADERS_COMMON_H
 
+#include "nv2a_debug.h"
+
 #define STRUCT_VERTEX_DATA "struct VertexData {\n" \
                            "  float inv_w;\n" \
                            "  vec4 D0;\n" \


### PR DESCRIPTION
In the event these features are utilized, execution may still continue,
albeit with the likely possibility graphical problems of varying degree.
This patch replaces hard assertions with debug print statements when
configured to do so.