### PR TITLE
nv2a: Enable fixed-function sphere map texgen

### DIFF
--- a/hw/xbox/nv2a/nv2a_shaders.c
+++ b/hw/xbox/nv2a/nv2a_shaders.c
@@ -448,7 +448,6 @@ GLSL_DEFINE(sceneAmbientColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_FR_AMB) ".xyz")
                 qstring_append_fmt(body, "  oT%d.%c = r.%c * invM + 0.5;\n",
                                    i, c, c);
                 qstring_append(body, "}\n");
-                assert(false); /* Untested */
                 break;
             case TEXGEN_REFLECTION_MAP:
                 assert(i < 3); /* Channels S,T,R only! */

--- a/hw/xbox/nv2a/nv2a_shaders.c
+++ b/hw/xbox/nv2a/nv2a_shaders.c
@@ -430,7 +430,7 @@ GLSL_DEFINE(sceneAmbientColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_FR_AMB) ".xyz")
                 assert(false); /* Untested */
                 break;
             case TEXGEN_SPHERE_MAP:
-                assert(i < 2);  /* Channels S,T only! */
+                assert(j < 2);  /* Channels S,T only! */
                 qstring_append(body, "{\n");
                 /* FIXME: u, r and m only have to be calculated once */
                 qstring_append(body, "  vec3 u = normalize(tPosition.xyz);\n");
@@ -450,7 +450,7 @@ GLSL_DEFINE(sceneAmbientColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_FR_AMB) ".xyz")
                 qstring_append(body, "}\n");
                 break;
             case TEXGEN_REFLECTION_MAP:
-                assert(i < 3); /* Channels S,T,R only! */
+                assert(j < 3); /* Channels S,T,R only! */
                 qstring_append(body, "{\n");
                 /* FIXME: u and r only have to be calculated once, can share the one from SPHERE_MAP */
                 qstring_append(body, "  vec3 u = normalize(tPosition.xyz);\n");
@@ -460,7 +460,7 @@ GLSL_DEFINE(sceneAmbientColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_FR_AMB) ".xyz")
                 qstring_append(body, "}\n");
                 break;
             case TEXGEN_NORMAL_MAP:
-                assert(i < 3); /* Channels S,T,R only! */
+                assert(j < 3); /* Channels S,T,R only! */
                 qstring_append_fmt(body, "oT%d.%c = tNormal.%c;\n",
                                    i, c, c);
                 break;


### PR DESCRIPTION
Can confirm the previously untested sphere map texgen code in nv2a_shader.c works fine, and should be safe to enable:

![image](https://user-images.githubusercontent.com/16278868/85931981-2b6cbe80-b8c0-11ea-8511-e3a1d528bfdb.png)

Had to also fix assertions wrongly comparing against the texture stage index instead of the channel index.