### PR TITLE
nv2a: Handle color material ambient/emissive

### DIFF
--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -300,6 +300,10 @@
 #       define NV_PGRAPH_CSV0_D_SKIN_4                              6
 #define NV_PGRAPH_CSV0_C                                 0x00000FB8
 #   define NV_PGRAPH_CSV0_C_CHEOPS_PROGRAM_START                0x0000FF00
+#   define NV_PGRAPH_CSV0_C_SPECULAR                            (3 << 19)
+#   define NV_PGRAPH_CSV0_C_DIFFUSE                             (3 << 21)
+#   define NV_PGRAPH_CSV0_C_AMBIENT                             (3 << 23)
+#   define NV_PGRAPH_CSV0_C_EMISSION                            (3 << 25)
 #   define NV_PGRAPH_CSV0_C_NORMALIZATION_ENABLE                (1 << 27)
 #   define NV_PGRAPH_CSV0_C_LIGHTING                            (1 << 31)
 #define NV_PGRAPH_CSV1_B                                 0x00000FBC
@@ -816,6 +820,7 @@
 #       define NV097_SET_CONTROL0_STENCIL_WRITE_ENABLE            (1 << 0)
 #       define NV097_SET_CONTROL0_Z_FORMAT                        (1 << 12)
 #       define NV097_SET_CONTROL0_Z_PERSPECTIVE_ENABLE            (1 << 16)
+#   define NV097_SET_COLOR_MATERIAL                           0x00000298
 #   define NV097_SET_FOG_MODE                                 0x0000029C
 #       define NV097_SET_FOG_MODE_V_LINEAR                        0x2601
 #       define NV097_SET_FOG_MODE_V_EXP                           0x800
@@ -940,6 +945,7 @@
 #       define NV097_SET_FRONT_FACE_V_CW                           0x900
 #       define NV097_SET_FRONT_FACE_V_CCW                          0x901
 #   define NV097_SET_NORMALIZATION_ENABLE                     0x000003A4
+#   define NV097_SET_MATERIAL_EMISSION                        0x000003A8
 #   define NV097_SET_LIGHT_ENABLE_MASK                        0x000003BC
 #           define NV097_SET_LIGHT_ENABLE_MASK_LIGHT0_OFF           0
 #           define NV097_SET_LIGHT_ENABLE_MASK_LIGHT0_INFINITE      1

--- a/hw/xbox/nv2a/nv2a_shaders.h
+++ b/hw/xbox/nv2a/nv2a_shaders.h
@@ -48,6 +48,12 @@ enum ShaderPolygonMode {
     POLY_MODE_LINE,
 };
 
+enum MaterialColorSource {
+    MATERIAL_COLOR_SRC_MATERIAL,
+    MATERIAL_COLOR_SRC_DIFFUSE,
+    MATERIAL_COLOR_SRC_SPECULAR,
+};
+
 typedef struct ShaderState {
     PshState psh;
 
@@ -61,6 +67,11 @@ typedef struct ShaderState {
     enum VshSkinning skinning;
 
     bool normalization;
+
+    enum MaterialColorSource emission_src;
+    enum MaterialColorSource ambient_src;
+    enum MaterialColorSource diffuse_src;
+    enum MaterialColorSource specular_src;
 
     bool lighting;
     enum VshLight light[NV2A_MAX_LIGHTS];


### PR DESCRIPTION
Support setting color material source (e.g. pulling ambient from vertex) and emissive color. Fixes some lighting bugs in THPS2X, among others. Screenshots below.

![tony_bad_ambient](https://user-images.githubusercontent.com/8210/92343187-ee6b3800-f077-11ea-9716-ed289a752f89.png)
![tony_good_ambient](https://user-images.githubusercontent.com/8210/92343191-f0cd9200-f077-11ea-8b6b-ef9302bea835.png)
![fusion_bad](https://user-images.githubusercontent.com/8210/92343397-781b0580-f078-11ea-9a1b-2dfb52cb1202.png)
![fusion_good](https://user-images.githubusercontent.com/8210/92343401-79e4c900-f078-11ea-9a95-be32bf1b5224.png)
