### PR TITLE
ui: Add 'MCPX' to BootROM field name in Settings 

### DIFF
--- a/ui/xemu-hud.cc
+++ b/ui/xemu-hud.cc
@@ -663,7 +663,7 @@ public:
         FilePicker("###Flash", flash_path, sizeof(flash_path), rom_file_filters);
         ImGui::NextColumn();
 
-        ImGui::Text("BootROM File");
+        ImGui::Text("MCPX Boot ROM File");
         ImGui::NextColumn();
         ImGui::SetNextItemWidth(picker_width);
         FilePicker("###BootROM", bootrom_path, sizeof(bootrom_path), rom_file_filters);


### PR DESCRIPTION
Seeing as an overwhelming majority of problem reports and help requests in the discord stems from people mixing up the mcpx and kernel dumps, some kind of clarification was needed.