### PR TITLE
nv2a: fix hangs when polling NV_PCRTC_RASTER

### DIFF
--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -603,7 +603,7 @@
 #   define NV_PCRTC_INTR_EN_0_VBLANK                            (1 << 0)
 #define NV_PCRTC_START                                   0x00000800
 #define NV_PCRTC_CONFIG                                  0x00000804
-
+#define NV_PCRTC_RASTER                                  0x00000808
 
 #define NV_PVIDEO_INTR                                   0x00000100
 #   define NV_PVIDEO_INTR_BUFFER_0                              (1 << 0)

--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -313,7 +313,7 @@ static void pgraph_set_surface_dirty(PGRAPHState *pg, bool color, bool zeta);
 static void pgraph_wait_for_surface_download(SurfaceBinding *e);
 static void pgraph_surface_access_callback(void *opaque, MemoryRegion *mr, hwaddr addr, hwaddr len, bool write);
 static SurfaceBinding *pgraph_surface_put(NV2AState *d, hwaddr addr, SurfaceBinding *e);
-static SurfaceBinding *pgraph_surface_get(NV2AState *d, hwaddr addr);
+SurfaceBinding *pgraph_surface_get(NV2AState *d, hwaddr addr);
 static void pgraph_unbind_surface(NV2AState *d, bool color);
 static void pgraph_surface_invalidate(NV2AState *d, SurfaceBinding *e);
 static void pgraph_surface_evict_old(NV2AState *d);
@@ -3856,7 +3856,7 @@ static SurfaceBinding *pgraph_surface_put(NV2AState *d,
     return surface_out;
 }
 
-static SurfaceBinding *pgraph_surface_get(NV2AState *d, hwaddr addr)
+SurfaceBinding *pgraph_surface_get(NV2AState *d, hwaddr addr)
 {
     SurfaceBinding *surface;
     QTAILQ_FOREACH(surface, &d->pgraph.surfaces, entry) {


### PR DESCRIPTION
This PR implements the NV_PCRTC_RASTER register, albeit as a hack.

This register is used by Direct3D to detect current status (eg. is blank in progress), this implementation switches between three states: start of frame, mid-frame and vblank: This is enough to coax games that use this method to wait for Vblank out of hanging.

With this, Alter Echo no longer hangs on the loading screen, instead, it hangs after the first line of spoken dialog. This is a different (unrelated) audio issue, however.

Before:
![Screenshot 2020-10-23 at 21 31 08](https://user-images.githubusercontent.com/740003/97051491-30dccb80-1577-11eb-9c21-183a96448cac.png)

After:
![Screenshot 2020-10-23 at 21 34 32](https://user-images.githubusercontent.com/740003/97051717-9335cc00-1577-11eb-9f5d-fb29836cf98f.png)
