### PR TITLE
nv2a: Add B8, G8B8 surface format placeholders

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -294,6 +294,12 @@ static const SurfaceColorFormatInfo kelvin_surface_color_format_map[] = {
         {4, GL_RGBA8, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV},
     [NV097_SET_SURFACE_FORMAT_COLOR_LE_A8R8G8B8] =
         {4, GL_RGBA8, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV},
+
+    // FIXME: Map channel color
+    [NV097_SET_SURFACE_FORMAT_COLOR_LE_B8] =
+        {1, GL_R8, GL_RED, GL_UNSIGNED_BYTE},
+    [NV097_SET_SURFACE_FORMAT_COLOR_LE_G8B8] =
+        {2, GL_RG8, GL_RG, GL_UNSIGNED_SHORT},
 };
 
 // static void pgraph_set_context_user(NV2AState *d, uint32_t val);


### PR DESCRIPTION
Should unblock:
- Counter Strike
- Enter the Matrix
- Advent Rising (Possibly, unconfirmed)
