### PR TITLE
nv2a: fix DS/DT texture offset shader operation

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -3312,6 +3312,10 @@ static void pgraph_bind_shaders(PGRAPHState *pg)
             GET_MASK(pg->regs[NV_PGRAPH_TEXFMT0 + i*4],
                      NV_PGRAPH_TEXFMT0_COLOR);
 
+        /* This is needed to detect cases where the wrong format for ds/dt textures is used
+         * and a remapping of the unsigned values to signed is needed (e.g. the boost dash in JSRF) */
+        state.psh.dsdt_tex[i] = kelvin_color_format_map[color_format].gl_type == GL_BYTE;
+
         if (enabled && kelvin_color_format_map[color_format].linear) {
             state.psh.rect_tex[i] = true;
         }

--- a/hw/xbox/nv2a/psh.h
+++ b/hw/xbox/nv2a/psh.h
@@ -45,6 +45,7 @@ typedef struct PshState {
     uint32_t alpha_inputs[8], alpha_outputs[8];
 
     bool rect_tex[4];
+    bool dsdt_tex[4];
     bool compare_mode[4][4];
     bool alphakill[4];
 


### PR DESCRIPTION
This fixes the DS/DT texture offset shader operations (BUMPENVMAP and BUMPENVMAP_LUM, for non-linear and linear textures).
There were a few mistakes before:
- DS/DT textures use the green and blue channels on hardware (plus the red channel for scale in BUMPENVMAP_LUM), in the code the red and green channels were used instead (plus blue for the scale).
- The matrix was used incorrectly. The swizzling was correct, but the offset vector had to be pre-multiplied by it, not post-multiplied (post-multiplying is the same as pre-multiplying by the transpose).
- On hardware, if the wrong format is used, the ds/dt values are still interpreted as signed, even if the texture is unsigned (this on hardware causes the boost dash effect in Jet Set Radio Future to look differently than intended).
- In the case of linear textures nothing special happens on hardware, so the asserts were not needed.

Taking into account those things results in [this sample](https://github.com/Voxel9/xbox-xgu-examples/tree/master/bumpenv_ripple) (see the screenshots below) and effects in other games working exactly as on hardware.

Removing the unneeded asserts also fixes crashes in Jet Set Radio Future (49470018), Halo 2 (4d530064), Otogi (46530002) and possibly other titles.

Big thanks to @Voxel9 for his sample, playing with it allowed me to figure out what was going on on hardware.

The aforementioned sample on hardware:
![bumpenv_ripple](https://raw.githubusercontent.com/Voxel9/xbox-xgu-examples/master/_screenshots/bumpenv_ripple.png)

The same sample on xemu with this PR:
![xemu_bumpenv_ripple](https://user-images.githubusercontent.com/29335145/98415145-fdbd3080-207c-11eb-801c-d183dee24fe0.png)

The boost dash effect in Jet Set Radio Future with this PR (same as on hardware, the rays look sharp instead of smooth like the ds/dt texture because the unsigned ds/dt texture is interpreted as signed):
![jsrf](https://user-images.githubusercontent.com/29335145/98605915-7e329a00-22e6-11eb-980c-b3c0af7864c9.png)
