### PR TITLE
hw: Add cached flash write workaround

### DIFF
--- a/hw/xbox/xbox.c
+++ b/hw/xbox/xbox.c
@@ -143,12 +143,26 @@ static void xbox_flash_init(MemoryRegion *rom_memory)
         g_free(filename);
     }
 
+    /* XBOX_FIXME: The "memory_region_set_readonly" calls below have been
+    * temporarily commented out due to MCPX 1.1-based kernels hanging
+    * in the first bootloader stage when doing RSA signature verification.
+    * 
+    * This is caused by code incorrectly using the flash memory range to
+    * store the following computation; luckily real hardware's writeback
+    * cache policy (verified against MTRR config) appears to allow this
+    * to succeed, but qemu's emulation of such isn't capable of this yet
+    * so the value is never updated in ROM unless readonly is unspecified.
+    * 
+    *   sub ds:0FFFFD52Ch, eax
+    *   mov eax, ds:0FFFFD52Ch
+    */
+
     /* Create BIOS region */
     MemoryRegion *bios;
     bios = g_malloc(sizeof(*bios));
     assert(bios != NULL);
     memory_region_init_ram(bios, NULL, "xbox.bios", bios_size, &error_fatal);
-    memory_region_set_readonly(bios, true);
+    //memory_region_set_readonly(bios, true);
     rom_add_blob_fixed("xbox.bios", bios_data, bios_size,
                        (uint32_t)(-2 * bios_size));
 
@@ -164,7 +178,7 @@ static void xbox_flash_init(MemoryRegion *rom_memory)
         MemoryRegion *map_bios = g_malloc(sizeof(*map_bios));
         memory_region_init_alias(map_bios, NULL, "pci-bios", bios, 0, bios_size);
         memory_region_add_subregion(rom_memory, map_loc, map_bios);
-        memory_region_set_readonly(map_bios, true);
+        //memory_region_set_readonly(map_bios, true);
     }
 }
 


### PR DESCRIPTION
Quoting @mborgerson from [here](https://github.com/mborgerson/xemu/issues/71)

> For MCPX 1.1-based kernels, early bootstrap code will attempt to write-then-read a value from memory-mapped flash. Based on a trace of memory accesses during boot, there appears to be only one instance of this case which occurs 5 times during boot.
> 
> ![image](https://user-images.githubusercontent.com/8210/98883987-62490880-244c-11eb-8b07-1e55e5667222.png)
> 
> I assume this works on hardware due to CPU writeback caching policy (confirmed w/ check against MTRR config), which could permit the immediate store and read back from this read-only memory region. Because QEMU does not support emulating the behavior of these CPU caching policies, and because this memory is marked as ROM, the value is not updated in xemu memory and these kernels will fail to boot. I also assume that this is a bug in MS code.
> 
> In testing, by permitting writes to flash memory (that is, not marking it as read-only), these later kernel revisions with corresponding MCPX 1.1 boot ROM and EEPROM will boot as expected in xemu.
> 
> In absence of accurate cache policy emulation, marking this memory region as read/write may be best immediate course of action, as it unblocks these later kernels without apparent side effects.
> 
> Big thanks to @Ernegien for his efforts in discovering the issue!

Fixes #71