### PR TITLE
ui: Mimic main thread and set tcg_ctx to tcg_init_ctx

### DIFF
--- a/include/tcg/tcg.h
+++ b/include/tcg/tcg.h
@@ -851,6 +851,10 @@ static inline void *tcg_malloc(int size)
     }
 }
 
+#ifdef XBOX
+void tcg_register_init_ctx(void);
+#endif
+
 void tcg_context_init(TCGContext *s);
 void tcg_register_thread(void);
 void tcg_prologue_init(TCGContext *s);

--- a/tcg/tcg.c
+++ b/tcg/tcg.c
@@ -775,6 +775,21 @@ void tcg_register_thread(void)
     tcg_ctx = &tcg_init_ctx;
 }
 #else
+
+#ifdef XBOX
+void tcg_register_init_ctx(void)
+{
+    /*
+     * For xemu we may exercise functions on the UI thread that would otherwise
+     * run on the main thread following initialization. We retain the BQL when
+     * running such commands, which should make this safe, but there are some
+     * data stored in TLS which get initialized early on and may be required
+     * later.
+     */
+    tcg_ctx = &tcg_init_ctx;
+}
+#endif
+
 void tcg_register_thread(void)
 {
     MachineState *ms = MACHINE(qdev_get_machine());


### PR DESCRIPTION
Necessary to handle callbacks (e.g. rom_reset) from UI thread which will
flush TBs and reference thread-local TCG context, which is initialized
for main QEMU thread early on as tcg_init_ctx.