### PR TITLE
input: Close gamecontroller handles on disconnect

### DIFF
--- a/ui/xemu-input.c
+++ b/ui/xemu-input.c
@@ -204,7 +204,12 @@ void xemu_input_process_sdl_events(const SDL_Event *event)
                 num_available_controllers--;
 
                 // Deallocate
-                // FIXME: Check to release any SDL handles, etc
+                if (iter->sdl_haptic) {
+                    SDL_HapticClose(iter->sdl_haptic);
+                }
+                if (iter->sdl_gamecontroller) {
+                    SDL_GameControllerClose(iter->sdl_gamecontroller);
+                }
                 free(iter);
 
                 handled = 1;


### PR DESCRIPTION
Resolves issue of haptic no longer working after disconnect-reconnect cycle. I think this Fixes #49 . We can re-open if issue persists.