### PR TITLE
nv2a: Support line and poly anti-aliasing

### DIFF
--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -467,6 +467,8 @@
 #   define NV_PGRAPH_SETUPRASTER_POFFSETPOINTENABLE             (1 << 6)
 #   define NV_PGRAPH_SETUPRASTER_POFFSETLINEENABLE              (1 << 7)
 #   define NV_PGRAPH_SETUPRASTER_POFFSETFILLENABLE              (1 << 8)
+#   define NV_PGRAPH_SETUPRASTER_LINESMOOTHENABLE               (1 << 10)
+#   define NV_PGRAPH_SETUPRASTER_POLYSMOOTHENABLE               (1 << 11)
 #   define NV_PGRAPH_SETUPRASTER_CULLCTRL                       0x00600000
 #       define NV_PGRAPH_SETUPRASTER_CULLCTRL_FRONT                 1
 #       define NV_PGRAPH_SETUPRASTER_CULLCTRL_BACK                  2
@@ -852,6 +854,8 @@
 #   define NV097_SET_DEPTH_TEST_ENABLE                        0x0000030C
 #   define NV097_SET_DITHER_ENABLE                            0x00000310
 #   define NV097_SET_LIGHTING_ENABLE                          0x00000314
+#   define NV097_SET_LINE_SMOOTH_ENABLE                       0x00000320
+#   define NV097_SET_POLY_SMOOTH_ENABLE                       0x00000324
 #   define NV097_SET_SKIN_MODE                                0x00000328
 #       define NV097_SET_SKIN_MODE_OFF                            0
 #       define NV097_SET_SKIN_MODE_2G                             1

--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -1087,6 +1087,14 @@ void pgraph_method(NV2AState *d,
         SET_MASK(pg->regs[NV_PGRAPH_CSV0_C], NV_PGRAPH_CSV0_C_LIGHTING,
                  parameter);
         break;
+    case NV097_SET_LINE_SMOOTH_ENABLE:
+        SET_MASK(pg->regs[NV_PGRAPH_SETUPRASTER],
+                 NV_PGRAPH_SETUPRASTER_LINESMOOTHENABLE, parameter);
+        break;
+    case NV097_SET_POLY_SMOOTH_ENABLE:
+        SET_MASK(pg->regs[NV_PGRAPH_SETUPRASTER],
+                 NV_PGRAPH_SETUPRASTER_POLYSMOOTHENABLE, parameter);
+        break;
     case NV097_SET_SKIN_MODE:
         SET_MASK(pg->regs[NV_PGRAPH_CSV0_D], NV_PGRAPH_CSV0_D_SKIN,
                  parameter);
@@ -2147,6 +2155,20 @@ void pgraph_method(NV2AState *d,
                 glEnable(GL_DITHER);
             } else {
                 glDisable(GL_DITHER);
+            }
+
+            /* Edge Antialiasing */
+            if (pg->regs[NV_PGRAPH_SETUPRASTER] &
+                    NV_PGRAPH_SETUPRASTER_LINESMOOTHENABLE) {
+                glEnable(GL_LINE_SMOOTH);
+            } else {
+                glDisable(GL_LINE_SMOOTH);
+            }
+            if (pg->regs[NV_PGRAPH_SETUPRASTER] &
+                    NV_PGRAPH_SETUPRASTER_POLYSMOOTHENABLE) {
+                glEnable(GL_POLYGON_SMOOTH);
+            } else {
+                glDisable(GL_POLYGON_SMOOTH);
             }
 
             //glDisableVertexAttribArray(NV2A_VERTEX_ATTR_DIFFUSE);


### PR DESCRIPTION
A marked reduction in aliasing artifacts in MS dashboard, possibly elsewhere:

![MS-0](https://user-images.githubusercontent.com/8210/100825993-9e053b80-3416-11eb-8b30-b695f4315a4d.png)
![MS-0-Smooth](https://user-images.githubusercontent.com/8210/100825995-9fceff00-3416-11eb-8bd0-db81465cebe7.png)

![Settings0](https://user-images.githubusercontent.com/8210/100826003-a3628600-3416-11eb-9f7e-0d7b8a29557a.png)
![Settings1](https://user-images.githubusercontent.com/8210/100826007-a493b300-3416-11eb-8be8-352364ad1916.png)
