### PR TITLE
nv2a: Add Gaussian convolution filter for AA

### DIFF
--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -517,6 +517,9 @@
 #define NV_PGRAPH_TEXCTL2_1                              0x000019F0
 #define NV_PGRAPH_TEXFILTER0                             0x000019F4
 #   define NV_PGRAPH_TEXFILTER0_MIPMAP_LOD_BIAS                 0x00001FFF
+#   define NV_PGRAPH_TEXFILTER0_CONVOLUTION_KERNEL              0x0000E000
+#       define NV_PGRAPH_TEXFILTER0_CONVOLUTION_KERNEL_QUINCUNX     1
+#       define NV_PGRAPH_TEXFILTER0_CONVOLUTION_KERNEL_GAUSSIAN_3   2
 #   define NV_PGRAPH_TEXFILTER0_MIN                             0x003F0000
 #       define NV_PGRAPH_TEXFILTER0_MIN_BOX_LOD0                    1
 #       define NV_PGRAPH_TEXFILTER0_MIN_TENT_LOD0                   2

--- a/hw/xbox/nv2a/psh.h
+++ b/hw/xbox/nv2a/psh.h
@@ -33,6 +33,12 @@ enum PshAlphaFunc {
     ALPHA_FUNC_ALWAYS,
 };
 
+enum ConvolutionFilter {
+    CONVOLUTION_FILTER_DISABLED,
+    CONVOLUTION_FILTER_QUINCUNX,
+    CONVOLUTION_FILTER_GAUSSIAN,
+};
+
 typedef struct PshState {
     /* fragment shader - register combiner stuff */
     uint32_t combiner_control;
@@ -48,6 +54,7 @@ typedef struct PshState {
     bool snorm_tex[4];
     bool compare_mode[4][4];
     bool alphakill[4];
+    enum ConvolutionFilter conv_tex[4];
 
     bool alpha_test;
     enum PshAlphaFunc alpha_func;


### PR DESCRIPTION
Improved texture filtering, used e.g. in AA for dashboard. Cleans up most (all?) of the remaining aliasing artifacts.

After:
![Settings-Gaussian](https://user-images.githubusercontent.com/8210/100849399-c05f7f00-343f-11eb-947b-1a1482fbac9d.png)
Before:
![Settings1](https://user-images.githubusercontent.com/8210/100849390-bd648e80-343f-11eb-8153-137240bcfd21.png)
