### PR TITLE
nv2a: Approximate CLAMP_OGL with CLAMP_TO_EDGE

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -80,7 +80,7 @@ static const GLenum pgraph_texture_addr_map[] = {
     GL_MIRRORED_REPEAT,
     GL_CLAMP_TO_EDGE,
     GL_CLAMP_TO_BORDER,
-    // GL_CLAMP
+    GL_CLAMP_TO_EDGE, /* Approximate GL_CLAMP */
 };
 
 static const GLenum pgraph_blend_factor_map[] = {


### PR DESCRIPTION
`CLAMP_OGL` should be implemented by `GL_CLAMP` but this was removed in GL 3.1+ core. Approximate the behavior with `CLAMP_TO_EDGE` and avoid crashing.