### PR TITLE
build.sh: guess job_count when possible, better way to guess project directory, fix out of tree build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,6 @@ trace-ust-all.h
 trace-ust-all.c
 /target/arm/decode-sve.inc.c
 
-
+/dist
 /xemu-version.c
 /xemu.ini

--- a/build.sh
+++ b/build.sh
@@ -245,4 +245,4 @@ set -x # Print commands from now on
 
 time make -j"${job_count}" 2>&1 | tee build.log
 
-${postbuild} # call post build functions
+"${postbuild}" # call post build functions

--- a/build.sh
+++ b/build.sh
@@ -11,8 +11,8 @@ package_windows() {
     mkdir -p dist
     cp i386-softmmu/qemu-system-i386.exe dist/xemu.exe
     cp i386-softmmu/qemu-system-i386w.exe dist/xemuw.exe
-    cp -r data dist/
-    python3 ./get_deps.py dist/xemu.exe dist
+    cp -r "${project_source_dir}/data" dist/
+    python3 "${project_source_dir}/get_deps.py" dist/xemu.exe dist
     strip dist/xemu.exe
     strip dist/xemuw.exe
 }
@@ -35,11 +35,11 @@ package_macos() {
 
     # Copy in runtime resources
     mkdir -p dist/xemu.app/Contents/Resources
-    cp -r data dist/xemu.app/Contents/Resources
+    cp -r "${project_source_dir}/data" dist/xemu.app/Contents/Resources
 
     # Generate icon file
     mkdir -p xemu.iconset
-    for r in 16 32 128 256 512; do cp ui/icons/xemu_${r}x${r}.png xemu.iconset/icon_${r}x${r}.png; done
+    for r in 16 32 128 256 512; do cp "${project_source_dir}/ui/icons/xemu_${r}x${r}.png" "xemu.iconset/icon_${r}x${r}.png"; done
     iconutil --convert icns --output dist/xemu.app/Contents/Resources/xemu.icns xemu.iconset
 
     # Generate Info.plist file
@@ -85,7 +85,7 @@ package_linux() {
     rm -rf dist
     mkdir -p dist
     cp i386-softmmu/qemu-system-i386 dist/xemu
-    cp -r data dist
+    cp -r "${project_source_dir}/data" dist
 }
 
 postbuild=''

--- a/build.sh
+++ b/build.sh
@@ -179,6 +179,7 @@ esac
 
 # find absolute path (and resolve symlinks) to build out of tree
 configure="${project_source_dir}/configure"
+build_cflags="${build_cflags} -I${project_source_dir}/ui/imgui"
 
 set -x # Print commands from now on
 


### PR DESCRIPTION
When I rewrote `build.sh` long time ago (2918fb9), it was told me it had to be very simple so I removed `job_count` computation from my PR at the time. But since the script became more complex and maybe I may suggest this little feature again ?

Also in the meantime I [reused my script](https://gitlab.com/xonotic/netradiant/-/blob/master/easy-builder) on another unrelated project so I updated and improved that `job_count` compute since that time. It is meant to work on Linux, FreeBSD, macOS, MSYS2, otherwise it falls back on the default number. Explicit command line option `-j` can still override it of course.

I also wrote for that `build.sh` derivative a better way to guess the project directory so I import that change as well.

I then used that project directory variable to fix imgui out of tree build and out of tree packaging.

While I was at it I added for free some quote around some strings to make them less error prone, I also silenced the `command -v greadlink` error since there is an explicit one right after that.