### PR TITLE
i386: Change default pentium3 cpuid to match 1.0 Xbox

### DIFF
--- a/target/i386/cpu.c
+++ b/target/i386/cpu.c
@@ -2077,8 +2077,13 @@ static X86CPUDefinition builtin_x86_defs[] = {
         .level = 3,
         .vendor = CPUID_VENDOR_INTEL,
         .family = 6,
+#ifdef XBOX
+         .model = 8,
+         .stepping = 10,
+#else
         .model = 7,
         .stepping = 3,
+#endif
         .features[FEAT_1_EDX] =
             PENTIUM3_FEATURES,
         .xlevel = 0,


### PR DESCRIPTION
Small mostly cosmetic change, however the original xbox does seem to actually have `CPUID_PN`, enabling this feature causes a warning
`xemu: warning: TCG doesn't support requested feature: CPUID.01H:EDX.pn [bit 18]` which is strange because if you set the CPU to be the `athlon` this actually has one set as well so the feature does seem to work?

retail box:
![2021-00-01_00-30-13-ed](https://user-images.githubusercontent.com/858612/103434370-a2b43f80-4bce-11eb-8430-8898254d5033.png)

xemu with change:
![after](https://user-images.githubusercontent.com/858612/103434403-d8f1bf00-4bce-11eb-8c82-6069ed91c270.png)

