### PR TITLE
xbox: Fix some PCI revs to match retail 1.0 Xbox

### DIFF
--- a/hw/xbox/mcpx/aci.c
+++ b/hw/xbox/mcpx/aci.c
@@ -86,7 +86,7 @@ static void mcpx_aci_class_init(ObjectClass *klass, void *data)
 
     k->vendor_id = PCI_VENDOR_ID_NVIDIA;
     k->device_id = PCI_DEVICE_ID_NVIDIA_MCPX_ACI;
-    k->revision = 210;
+    k->revision = 177;
     k->class_id = PCI_CLASS_MULTIMEDIA_AUDIO;
     k->realize = mcpx_aci_realize;
 

--- a/hw/xbox/mcpx/apu.c
+++ b/hw/xbox/mcpx/apu.c
@@ -2482,7 +2482,7 @@ static void mcpx_apu_class_init(ObjectClass *klass, void *data)
 
     k->vendor_id = PCI_VENDOR_ID_NVIDIA;
     k->device_id = PCI_DEVICE_ID_NVIDIA_MCPX_APU;
-    k->revision = 210;
+    k->revision = 177;
     k->class_id = PCI_CLASS_MULTIMEDIA_AUDIO;
     k->realize = mcpx_apu_realize;
     k->exit = mcpx_apu_exitfn;

--- a/hw/xbox/nvnet.c
+++ b/hw/xbox/nvnet.c
@@ -1116,7 +1116,7 @@ static void nvnet_class_init(ObjectClass *klass, void *data)
 
     k->vendor_id = PCI_VENDOR_ID_NVIDIA;
     k->device_id = PCI_DEVICE_ID_NVIDIA_NVENET_1;
-    k->revision = 210;
+    k->revision = 177;
     k->class_id = PCI_CLASS_NETWORK_ETHERNET;
     k->realize = nvnet_realize;
     k->exit = nvnet_uninit;

--- a/hw/xbox/xbox_pci.c
+++ b/hw/xbox/xbox_pci.c
@@ -392,7 +392,7 @@ static void xbox_lpc_class_init(ObjectClass *klass, void *data)
     //k->config_write = xbox_lpc_config_write;
     k->vendor_id = PCI_VENDOR_ID_NVIDIA;
     k->device_id = PCI_DEVICE_ID_NVIDIA_NFORCE_LPC;
-    k->revision = 212;
+    k->revision = 178;
     k->class_id = PCI_CLASS_BRIDGE_ISA;
 
     dc->desc = "nForce LPC Bridge";

--- a/hw/xbox/xbox_pci.c
+++ b/hw/xbox/xbox_pci.c
@@ -277,7 +277,7 @@ static void xbox_smbus_class_init(ObjectClass *klass, void *data)
     k->realize = xbox_smbus_realize;
     k->vendor_id = PCI_VENDOR_ID_NVIDIA;
     k->device_id = PCI_DEVICE_ID_NVIDIA_NFORCE_SMBUS;
-    k->revision = 161;
+    k->revision = 177;
     k->class_id = PCI_CLASS_SERIAL_SMBUS;
 
     dc->desc = "nForce PCI System Management";


### PR DESCRIPTION
While looking into some stuff with Cromwell I noticed that during init it does some checking with some PCI stuff. This byte on a retail 1.0 box reports as `0xB2` while xemu reports this as `0xD4`. If I follow the logic right in Cromwell it thinks xemu is a 1.1+ system.

Not sure if anything else checks for this.

https://github.com/XboxDev/cromwell/blob/master/drivers/pci/pci.c#L325

Test code:
```
#include <hal/debug.h>
#include <hal/video.h>
#include <windows.h>
#include <hal/io.h>

uint8_t PciReadByte(unsigned int bus, unsigned int dev,
                    unsigned int func, unsigned int reg_off)
{
    uint32_t base_addr = 0x80000000;
    base_addr |= ((bus & 0xFF) << 16);      // bus #
    base_addr |= ((dev & 0x1F) << 11);      // device #
    base_addr |= ((func & 0x07) << 8);      // func #

    IoOutputDword(0xcf8, (base_addr + (reg_off & 0xfc)));
    return IoInputByte(0xcfc + (reg_off & 3));
}

int main(void)
{
    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

    uint8_t rev;
    rev = PciReadByte(0, 1, 0, 0x8);
    debugPrint("Mystery 1: 0x%2X\n", rev);

    Sleep(10000);
    return 0;
}
```

xbox:
![image](https://user-images.githubusercontent.com/858612/103449874-62ab9600-4c7c-11eb-9cdd-65cd536aaca3.png)

xemu before:
![image](https://user-images.githubusercontent.com/858612/103449909-d5b50c80-4c7c-11eb-953c-8df1e0f11d65.png)
