### PR TITLE
smbus: Fix Xbox SMC version detection

### DIFF
--- a/hw/xbox/smbus_xbox_smc.c
+++ b/hw/xbox/smbus_xbox_smc.c
@@ -91,7 +91,7 @@
 #define SMC_REG_SCRATCH             0x1b
 #define     SMC_REG_SCRATCH_SHORT_ANIMATION 0x04
 
-static const char *smc_version_string = "P01";
+static const char smc_version_string[] = "P01";
 
 typedef struct SMBusSMCDevice {
     SMBusDevice smbusdev;


### PR DESCRIPTION
This fixes the version detection, I think it is probably required for some stuff as the kernels check it during boot, first they check `[0]` then reset the index then check the full string. So probably doing something backend.

Eventually I'd like to have this configurable at run-time so I moved it into the device struct.

xemu:
![image](https://user-images.githubusercontent.com/858612/103450414-fb91df80-4c83-11eb-954f-23b161614dba.png)

Fixes #128 
