### PR TITLE
i8254: Update base freq to more closely match Xbox

### DIFF
--- a/include/hw/timer/i8254.h
+++ b/include/hw/timer/i8254.h
@@ -29,7 +29,15 @@
 #include "hw/isa/isa.h"
 #include "qapi/error.h"
 
+#ifdef XBOX
+/* FIXME: As 8254 code is written, this cannot be exactly 1125000, as counter
+ * will always trigger w/ how Xbox software configures PIT. Use a small delta
+ * for now.
+ */
+#define PIT_FREQ 1125001
+#else
 #define PIT_FREQ 1193182
+#endif
 
 typedef struct PITChannelInfo {
     int gate;


### PR DESCRIPTION
Current PIT runs ~6% too fast. This gets it closer, within approx 0.03%