### PR TITLE
 eeprom: Set default time zone and language during generation

### DIFF
--- a/hw/xbox/eeprom_generation.c
+++ b/hw/xbox/eeprom_generation.c
@@ -221,6 +221,12 @@ bool xbox_eeprom_generate(const char *file, XboxEEPROMVersion ver) {
         e.serial[i] = '0' + (e.serial[i] % 10);
     }
     
+    // FIXME: temporarily set default London (GMT+0) time zone and English language
+    memcpy(e.user_section, "\x00\x00\x00\x00\x47\x4D\x54\x00\x42\x53\x54\x00" \
+    "\x00\x00\x00\x00\x00\x00\x00\x00\x0A\x05\x00\x02\x03\x05\x00\x01\x00\x00" \
+    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xC4\xFF\xFF\xFF", 44);
+    *(uint32_t*)(e.user_section + 0x2C) = cpu_to_le32(1);
+
     // update checksums
     e.checksum = cpu_to_le32(xbox_eeprom_crc(e.serial, 0x2C));
     e.user_checksum = cpu_to_le32(xbox_eeprom_crc(e.user_section, 0x5C));

--- a/hw/xbox/xbox.c
+++ b/hw/xbox/xbox.c
@@ -143,12 +143,26 @@ static void xbox_flash_init(MemoryRegion *rom_memory)
         g_free(filename);
     }
 
+    /* XBOX_FIXME: The "memory_region_set_readonly" calls below have been
+    * temporarily commented out due to MCPX 1.1-based kernels hanging
+    * in the first bootloader stage when doing RSA signature verification.
+    * 
+    * This is caused by code incorrectly using the flash memory range to
+    * store the following computation; luckily real hardware's writeback
+    * cache policy (verified against MTRR config) appears to allow this
+    * to succeed, but qemu's emulation of such isn't capable of this yet
+    * so the value is never updated in ROM unless readonly is unspecified.
+    * 
+    *   sub ds:0FFFFD52Ch, eax
+    *   mov eax, ds:0FFFFD52Ch
+    */
+
     /* Create BIOS region */
     MemoryRegion *bios;
     bios = g_malloc(sizeof(*bios));
     assert(bios != NULL);
     memory_region_init_ram(bios, NULL, "xbox.bios", bios_size, &error_fatal);
-    memory_region_set_readonly(bios, true);
+    //memory_region_set_readonly(bios, true);
     rom_add_blob_fixed("xbox.bios", bios_data, bios_size,
                        (uint32_t)(-2 * bios_size));
 
@@ -164,7 +178,7 @@ static void xbox_flash_init(MemoryRegion *rom_memory)
         MemoryRegion *map_bios = g_malloc(sizeof(*map_bios));
         memory_region_init_alias(map_bios, NULL, "pci-bios", bios, 0, bios_size);
         memory_region_add_subregion(rom_memory, map_loc, map_bios);
-        memory_region_set_readonly(map_bios, true);
+        //memory_region_set_readonly(map_bios, true);
     }
 }
 

--- a/hw/xbox/xbox.c
+++ b/hw/xbox/xbox.c
@@ -153,6 +153,7 @@ static void xbox_flash_init(MemoryRegion *rom_memory)
             return;
         }
 
+        /* Read in MCPX ROM over last 512 bytes of BIOS data */
         int fd = open(filename, O_RDONLY | O_BINARY);
         assert(fd >= 0);
         int rc = read(fd, bios_data + bios_size - bootrom_size, bootrom_size);

--- a/hw/xbox/xbox.c
+++ b/hw/xbox/xbox.c
@@ -137,8 +137,14 @@ static void xbox_flash_init(MemoryRegion *rom_memory)
         /* Read in MCPX ROM over last 512 bytes of BIOS data */
         int fd = open(filename, O_RDONLY | O_BINARY);
         assert(fd >= 0);
-        int rc = read(fd, &bios_data[bios_size - bootrom_size], bootrom_size);
+        uint8_t mcpx_data[512];
+        int rc = read(fd, mcpx_data, bootrom_size);
         assert(rc == bootrom_size);
+        MemoryRegion *mcpx = g_malloc(sizeof(MemoryRegion));
+        memory_region_init_ram(mcpx, NULL, "xbox.mcpx", bootrom_size, &error_fatal);
+        rom_add_blob_fixed("xbox.mcpx", mcpx_data, bootrom_size, 0xFFFFFE00);
+        memory_region_add_subregion_overlap(rom_memory, 0xFFFFFE00, mcpx, 1);
+        memory_region_set_readonly(mcpx, true);
         close(fd);
         g_free(filename);
     }

--- a/hw/xbox/xbox_pci.c
+++ b/hw/xbox/xbox_pci.c
@@ -323,12 +323,15 @@ static void xbox_lpc_config_write(PCIDevice *dev,
     XBOX_LPCState *s = XBOX_LPC_DEVICE(dev);
 
     pci_default_write_config(dev, addr, val, len);
-    if ((addr == 0x80) && (val & 2)) {  // TODO: is this right?
+    
+    if ((addr == 0x80) && (val & 2)) {
         XBOXPCI_DPRINTF("DEACTIVATING BOOT ROM\n");
-
-        // TODO: proper scan by name/address instead of relying on it being last added!
-        MemoryRegion *mcpx = s->rom_memory->subregions.tqh_first;
-        memory_region_set_enabled(mcpx, false);
+        MemoryRegion *subregion;
+        QTAILQ_FOREACH(subregion, &s->rom_memory->subregions, subregions_link) {
+            if (subregion->name != NULL && strcmp(subregion->name, "xbox.mcpx") == 0) {
+                memory_region_set_enabled(subregion, false);
+            }
+        }
     }
 
     XBOXPCI_DPRINTF("%s: %x %x %d\n", __func__, addr, val, len);

--- a/hw/xbox/xbox_pci.c
+++ b/hw/xbox/xbox_pci.c
@@ -323,13 +323,14 @@ static void xbox_lpc_config_write(PCIDevice *dev,
     XBOX_LPCState *s = XBOX_LPC_DEVICE(dev);
 
     pci_default_write_config(dev, addr, val, len);
-    
+
     if ((addr == 0x80) && (val & 2)) {
         XBOXPCI_DPRINTF("DEACTIVATING BOOT ROM\n");
         MemoryRegion *subregion;
         QTAILQ_FOREACH(subregion, &s->rom_memory->subregions, subregions_link) {
             if (subregion->name != NULL && strcmp(subregion->name, "xbox.mcpx") == 0) {
                 memory_region_set_enabled(subregion, false);
+                break;
             }
         }
     }

--- a/hw/xbox/xbox_pci.h
+++ b/hw/xbox/xbox_pci.h
@@ -53,6 +53,7 @@ typedef struct XBOX_LPCState {
     XBOX_PMRegs pm;
     qemu_irq *pic;
 
+    MemoryRegion *rom_memory;
     int bootrom_size;
     uint8_t bootrom_data[512];
 } XBOX_LPCState;
@@ -73,6 +74,7 @@ void xbox_pci_init(qemu_irq *pic,
                    MemoryRegion *address_space_io,
                    MemoryRegion *pci_memory,
                    MemoryRegion *ram_memory,
+                   MemoryRegion *rom_memory,
                    PCIBus **out_host_bus,
                    ISABus **out_isa_bus,
                    I2CBus **out_smbus,


### PR DESCRIPTION
These changes are intended to temporarily improve usability until an open-source replacement dash supports the ability to prompt the user for this information instead. Games may not load properly without these values set.