### PR TITLE
vl: Allow overriding settings path from command line

### DIFF
--- a/softmmu/vl.c
+++ b/softmmu/vl.c
@@ -2925,6 +2925,16 @@ void qemu_init(int argc, char **argv, char **envp)
     // reporting. This should be replaced eventually, but is "good enough" for
     // now.
     //
+    for (int i = 1; i < argc; i++) {
+        if (argv[i] && strcmp(argv[i], "-config_path") == 0) {
+            argv[i] = NULL;
+            if (i < argc - 1 && argv[i+1]) {
+                xemu_settings_set_path(argv[i+1]);
+                argv[i+1] = NULL;
+            }
+            break;
+        }
+    }
     xemu_settings_load();
     int first_boot = xemu_settings_did_fail_to_load();
     int fake_argc = 32 + argc;
@@ -3069,9 +3079,9 @@ void qemu_init(int argc, char **argv, char **envp)
 
     // Allow overriding the dvd path from command line
     for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-dvd_path") == 0) {
+        if (argv[i] && strcmp(argv[i], "-dvd_path") == 0) {
             argv[i] = NULL;
-            if (i < argc - 1) {
+            if (i < argc - 1 && argv[i+1]) {
                 dvd_path = argv[i+1];
                 argv[i+1] = NULL;
             }

--- a/ui/xemu-settings.c
+++ b/ui/xemu-settings.c
@@ -205,6 +205,14 @@ bool xemu_settings_detect_portable_mode(void)
 	return val;
 }
 
+void xemu_settings_set_path(const char *path)
+{
+	assert(path != NULL);
+	assert(settings_path == NULL);
+	settings_path = path;
+	fprintf(stderr, "%s: config path: %s\n", __func__, settings_path);
+}
+
 const char *xemu_settings_get_path(void)
 {
 	if (settings_path != NULL) {

--- a/ui/xemu-settings.h
+++ b/ui/xemu-settings.h
@@ -71,6 +71,9 @@ enum xemu_net_backend {
 // Determine whether settings were loaded or not
 int xemu_settings_did_fail_to_load(void);
 
+// Override the default config file paths
+void xemu_settings_set_path(const char *path);
+
 // Get path of the config file on disk
 const char *xemu_settings_get_path(void);
 


### PR DESCRIPTION
This allows to override the settings file path from the command line by using `-config_path`, similar to what's possible with `-dvd_path`. It's mainly a qol improvement for myself, to make it easier to switch between different hdd and eeprom image combinations for testing.