### PR TITLE
xbox: revert LPC revision change to fix USB bug & add warning

### DIFF
--- a/hw/xbox/xbox_pci.c
+++ b/hw/xbox/xbox_pci.c
@@ -392,7 +392,8 @@ static void xbox_lpc_class_init(ObjectClass *klass, void *data)
     //k->config_write = xbox_lpc_config_write;
     k->vendor_id = PCI_VENDOR_ID_NVIDIA;
     k->device_id = PCI_DEVICE_ID_NVIDIA_NFORCE_LPC;
-    k->revision = 178;
+    /* FIXME - correct revision for this is 0xB2 (178) for retail 1.0 Xbox, causes known USB bug */
+    k->revision = 212;
     k->class_id = PCI_CLASS_BRIDGE_ISA;
 
     dc->desc = "nForce LPC Bridge";


### PR DESCRIPTION
Never tested outside a non-input nxdk application. Just noticed that USB is completely broken due to this specific change.

Should be investigated more, I believe it's specifically looking for the daughter board as `XboxHardwareInfo` claims it has `XBOX_HW_FLAG_INTERNAL_USB_HUB` when the correct LPC revision is set.