### PR TITLE
Add workaround for OpenGL Core profiles (macOS)

### DIFF
--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -341,6 +341,7 @@ typedef struct PGRAPHState {
 
     unsigned int inline_elements_length;
     uint32_t inline_elements[NV2A_MAX_BATCH_LENGTH];
+    GLuint gl_inline_elements_buffer;
 
     unsigned int inline_buffer_length;
 

--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -2085,9 +2085,14 @@ int pgraph_method(NV2AState *d, unsigned int subchannel,
 
                 pgraph_bind_vertex_attributes(d, max_element+1, false, 0);
 
+                glBindBuffer(GL_ELEMENT_ARRAY_BUFFER,
+                             pg->gl_inline_elements_buffer);
+                glBufferData(GL_ELEMENT_ARRAY_BUFFER,
+                             pg->inline_elements_length * sizeof(uint32_t),
+                             pg->inline_elements, GL_STREAM_DRAW);
                 glDrawElements(pg->shader_binding->gl_primitive_mode,
                                pg->inline_elements_length, GL_UNSIGNED_INT,
-                               (void *)pg->inline_elements);
+                               (void *)0);
             } else {
                 NV2A_GL_DPRINTF(true, "EMPTY NV097_SET_BEGIN_END");
                 NV2A_UNCONFIRMED("EMPTY NV097_SET_BEGIN_END");
@@ -3043,6 +3048,7 @@ void pgraph_init(NV2AState *d)
         attribute->inline_buffer_populated = false;
     }
     glGenBuffers(1, &pg->gl_inline_array_buffer);
+    glGenBuffers(1, &pg->gl_inline_elements_buffer);
 
     glGenBuffers(1, &pg->gl_memory_buffer);
     glBindBuffer(GL_ARRAY_BUFFER, pg->gl_memory_buffer);


### PR DESCRIPTION
This is a workaround for the crashing on macOS that was introduced after the recent revisions to the nv2a code. Tested successfully on a 2020 MacBook Pro 13-inch model with Big Sur 11.2.2 installed.

References:
https://community.khronos.org/t/gldrawelements-causes-gl-invalid-operation/65185
https://github.com/ocornut/imgui/pull/278/files
https://stackoverflow.com/a/12618739

Fixes #214 