### PR TITLE
nv2a/vsh: Output muxed op first to avoid temp clobber

### DIFF
--- a/hw/xbox/nv2a/vsh.c
+++ b/hw/xbox/nv2a/vsh.c
@@ -405,13 +405,6 @@ static QString* decode_opcode(const uint32_t *shader_token,
         reg_num = 1;
     }
 
-    if (strcmp(opcode, mac_opcode[MAC_ARL]) == 0) {
-        qstring_append_fmt(ret, "  ARL(A0%s);\n", inputs);
-    } else if (mask > 0) {
-        qstring_append_fmt(ret, "  %s(R%d%s%s);\n",
-                           opcode, reg_num, mask_str[mask], inputs);
-    }
-
     /* See if we must add a muxed opcode too: */
     if (vsh_get_field(shader_token, FLD_OUT_MUX) == out_mux
         /* Only if it's not masked away: */
@@ -437,6 +430,13 @@ static QString* decode_opcode(const uint32_t *shader_token,
                 vsh_get_field(shader_token, FLD_OUT_O_MASK)]);
         qstring_append(ret, inputs);
         qstring_append(ret, ");\n");
+    }
+
+    if (strcmp(opcode, mac_opcode[MAC_ARL]) == 0) {
+        qstring_append_fmt(ret, "  ARL(A0%s);\n", inputs);
+    } else if (mask > 0) {
+        qstring_append_fmt(ret, "  %s(R%d%s%s);\n",
+                           opcode, reg_num, mask_str[mask], inputs);
     }
 
     return ret;


### PR DESCRIPTION
Fixes #225 
Sgt. Johnson approves of this patch.

![before](https://user-images.githubusercontent.com/8210/110226678-912d3380-7eae-11eb-80e7-cc28fb787765.png)
![after](https://user-images.githubusercontent.com/8210/110226679-938f8d80-7eae-11eb-91cb-ec7b032cafa3.png)
