### PR TITLE
video: Default to HDTV avpack

### DIFF
--- a/hw/xbox/smbus_xbox_smc.c
+++ b/hw/xbox/smbus_xbox_smc.c
@@ -230,7 +230,7 @@ bool xbox_smc_avpack_to_reg(const char *avpack, uint8_t *value)
 
 void xbox_smc_append_avpack_hint(Error **errp)
 {
-    error_append_hint(errp, "Valid options are: composite (default), scart, svideo, vga, rfu, hdtv, none\n");
+    error_append_hint(errp, "Valid options are: composite, scart, svideo, vga, rfu, hdtv (default), none\n");
 }
 
 static void smbus_smc_realize(DeviceState *dev, Error **errp)

--- a/hw/xbox/xbox.c
+++ b/hw/xbox/xbox.c
@@ -432,8 +432,8 @@ static inline void xbox_machine_initfn(Object *obj)
     object_property_add_str(obj, "avpack", machine_get_avpack,
                             machine_set_avpack);
     object_property_set_description(obj, "avpack",
-                                    "Xbox video connector: composite (default), scart, svideo, vga, rfu, hdtv, none");
-    object_property_set_str(obj, "avpack", "composite", &error_fatal);
+                                    "Xbox video connector: composite, scart, svideo, vga, rfu, hdtv (default), none");
+    object_property_set_str(obj, "avpack", "hdtv", &error_fatal);
 
     object_property_add_bool(obj, "short-animation",
                              machine_get_short_animation,


### PR DESCRIPTION
Small change.
Most of us are interested in the emulation looking as good as possible - something unlocked by using the HDTV avpack.

Allowing the user to set the avpack to use themselves through the GUI has been suggested in the Discord server previously.
I believe this is a worthy stopgap solution until that is implemented.