### PR TITLE
nv2a: implement FFP LIGHT_SPOT

### DIFF
--- a/hw/xbox/nv2a/shaders.c
+++ b/hw/xbox/nv2a/shaders.c
@@ -566,8 +566,31 @@ GLSL_DEFINE(materialEmissionColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_CM_COL) ".xyz
                 /* Everything done already */
                 break;
             case LIGHT_SPOT:
-                assert(false);
-                /*FIXME: calculate falloff */
+                /* From: https://docs.microsoft.com/en-us/windows/win32/direct3d9/attenuation-and-spotlight-factor#spotlight-factor */
+                /* Note: normalizing the direction does not produce the same result as on hardware.
+                 *       Instead, dividing the direction by 1-w produces the same result as on hardware.
+                 *       Rationale: the w component is always close (but not equal to) the difference
+                 *       between 1 and the the direction vector length (e.g. 1.0-2.6=-1.6, with w=-1.5).
+                 *       So, dividing by 1-w is the same as normalizing the vector and scaling it a bit.
+                 *       In the example: 1-(-1.5) = 2.5, 2.6/2.5 = 1.04. This also scales the subsequent
+                 *       dot product by the same amount, effectively increasing the spotlight radius.
+                 */
+                qstring_append_fmt(body,
+                    "  vec3 dir = lightSpotDirection(%d).xyz / (1.0 - lightSpotDirection(%d).w);\n"
+                    "  float rho = dot(dir, VP);\n"
+                    "  float theta = lightSpotFalloff(%d).x;\n"
+                    "  float phi = lightSpotFalloff(%d).y;\n"
+                    "  float falloff = lightSpotFalloff(%d).z;\n"
+                    "  float cosHalfPhi = cos(phi * 0.5);\n"
+                    "  float cosHalfTheta = cos(theta * 0.5);\n"
+                    "  if (rho > cosHalfTheta) {\n" /* do nothing => spotlightFactor = 1 */
+                    "  } else if (rho <= cosHalfPhi) {\n"
+                    "    attenuation = 0.0;\n" /* spotlightFactor = 0 */
+                    "  } else {\n"
+                    "    float spotlightFactor = pow((rho - cosHalfPhi) / (cosHalfTheta - cosHalfPhi), falloff);\n"
+                    "    attenuation = attenuation * spotlightFactor;\n"
+                    "  }\n",
+                    i, i, i, i, i);
                 break;
             default:
                 assert(false);


### PR DESCRIPTION
This closes #162.

Tested on Conflict: Desert Storm (53430001), Hunter: The Reckoning (564e0004) and Batman: Dark Tomorrow (4b420001).

It works mostly as described [here](https://docs.microsoft.com/en-us/windows/win32/direct3d9/attenuation-and-spotlight-factor#spotlight-factor).
However, there are a couple of things that had to be figured out.

The first is the order of the parameters `falloff`, `phi` and `theta`, since the input for all of them is a single `vec3` (`lightSpotFalloff`)
The values used by the 3 games I tested were:
`0.000000, -0.494592, 1.494592` (Conflict: Desert Storm and Hunter: The Reckoning)
`-0.581921, -2.174225, 2.592304` (Batman: Dark Tomorrow)

Now, the requirements are:
* `abs(phi) >= abs(theta)` (in theory `phi` and `theta` should be non-negative, but in fact using the absolute value is enough, since `cos(x)==cos(-x)`)
* `abs(phi) < pi` and `abs(theta) < pi` (but all the values above satisfy this requirement, so this does not help)
* `falloff > 0` (else the falloff curve would not be decreasing)

Considering the values above, the only order that satisfies these requirements (and indeed produces the same result as on hardware) is: `x, y, z` => `theta, phi, falloff`

The second thing is the direction vector. Normalizing it (as described in the documentation linked above) does not produce the same result as on hardware.
After looking at the values used by the games, I noticed that the `w` component is always close to the difference between 1 and the vector length.
So, dividing the vector by `1-w` is the same as normalizing it and scaling it a bit (which in turn scales the subsequent dot product, effectively changing the spotlight radius), and in fact doing this produces the same result as on hardware.

Some examples:
(from Hunter: The Reckoning):
* direction: `0.000000, -62.513657, -46.423523, -75.486740`
* `length = 77.865916`
* `1 - length = -76.865916`
* `length / (1 - w) = 1.018032`

(from Conflict: Desert Storm):
* direction: `1.720397, 1.274108, -1.382891, -1.461833`
* `length = 2.548628`
* `1 - length = -1.548628`
* `length / (1 - w) = 1.035256`

(from Batman: Dark Tomorrow):
* direction: `-0.389671, 0.743980, -0.574882, -0.017762`
* `length = 1.017762`
* `1 - length = -0.017762`
* `length / (1 - w) = 1.0`

A spotlight in the intro of Conflict: Desert Storm with this PR (same as on hardware):
![cds](https://user-images.githubusercontent.com/29335145/116821407-12850780-ab7a-11eb-8da5-e25c28a96c0f.jpg)

Here (Hunter: The Reckoning, in the subway station at the beginning of the game) spotlights are used on the characters, matching the ground illumination (same as on hardware):
![htr](https://user-images.githubusercontent.com/29335145/116821416-19137f00-ab7a-11eb-946c-a009eb49b670.gif)
