### PR TITLE
Support X8R8G8B8 NV062 linear color format.

### DIFF
--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -750,6 +750,7 @@
 #   define NV062_SET_COLOR_FORMAT                             0x00000300
 #       define NV062_SET_COLOR_FORMAT_LE_Y8                    0x01
 #       define NV062_SET_COLOR_FORMAT_LE_R5G6B5                0x04
+#       define NV062_SET_COLOR_FORMAT_LE_X8R8G8B8              0x07
 #       define NV062_SET_COLOR_FORMAT_LE_A8R8G8B8              0x0A
 #   define NV062_SET_PITCH                                    0x00000304
 #   define NV062_SET_OFFSET_SOURCE                            0x00000308

--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -845,6 +845,7 @@ int pgraph_method(NV2AState *d, unsigned int subchannel,
                 bytes_per_pixel = 2;
                 break;
             case NV062_SET_COLOR_FORMAT_LE_A8R8G8B8:
+            case NV062_SET_COLOR_FORMAT_LE_X8R8G8B8:
                 bytes_per_pixel = 4;
                 break;
             default:


### PR DESCRIPTION
- fixes troubles with opening menu in OFP: Elite game

_PS: OFP: Elite doesn't start with original disc, there are some manual changes needed first. I can provide more detailed steps how to test this with OFP: Elite game if needed. Feel free to ping me._