### PR TITLE
Fix some issues with Intel integrated graphics on Windows

### DIFF
--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -283,7 +283,13 @@ typedef struct PGRAPHState {
     float bump_env_matrix[NV2A_MAX_TEXTURES - 1][4]; /* 3 allowed stages with 2x2 matrix each */
 
     GLuint gl_framebuffer;
+
     GLuint gl_display_buffer;
+    GLint gl_display_buffer_internal_format;
+    GLsizei gl_display_buffer_width;
+    GLsizei gl_display_buffer_height;
+    GLenum gl_display_buffer_format;
+    GLenum gl_display_buffer_type;
 
     hwaddr dma_state;
     hwaddr dma_notifies;

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -859,6 +859,7 @@ static void sdl2_display_very_early_init(DisplayOptions *o)
         SDL_Quit();
         exit(1);
     }
+    SDL_GL_MakeCurrent(m_window, m_context);
 
     int width, height, channels = 0;
     stbi_set_flip_vertically_on_load(0);
@@ -872,6 +873,11 @@ static void sdl2_display_very_early_init(DisplayOptions *o)
         // Note: Retaining the memory allocated by stbi_load. It's used in place
         // by the SDL surface.
     }
+
+    fprintf(stderr, "GL_VENDOR: %s\n", glGetString(GL_VENDOR));
+    fprintf(stderr, "GL_RENDERER: %s\n", glGetString(GL_RENDERER));
+    fprintf(stderr, "GL_VERSION: %s\n", glGetString(GL_VERSION));
+    fprintf(stderr, "GL_SHADING_LANGUAGE_VERSION: %s\n", glGetString(GL_SHADING_LANGUAGE_VERSION));
 
     // Initialize offscreen rendering context now
     nv2a_gl_context_init();
@@ -981,7 +987,6 @@ type_init(register_sdl1);
 
 void xb_surface_gl_create_texture(DisplaySurface *surface)
 {
-    // assert(gls);
     assert(QEMU_IS_ALIGNED(surface_stride(surface), surface_bytes_per_pixel(surface)));
 
     switch (surface->format) {
@@ -1496,6 +1501,11 @@ int main(int argc, char **argv)
         }
     }
 #endif
+
+    fprintf(stderr, "xemu_version: %s\n", xemu_version);
+    fprintf(stderr, "xemu_branch: %s\n", xemu_branch);
+    fprintf(stderr, "xemu_commit: %s\n", xemu_commit);
+    fprintf(stderr, "xemu_date: %s\n", xemu_date);
 
     DPRINTF("Entered main()\n");
     gArgc = argc;

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -1186,6 +1186,7 @@ void sdl2_gl_refresh(DisplayChangeListener *dcl)
     qemu_mutex_unlock_iothread();
     qemu_mutex_unlock_main_loop();
 
+    glFinish();
     SDL_GL_SwapWindow(scon->real_window);
 
     /* VGA update (see note above) + vblank */


### PR DESCRIPTION
Tested working on:
* Intel UHD Graphics 630, 27.20.100.8729 9/11/2020 W10 x64
* Intel UHD 750 [thx for testing @MasonT8198]
* Intel UHD 620
* Intel HD 615 (GPD Win 2) [thx for testing @re4thewin]
* Intel HD 5500, 20.19.15.5126 [@MasonT8198]
* Intel HD Graphics 520
* Intel Iris Xe [cc @DukeZilla]

Does not `fix` #84 which affects:
  * Intel HD 4600
  * Intel HD 4000

Fixes #345 
Fixes #137
