### PR TITLE
build: Don't strip Windows debug binaries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,9 @@ package_windows() {
     cp build/qemu-system-i386w.exe dist/xemu.exe
     # cp -r "${project_source_dir}/data" dist/
     python3 "${project_source_dir}/get_deps.py" dist/xemu.exe dist
-    strip dist/xemu.exe
+    if [ "$debug" != "y" ]; then
+        strip dist/xemu.exe
+    fi
 }
 
 package_wincross() {
@@ -23,7 +25,9 @@ package_wincross() {
     mkdir -p dist
     cp build/qemu-system-i386w.exe dist/xemu.exe
     # cp -r "${project_source_dir}/data" dist/
-    $STRIP dist/xemu.exe
+    if [ "$debug" != "y" ]; then
+        $STRIP dist/xemu.exe
+    fi
     python3 ./scripts/gen-license.py --platform windows > dist/LICENSE.txt
 }
 


### PR DESCRIPTION
This came up in a Discord discussion yesterday, where a user wanted to debug the xemu process on Windows, but gdb complained about missing debug information despite it being the debug build.
This was caused by running the strip tool on the debug builds, so this commit disables that.

Not stripping the debug binary approximately doubles its size.