### PR TITLE
nv2a: Improve clipped surface handling

### DIFF
--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -242,6 +242,8 @@ typedef struct PGRAPHState {
 
     struct disp_rndr {
         GLuint fbo, vao, vbo, prog;
+        GLuint display_size_loc;
+        GLuint line_offset_loc;
         GLuint tex_loc;
         GLuint pvideo_tex;
         GLint pvideo_enable_loc;

--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -101,6 +101,14 @@ typedef struct VertexAttribute {
     GLuint gl_inline_buffer;
 } VertexAttribute;
 
+typedef struct SurfaceFormatInfo {
+    unsigned int bytes_per_pixel;
+    GLint gl_internal_format;
+    GLenum gl_format;
+    GLenum gl_type;
+    GLenum gl_attachment;
+} SurfaceFormatInfo;
+
 typedef struct Surface {
     bool draw_dirty;
     bool buffer_dirty;
@@ -126,6 +134,7 @@ typedef struct SurfaceBinding {
 
     hwaddr vram_addr;
 
+    SurfaceFormatInfo fmt;
     SurfaceShape shape;
     uintptr_t dma_addr;
     uintptr_t dma_len;
@@ -135,13 +144,8 @@ typedef struct SurfaceBinding {
     unsigned int width;
     unsigned int height;
     unsigned int pitch;
-    unsigned int bytes_per_pixel;
     size_t size;
 
-    GLenum gl_attachment;
-    GLenum gl_internal_format;
-    GLenum gl_format;
-    GLenum gl_type;
     GLuint gl_buffer;
 
     int frame_time;

--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -5080,19 +5080,6 @@ static void pgraph_update_surface_part(NV2AState *d, bool upload, bool color)
         assert(glCheckFramebufferStatus(GL_FRAMEBUFFER)
             == GL_FRAMEBUFFER_COMPLETE);
 
-        NV2A_GL_DPRINTF(true, "upload_surface %s "
-                      "0x%" HWADDR_PRIx " - 0x%" HWADDR_PRIx ", "
-                      "(0x%" HWADDR_PRIx " - 0x%" HWADDR_PRIx ", "
-                        "%d %d, %d %d, %d)",
-            color ? "color" : "zeta",
-            dma.address, dma.address + dma.limit,
-            dma.address + surface->offset,
-            dma.address + surface->pitch * height,
-            pg->surface_shape.clip_x, pg->surface_shape.clip_y,
-            pg->surface_shape.clip_width,
-            pg->surface_shape.clip_height,
-            surface->pitch);
-
         surface->buffer_dirty = false;
     }
 
@@ -5103,21 +5090,8 @@ static void pgraph_update_surface_part(NV2AState *d, bool upload, bool color)
                 color ? pg->color_binding : pg->zeta_binding, true);
         }
 
-        /* read the opengl framebuffer into the surface */
         surface->write_enabled_cache = false;
         surface->draw_dirty = false;
-
-        NV2A_GL_DPRINTF(true, "read_surface %s "
-                      "0x%" HWADDR_PRIx " - 0x%" HWADDR_PRIx ", "
-                      "(0x%" HWADDR_PRIx " - 0x%" HWADDR_PRIx ", "
-                        "%d %d, %d %d, %d)",
-            color ? "color" : "zeta",
-            dma.address, dma.address + dma.limit,
-            dma.address + surface->offset,
-            dma.address + surface->pitch * pg->surface_shape.clip_height,
-            pg->surface_shape.clip_x, pg->surface_shape.clip_y,
-            pg->surface_shape.clip_width, pg->surface_shape.clip_height,
-            surface->pitch);
     }
 }
 


### PR DESCRIPTION
Probably fixes most issues with #312 #148 #309

Fixes #77 
Fixes #355

Needs testing:
- [x] Batman Begins
- [ ] Battlefield 2 Modern Combat
- [ ] Close Combat: First to Fight: United States Marines
- [x] Colin McRae Rally 2005
- [ ] Destroy All Humans
- [ ] Future Tactics Uprising
- [ ] Gene Troopers
- [ ] Goblin Commander
- [ ] Headhunter: Redemption
- [x] Kung-Fu Chaos
- [x] Madden 2005
- [ ] Pirates of the Caribbean
- [ ] Robots
- [ ] Shikigami no Shiro Evolution
- [ ] Spikeout Battle Street
- [ ] TimeSplitters Future Perfect
- [ ] Toca 2
- [ ] Toca 3
- [ ] Winback 2 Project Poseidon

Of course, other games should be tested for regressions as well.

- [x] Fix recreation write gate desync