### PR TITLE
nv2a: Support NV062_SET_COLOR_FORMAT_LE_Y32 blitting

### DIFF
--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -756,6 +756,7 @@
 #       define NV062_SET_COLOR_FORMAT_LE_R5G6B5                0x04
 #       define NV062_SET_COLOR_FORMAT_LE_X8R8G8B8              0x07
 #       define NV062_SET_COLOR_FORMAT_LE_A8R8G8B8              0x0A
+#       define NV062_SET_COLOR_FORMAT_LE_Y32                   0x0B
 #   define NV062_SET_PITCH                                    0x00000304
 #   define NV062_SET_OFFSET_SOURCE                            0x00000308
 #   define NV062_SET_OFFSET_DESTIN                            0x0000030C

--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -862,6 +862,7 @@ int pgraph_method(NV2AState *d, unsigned int subchannel,
                 break;
             case NV062_SET_COLOR_FORMAT_LE_A8R8G8B8:
             case NV062_SET_COLOR_FORMAT_LE_X8R8G8B8:
+            case NV062_SET_COLOR_FORMAT_LE_Y32:
                 bytes_per_pixel = 4;
                 break;
             default:


### PR DESCRIPTION
Harry Potter and the Sorcerer's Stone asserts [here](https://github.com/mborgerson/xemu/blob/cc6d19e0990ab94aa55632302afb76b22f3ca09d/hw/xbox/nv2a/pgraph.c#L869) after finishing the wand shop tutorials. I'm fairly certain surface format 0xB is Y32 as the rest of [these](https://cgit.freedesktop.org/nouveau/xf86-video-nouveau/tree/src/hwdefs/nv01_2d.xml.h?id=e70d801ae9287eab5e82f4d467dc8cd4be1b31a8#n265) values line up with what we already have, but this needs more testing to be 100% sure.