### PR TITLE
nv2a: Set frequency to 233MHz

### DIFF
--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -306,8 +306,8 @@ static void nv2a_reset(NV2AState *d)
     memset(d->pgraph.regs, 0, sizeof(d->pgraph.regs));
 
     d->pcrtc.start = 0;
-    d->pramdac.core_clock_coeff = 0x00011c01; /* 189MHz...? */
-    d->pramdac.core_clock_freq = 189000000;
+    d->pramdac.core_clock_coeff = 0x00011C01; /* 189MHz...? */
+    d->pramdac.core_clock_freq = 233333324;
     d->pramdac.memory_clock_coeff = 0;
     d->pramdac.video_clock_coeff = 0x0003C20D; /* 25182Khz...? */
 


### PR DESCRIPTION
No clue about the coefficients and such but the frequency is supposed to be 233MHz according to `XBOverclock`. This might not even matter if it gets set in `pramdac_write` correctly.

Unrelated has anyone seen if nxdk apps work recently? I get a black screen, or a broken Xbox logo, and if I reset I can see what was supposed to be shown as if the surface wasn't updated.