### PR TITLE
Improve Unicode filename handling on Windows

### DIFF
--- a/hw/core/loader.c
+++ b/hw/core/loader.c
@@ -70,7 +70,7 @@ int64_t get_image_size(const char *filename)
 {
     int fd;
     int64_t size;
-    fd = open(filename, O_RDONLY | O_BINARY);
+    fd = qemu_open(filename, O_RDONLY | O_BINARY, NULL);
     if (fd < 0)
         return -1;
     size = lseek(fd, 0, SEEK_END);
@@ -84,7 +84,7 @@ ssize_t load_image_size(const char *filename, void *addr, size_t size)
     int fd;
     ssize_t actsize, l = 0;
 
-    fd = open(filename, O_RDONLY | O_BINARY);
+    fd = qemu_open(filename, O_RDONLY | O_BINARY, NULL);
     if (fd < 0) {
         return -1;
     }
@@ -229,7 +229,7 @@ int load_aout(const char *filename, hwaddr addr, int max_sz,
     struct exec e;
     uint32_t magic;
 
-    fd = open(filename, O_RDONLY | O_BINARY);
+    fd = qemu_open(filename, O_RDONLY | O_BINARY, NULL);
     if (fd < 0)
         return -1;
 
@@ -359,7 +359,7 @@ void load_elf_hdr(const char *filename, void *hdr, bool *is64, Error **errp)
     }
     e_ident = hdr;
 
-    fd = open(filename, O_RDONLY | O_BINARY);
+    fd = qemu_open(filename, O_RDONLY | O_BINARY, NULL);
     if (fd < 0) {
         error_setg_errno(errp, errno, "Failed to open file: %s", filename);
         return;
@@ -456,7 +456,7 @@ int load_elf_ram_sym(const char *filename,
     int fd, data_order, target_data_order, must_swab, ret = ELF_LOAD_FAILED;
     uint8_t e_ident[EI_NIDENT];
 
-    fd = open(filename, O_RDONLY | O_BINARY);
+    fd = qemu_open(filename, O_RDONLY | O_BINARY, NULL);
     if (fd < 0) {
         perror(filename);
         return -1;
@@ -613,7 +613,7 @@ static int load_uboot_image(const char *filename, hwaddr *ep, hwaddr *loadaddr,
     int ret = -1;
     int do_uncompress = 0;
 
-    fd = open(filename, O_RDONLY | O_BINARY);
+    fd = qemu_open(filename, O_RDONLY | O_BINARY, NULL);
     if (fd < 0)
         return -1;
 
@@ -962,7 +962,7 @@ int rom_add_file(const char *file, const char *fw_dir,
         rom->path = g_strdup(file);
     }
 
-    fd = open(rom->path, O_RDONLY | O_BINARY);
+    fd = qemu_open(rom->path, O_RDONLY | O_BINARY, NULL);
     if (fd == -1) {
         fprintf(stderr, "Could not open option rom '%s': %s\n",
                 rom->path, strerror(errno));

--- a/hw/xbox/eeprom_generation.c
+++ b/hw/xbox/eeprom_generation.c
@@ -241,7 +241,7 @@ bool xbox_eeprom_generate(const char *file, XboxEEPROMVersion ver) {
     xbox_rc4_crypt(&rctx, e.confounder, 0x1C);
 
     // save to file
-    FILE *fd = fopen(file, "wb");
+    FILE *fd = qemu_fopen(file, "wb");
     if (fd == NULL) {
         return false;
     }

--- a/hw/xbox/smbus_storage.c
+++ b/hw/xbox/smbus_storage.c
@@ -68,7 +68,7 @@ static void smbus_storage_realize(DeviceState *dev, Error **errp)
             return;
         }
 
-        int fd = open(s->file, O_RDONLY | O_BINARY);
+        int fd = qemu_open(s->file, O_RDONLY | O_BINARY, NULL);
         if (fd < 0) {
             error_setg(errp, "%s: file '%s' could not be opened\n",
                 __func__, s->file);
@@ -109,7 +109,7 @@ static int smbus_storage_write_data(SMBusDevice *dev, uint8_t *buf, uint8_t len)
     }
 
     if (changed && s->file && s->persist) {
-        int fd = open(s->file, O_WRONLY | O_BINARY);
+        int fd = qemu_open(s->file, O_WRONLY | O_BINARY, NULL);
         if (fd < 0) {
             DPRINTF("%s: file '%s' could not be opened\n", __func__, s->file);
             return -1;

--- a/hw/xbox/xbox.c
+++ b/hw/xbox/xbox.c
@@ -87,7 +87,7 @@ static void xbox_flash_init(MachineState *ms, MemoryRegion *rom_memory)
     if (!failed_to_load_bios && (filename != NULL)) {
         /* Read BIOS ROM into memory */
         failed_to_load_bios = 1;
-        int fd = open(filename, O_RDONLY | O_BINARY);
+        int fd = qemu_open(filename, O_RDONLY | O_BINARY, NULL);
         if (fd >= 0) {
             int rc = read(fd, bios_data, bios_size);
             if (rc == bios_size) {
@@ -156,7 +156,7 @@ static void xbox_flash_init(MachineState *ms, MemoryRegion *rom_memory)
         }
 
         /* Read in MCPX ROM over last 512 bytes of BIOS data */
-        int fd = open(filename, O_RDONLY | O_BINARY);
+        int fd = qemu_open(filename, O_RDONLY | O_BINARY, NULL);
         assert(fd >= 0);
         int rc = read(fd, bios_data + bios_size - bootrom_size, bootrom_size);
         assert(rc == bootrom_size);

--- a/include/qemu/osdep.h
+++ b/include/qemu/osdep.h
@@ -593,6 +593,21 @@ int qemu_lock_fd_test(int fd, int64_t start, int64_t len, bool exclusive);
 bool qemu_has_ofd_lock(void);
 #endif
 
+#ifdef _WIN32
+FILE *qemu_fopen(const char *filename, const char *mode);
+int qemu_access(const char *pathname, int mode);
+#else
+static inline FILE *qemu_fopen(const char *filename, const char *mode)
+{
+    return fopen(filename, mode);
+}
+
+static inline int qemu_access(const char *pathname, int mode)
+{
+    return access(pathname, mode);
+}
+#endif
+
 #if defined(__HAIKU__) && defined(__i386__)
 #define FMT_pid "%ld"
 #elif defined(WIN64)

--- a/softmmu/datadir.c
+++ b/softmmu/datadir.c
@@ -38,7 +38,7 @@ char *qemu_find_file(int type, const char *name)
     char *buf;
 
     /* Try the name as a straight path first */
-    if (access(name, R_OK) == 0) {
+    if (qemu_access(name, R_OK) == 0) {
         trace_load_file(name, name);
         return g_strdup(name);
     }
@@ -56,7 +56,7 @@ char *qemu_find_file(int type, const char *name)
 
     for (i = 0; i < data_dir_idx; i++) {
         buf = g_strdup_printf("%s/%s%s", data_dir[i], subdir, name);
-        if (access(buf, R_OK) == 0) {
+        if (qemu_access(buf, R_OK) == 0) {
             trace_load_file(name, buf);
             return buf;
         }

--- a/softmmu/vl.c
+++ b/softmmu/vl.c
@@ -2436,7 +2436,7 @@ static void create_default_memdev(MachineState *ms, const char *path)
 /* Return 1 if file fails to open */
 static int xemu_check_file(const char *path)
 {
-    FILE *fd = fopen(path, "rb");
+    FILE *fd = qemu_fopen(path, "rb");
     if (fd == NULL) {
         return 1;
     }
@@ -3768,7 +3768,7 @@ void qemu_init(int argc, char **argv, char **envp)
                     if (strcmp(optarg, "-") == 0) {
                         fp = stdout;
                     } else {
-                        fp = fopen(optarg, "w");
+                        fp = qemu_fopen(optarg, "w");
                         if (fp == NULL) {
                             error_report("open %s: %s", optarg,
                                          strerror(errno));
@@ -3856,7 +3856,7 @@ void qemu_init(int argc, char **argv, char **envp)
                                  "option may be given");
                     exit(1);
                 }
-                vmstate_dump_file = fopen(optarg, "w");
+                vmstate_dump_file = qemu_fopen(optarg, "w");
                 if (vmstate_dump_file == NULL) {
                     error_report("open %s: %s", optarg, strerror(errno));
                     exit(1);

--- a/ui/inih/ini.c
+++ b/ui/inih/ini.c
@@ -18,6 +18,7 @@ https://github.com/benhoyt/inih
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>
+#include "qemu/osdep.h"
 
 #include "ini.h"
 
@@ -238,7 +239,7 @@ int ini_parse(const char* filename, ini_handler handler, void* user)
     FILE* file;
     int error;
 
-    file = fopen(filename, "r");
+    file = qemu_fopen(filename, "r");
     if (!file)
         return -1;
     error = ini_parse_file(file, handler, user);

--- a/ui/xemu-settings.c
+++ b/ui/xemu-settings.c
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "qemu/osdep.h"
 #include <stdlib.h>
 #include <SDL_filesystem.h>
 #include <string.h>
@@ -208,7 +209,7 @@ static bool xemu_settings_detect_portable_mode(void)
 	bool val = false;
 	char *portable_path = g_strdup_printf("%s%s", SDL_GetBasePath(), filename);
 	FILE *tmpfile;
-	if ((tmpfile = fopen(portable_path, "r"))) {
+	if ((tmpfile = qemu_fopen(portable_path, "r"))) {
 		fclose(tmpfile);
 		val = true;
 	}
@@ -392,7 +393,7 @@ void xemu_settings_load(void)
 
 int xemu_settings_save(void)
 {
-	FILE *fd = fopen(xemu_settings_get_path(), "wb");
+	FILE *fd = qemu_fopen(xemu_settings_get_path(), "wb");
 	assert(fd != NULL);
 
 	const char *last_section = "";

--- a/util/path.c
+++ b/util/path.c
@@ -53,7 +53,7 @@ const char *path(const char *name)
         char *full = g_build_filename(base, name, NULL);
 
         /* Look for the path; record the result, pass or fail.  */
-        if (access(full, F_OK) == 0) {
+        if (qemu_access(full, F_OK) == 0) {
             /* Exists.  */
             g_hash_table_insert(hash, save, full);
             ret = full;

--- a/util/qemu-config.c
+++ b/util/qemu-config.c
@@ -452,7 +452,7 @@ int qemu_config_parse(FILE *fp, QemuOptsList **lists, const char *fname, Error *
 
 int qemu_read_config_file(const char *filename, QEMUConfigCB *cb, Error **errp)
 {
-    FILE *f = fopen(filename, "r");
+    FILE *f = qemu_fopen(filename, "r");
     int ret;
 
     if (f == NULL) {


### PR DESCRIPTION
All identified UTF-8/Unicode issues have been fixed, now xemu can:
* Run from a directory with Unicode characters
* Load/save settings to a directory with Unicode characters (typically non-ASCII user names)
* Load BIOS/hard disc from directories with Unicode characters
* Run games from directories with Unicode characters

![image](https://user-images.githubusercontent.com/7947461/137635367-989b279b-7241-4053-8ef4-ea63f66a9474.png)
Here it's been tested with nonsense paths, but in practice this means that if those paths work, then e.g. paths with Russian, Japanese or Chinese characters will also work fine.

There may be more places that need fixing, but basing on my testing of the above, all known broken cases are now handled properly.

Fixes #479