### PR TITLE
Add USB daughterboard

### DIFF
--- a/hw/xbox/xbox_pci.c
+++ b/hw/xbox/xbox_pci.c
@@ -419,8 +419,7 @@ static void xbox_lpc_class_init(ObjectClass *klass, void *data)
     k->config_write = xbox_lpc_config_write;
     k->vendor_id = PCI_VENDOR_ID_NVIDIA;
     k->device_id = PCI_DEVICE_ID_NVIDIA_NFORCE_LPC;
-    /* FIXME - correct revision for this is 0xB2 (178) for retail 1.0 Xbox, causes known USB bug */
-    k->revision = 212;
+    k->revision = 178;
     k->class_id = PCI_CLASS_BRIDGE_ISA;
 
     dc->desc = "nForce LPC Bridge";

--- a/ui/xemu-input.c
+++ b/ui/xemu-input.c
@@ -431,7 +431,19 @@ void xemu_input_bind(int index, ControllerState *state, int save)
         bound_controllers[index]->bound = index;
 
         const int port_map[4] = {3, 4, 1, 2};
+        char *tmp;
 
+        // Create controller's internal USB hub.
+        QDict *usbhub_qdict = qdict_new();
+        qdict_put_str(usbhub_qdict, "driver", "usb-hub");
+        tmp = g_strdup_printf("1.%d", port_map[index]);
+        qdict_put_str(usbhub_qdict, "port", tmp);
+        qdict_put_int(usbhub_qdict, "ports", 3);
+        QemuOpts *usbhub_opts = qemu_opts_from_qdict(qemu_find_opts("device"), usbhub_qdict, &error_abort);
+        DeviceState *usbhub_dev = qdev_device_add(usbhub_opts, &error_abort);
+        g_free(tmp);
+
+        // Create XID controller. This is connected to Port 1 of the controller's internal USB Hub
         QDict *qdict = qdict_new();
 
         // Specify device driver
@@ -439,13 +451,13 @@ void xemu_input_bind(int index, ControllerState *state, int save)
 
         // Specify device identifier
         static int id_counter = 0;
-        char *tmp = g_strdup_printf("gamepad_%d", id_counter++);
+        tmp = g_strdup_printf("gamepad_%d", id_counter++);
         qdict_put_str(qdict, "id", tmp);
         g_free(tmp);
 
         // Specify index/port
         qdict_put_int(qdict, "index", index);
-        tmp = g_strdup_printf("1.%d", port_map[index]);
+        tmp = g_strdup_printf("1.%d.1", port_map[index]);
         qdict_put_str(qdict, "port", tmp);
         g_free(tmp);
 
@@ -455,10 +467,12 @@ void xemu_input_bind(int index, ControllerState *state, int save)
         assert(dev);
 
         // Unref for eventual cleanup
+        qobject_unref(usbhub_qdict);
+        object_unref(OBJECT(usbhub_dev));
         qobject_unref(qdict);
         object_unref(OBJECT(dev));
 
-        state->device = dev;
+        state->device = usbhub_dev;
     }
 }
 


### PR DESCRIPTION
This adds emulation for the USB Daugherboard which caused the USB input bug described here: https://github.com/mborgerson/xemu/pull/223

Additionally this adds the internal hubs for the game controllers in a separate commit. This is the initial step to add XMU support etc. Note the PID/VIDs for the hubs are different from retail, only because I am using QEMUs usb-hub device which does not have configurable IDs. This does not seem to impact functionality.

I was able to reproduce the input issue when the MCPX rev was set for 1.0 Xbox (no input at all), and adding the daughterboard fixed it.

Based on testing on real hardware, the USB daughterboard is connected to Port 1 of the root hub. The controllers are connected to ports 3,4,1,2 respectively on the daughterboard.

This PR vs real HW when connecting then disconnecting a controller from controller port 1:
![image](https://user-images.githubusercontent.com/21236406/141931636-29660865-042a-4f7c-8fa5-165709453f35.png)

Output from all 4 controllers:
![image](https://user-images.githubusercontent.com/21236406/141931703-10acd3f0-6ceb-46ed-bde8-1a032ef427a8.png)

Tested on a few retail titles and MS Dashboard. 4 players tested on Halo CE, all work as expected.