### PR TITLE
pgraph: Enables 16-bit floating point z-buffer mode.

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -3043,7 +3043,6 @@ DEF_METHOD(NV097, CLEAR_SURFACE)
             /* FIXME: Remove bit for stencil clear? */
             if (pg->surface_shape.z_format) {
                 gl_clear_depth = convert_f16_to_float(z) / f16_max;
-                assert(false); /* FIXME: Untested */
             } else {
                 gl_clear_depth = z / (float)0xFFFF;
             }


### PR DESCRIPTION
Removes the verification assert when clearing 16-bit floating point z-buffer.

Tested via https://github.com/abaire/nxdk_pgraph_tests and for the most part the output produced by xemu very closely matches the output from a 1.0 XBOX (there are very minor differences in color blending that are also observable in normal texturing and do not appear to be related to z-buffering). Output of running the test against hardware can be found here: https://github.com/abaire/nxdk_pgraph_tests_golden_results

The main difference I observed is that on the XBOX, z values < `convert_f16_to_float(0x1000) == 0.0156250f` will all result in 0 being written to the depth buffer, whereas xemu seems to support all mappable values down to zero. This results in clear values < 0x1000 still rendering anything < `0.0156250f` on hardware but content being properly cleared on xemu. I'm not sure if this matters in practice as it only affects a small range of z-values with clipping disabled or with a 0 near-plane.

Fixes #60 