### PR TITLE
vsh: Uses double precision when doing clip range remapping.

### DIFF
--- a/hw/xbox/nv2a/vsh.c
+++ b/hw/xbox/nv2a/vsh.c
@@ -776,9 +776,15 @@ void vsh_translate(uint16_t version,
          * Note this makes the values in the depth buffer wrong. This should be
          * handled with gl_ClipDistance instead, but that has performance issues
          * on OS X.
+         *
+         * This conversion is performed at double precision to handle max depth
+         * clipping in the Xbox z24s8 floating point mode.
          */
         "  if (clipRange.y != clipRange.x) {\n"
-        "    oPos.z = (oPos.z - clipRange.x)/(0.5*(clipRange.y - clipRange.x)) - 1;\n"
+        "    double work = double(oPos.z - clipRange.x);\n"
+        "    double half_full_distance = 0.5 * double(clipRange.y - clipRange.x);\n"
+        "    oPos.z = float(work / half_full_distance);\n"
+        "    oPos.z = oPos.z - 1;\n"
         "  }\n"
 
         /* Correct for the perspective divide */
@@ -794,4 +800,3 @@ void vsh_translate(uint16_t version,
     );
 
 }
-


### PR DESCRIPTION
Fixes failure when mapping a full range floating point z24s8 clip range into OpenGL due to lack of precision.