### PR TITLE
nv2a/vsh: Precompute clip range to avoid double in shader.

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -3770,7 +3770,8 @@ static void pgraph_shader_update_constants(PGRAPHState *pg,
     }
 
     if (binding->clip_range_loc != -1) {
-        glUniform2f(binding->clip_range_loc, zclip_min, zclip_max);
+        double precomputed_depth = (double)(zclip_max - zclip_min) * 0.5;
+        glUniform2f(binding->clip_range_loc, zclip_min, (float)precomputed_depth);
     }
 
     /* Clipping regions */

--- a/hw/xbox/nv2a/shaders.c
+++ b/hw/xbox/nv2a/shaders.c
@@ -682,6 +682,8 @@ static MString *generate_vertex_shader(const ShaderState state,
     MString *header = mstring_from_str(
 "#version 400\n"
 "\n"
+// Holds an offset (the near plane) and a precomputed 1/2 (far - near) suitable
+// for converting Xbox coordinates into GL.
 "uniform vec2 clipRange;\n"
 "uniform vec2 surfaceSize;\n"
 "\n"

--- a/hw/xbox/nv2a/vsh.c
+++ b/hw/xbox/nv2a/vsh.c
@@ -781,10 +781,7 @@ void vsh_translate(uint16_t version,
          * clipping in the Xbox z24s8 floating point mode.
          */
         "  if (clipRange.y != clipRange.x) {\n"
-        "    double work = double(oPos.z - clipRange.x);\n"
-        "    double half_full_distance = 0.5 * double(clipRange.y - clipRange.x);\n"
-        "    oPos.z = float(work / half_full_distance);\n"
-        "    oPos.z = oPos.z - 1;\n"
+        "    oPos.z = (oPos.z - clipRange.x) / clipRange.y - 1.0;\n"
         "  }\n"
 
         /* Correct for the perspective divide */


### PR DESCRIPTION
It looks like clip range is only used in the vertex shader so we can avoid hopping into (potentially slow) doubles and precompute the depth buffer mapping at double precision once on the CPU instead of on every frame in the shader.

I'm not sure if it's also worth renaming `clipRange` to something like `clipMapping` or `clipRangeMapping` to better capture the fact that it's not actually a range. I added a comment where it's declared to describe it (I'm assuming anybody confused by the behavior would search for `clipRange` and see it there).