### PR TITLE
nv2a: Treat 0 SET_FRONT_FACE as CCW to match hw.

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -1704,9 +1704,8 @@ DEF_METHOD(NV097, SET_FRONT_FACE)
     case NV097_SET_FRONT_FACE_V_CCW:
         ccw = true; break;
     default:
-        fprintf(stderr, "Unknown front face: 0x%x\n", parameter);
-        assert(false);
-        break;
+        NV2A_DPRINTF("Unknown front face: 0x%08x\n", parameter);
+        return; /* discard */
     }
     SET_MASK(pg->regs[NV_PGRAPH_SETUPRASTER],
              NV_PGRAPH_SETUPRASTER_FRONTFACE,


### PR DESCRIPTION
Treats a `SET_FRONT_FACE` of `0` as `CCW` to match observed behavior on HW (Xbox 1.0).

Test case: https://github.com/abaire/nxdk_pgraph_tests/blob/main/tests/front_face_tests.cpp

Fixes #321 