### PR TITLE
hud: Add nv2a state debug window.

### DIFF
--- a/hw/xbox/nv2a/debug.h
+++ b/hw/xbox/nv2a/debug.h
@@ -137,6 +137,10 @@ typedef struct NV2AStats {
         int counters[NV2A_PROF__COUNT];
     } frame_working, frame_history[NV2A_PROF_NUM_FRAMES];
     unsigned int frame_ptr;
+
+    const unsigned char *vram_ptr;
+    const unsigned char *ramin_ptr;
+    const unsigned int *pfifo_regs;
 } NV2AStats;
 
 #ifdef __cplusplus
@@ -147,6 +151,9 @@ extern NV2AStats g_nv2a_stats;
 
 const char *nv2a_profile_get_counter_name(unsigned int cnt);
 int nv2a_profile_get_counter_value(unsigned int cnt);
+
+unsigned int nv2a_get_ramht_offset(void);
+unsigned int nv2a_get_ramht_size(void);
 
 #ifdef __cplusplus
 }

--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -248,6 +248,10 @@ static void nv2a_init_memory(NV2AState *d, MemoryRegion *ram)
     d->vram_ptr = memory_region_get_ram_ptr(d->vram);
     d->ramin_ptr = memory_region_get_ram_ptr(&d->ramin);
 
+    g_nv2a_stats.vram_ptr = d->vram_ptr;
+    g_nv2a_stats.ramin_ptr = d->ramin_ptr;
+    g_nv2a_stats.pfifo_regs = d->pfifo.regs;
+
     memory_region_set_log(d->vram, true, DIRTY_MEMORY_NV2A);
     memory_region_set_log(d->vram, true, DIRTY_MEMORY_NV2A_TEX);
     memory_region_set_dirty(d->vram, 0, memory_region_size(d->vram));

--- a/hw/xbox/nv2a/pfifo.c
+++ b/hw/xbox/nv2a/pfifo.c
@@ -527,6 +527,17 @@ static uint32_t ramht_hash(NV2AState *d, uint32_t handle)
     return hash;
 }
 
+unsigned int nv2a_get_ramht_offset(void)
+{
+    return GET_MASK(g_nv2a_stats.pfifo_regs[NV_PFIFO_RAMHT],
+                    NV_PFIFO_RAMHT_BASE_ADDRESS) << 12;
+}
+
+unsigned int nv2a_get_ramht_size(void)
+{
+    return 1 << (GET_MASK(g_nv2a_stats.pfifo_regs[NV_PFIFO_RAMHT],
+                          NV_PFIFO_RAMHT_SIZE) + 12);
+}
 
 static RAMHTEntry ramht_lookup(NV2AState *d, uint32_t handle)
 {


### PR DESCRIPTION
In investigating #324 I found that it'd be useful to understand which `ramin` context objects are involved in blitting, so I added an additional window to the debug menu to visualize the entries in the nv2a `ramht` table.

![Screen Shot 2021-11-22 at 19 01 11](https://user-images.githubusercontent.com/448413/142965513-37007ef1-1fc1-4da4-8a07-1f46e904ad0d.png)
