### PR TITLE
nv2a: Don't manually set NV_PFB_CFG0 reg

### DIFF
--- a/hw/xbox/nv2a/pfb.c
+++ b/hw/xbox/nv2a/pfb.c
@@ -27,10 +27,6 @@ uint64_t pfb_read(void *opaque, hwaddr addr, unsigned int size)
 
     uint64_t r = 0;
     switch (addr) {
-    case NV_PFB_CFG0:
-        /* 3-4 memory partitions. The debug bios checks this. */
-        r = 3;
-        break;
     case NV_PFB_CSTATUS:
         r = memory_region_size(d->vram);
         break;


### PR DESCRIPTION
Looking through XBlast I found some stuff that plays with some regs in nv2a.

<https://github.com/einsteinx2/lpcmod_os/blob/b2b9fbb4dd43216acc936bee250029dee2492376/menu/actions/ToolsMenuActions.c#L130>

In xemu we seem to manually set this. However if we look at the xcodes with xdecode (thanks Ernegien), these are actually being set in the xcode stage, I think.

```
xc_mem_write 0x0F100200, 0x03070103 ; same numbers at the correct base according, setting 128MB limit?
xc_mem_write 0x0F100204, 0x11448000 ; 

// directly after memtest it writes this
xc_mem_write 0x0F100200, 0x03070003 ; the 64MB versions of above?
xc_mem_write 0x0F100204, 0x11338000 ; 
```

Looking at the memory locations after boot we see `0xFD000000 + 0x100204` set properly and `0xFD000000 + 0x100200` having a hardcode of `0x03`.

Removing the hardcode, *something* sets this properly.

I don't know if anything even checks this, although the comment on it claims debug kernels do but I can't confirm.

