### PR TITLE
Allow to overwrite version with environment variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
       run: |
         pushd src
         echo -e "\
-        xemu (1:$(cat XEMU_VERSION)-0) unstable; urgency=medium\n\
+        xemu (1:$(cat XEMU_VERSION | cut -c2-)-0) unstable; urgency=medium\n\
           Built from $(cat XEMU_VERSION)\n\
          -- Matt Borgerson <contact@mborgerson.com>  $(date -R)" > debian/changelog
         popd
@@ -333,7 +333,7 @@ jobs:
       run: |
         pushd src
         echo -e "\
-        xemu (1:$(cat XEMU_VERSION)-0) unstable; urgency=medium\n\
+        xemu (1:$(cat XEMU_VERSION | cut -c2-)-0) unstable; urgency=medium\n\
           Built from $(cat XEMU_VERSION)\n\
          -- Matt Borgerson <contact@mborgerson.com>  $(date -R)" > debian/changelog
         popd

--- a/scripts/archive-source.sh
+++ b/scripts/archive-source.sh
@@ -76,7 +76,7 @@ done
 
 git rev-parse HEAD 2>/dev/null | tr -d '\n' > XEMU_COMMIT
 git symbolic-ref --short HEAD > XEMU_BRANCH
-git describe --tags --match 'xemu-v*' | cut -c 7- | tr -d '\n' > XEMU_VERSION
+git describe --tags --match 'xemu-v*' | cut -c 6- | tr -d '\n' > XEMU_VERSION
 tar -r --file "$tar_file" XEMU_COMMIT XEMU_BRANCH XEMU_VERSION
 
 exit 0

--- a/scripts/xemu-version.sh
+++ b/scripts/xemu-version.sh
@@ -3,7 +3,7 @@
 set -eu
 
 dir="$1"
-XEMU_DATE=$(date -u)
+: ${XEMU_DATE=$(date -u)}
 XEMU_COMMIT=$( \
   cd "$dir"; \
   if test -e .git; then \

--- a/scripts/xemu-version.sh
+++ b/scripts/xemu-version.sh
@@ -21,13 +21,13 @@ XEMU_BRANCH=$( \
 : ${XEMU_VERSION=$( \
   cd "$dir"; \
   if test -e .git; then \
-    git describe --tags --match 'xemu-v*' | cut -c 7- | tr -d '\n'; \
+    git describe --tags --match 'xemu-v*' | cut -c 6- | tr -d '\n'; \
   elif test -e XEMU_VERSION; then \
     cat XEMU_VERSION; \
   fi)}
 
 get_version_field() {
-  echo ${XEMU_VERSION}-0 | cut -d- -f$1
+  echo ${XEMU_VERSION#v}-0 | cut -d- -f$1
 }
 
 get_version_dot () {

--- a/scripts/xemu-version.sh
+++ b/scripts/xemu-version.sh
@@ -18,13 +18,13 @@ XEMU_BRANCH=$( \
   elif test -e XEMU_BRANCH; then \
     cat XEMU_BRANCH; \
   fi)
-XEMU_VERSION=$( \
+: ${XEMU_VERSION=$( \
   cd "$dir"; \
   if test -e .git; then \
     git describe --tags --match 'xemu-v*' | cut -c 7- | tr -d '\n'; \
   elif test -e XEMU_VERSION; then \
     cat XEMU_VERSION; \
-  fi)
+  fi)}
 
 get_version_field() {
   echo ${XEMU_VERSION}-0 | cut -d- -f$1

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -835,7 +835,7 @@ static void sdl2_display_very_early_init(DisplayOptions *o)
         SDL_GL_CONTEXT_PROFILE_CORE);
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
-    char *title = g_strdup_printf("xemu | v%s"
+    char *title = g_strdup_printf("xemu | %s"
 #if XEMU_DEBUG_BUILD
                                   " Debug"
 #endif


### PR DESCRIPTION
The change is fairly minimal, and allows to easily overwrite `XEMU_VERSION` with environment variables.

It could be done by using the already configured `XEMU_VERSION` file, but for now it won't work because the condition is after the one that checks the `.git` directory.

In the case of Flatpak, it allows us to just define an environment variable instead of adding a custom script, which will then call the build system inside - not ideal.

I have also added the feature for `XEMU_DATE` for those wanting reproducible builds.