### PR TITLE
nv2a: Mark surface buffers dirty on DMA update, Permit limited swizzled<>linear surface migration

### DIFF
--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -149,6 +149,7 @@ typedef struct SurfaceBinding {
 
     GLuint gl_buffer;
 
+    bool cleared;
     int frame_time;
     int draw_time;
     bool draw_dirty;
@@ -368,6 +369,7 @@ typedef struct PGRAPHState {
 
     uint32_t regs[0x2000];
 
+    bool clearing;
     bool waiting_for_nop;
     bool waiting_for_flip;
     bool waiting_for_context_switch;

--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -1186,11 +1186,13 @@ DEF_METHOD(NV097, SET_CONTEXT_DMA_COLOR)
     pgraph_update_surface(d, false, true, true);
 
     pg->dma_color = parameter;
+    pg->surface_color.buffer_dirty = true;
 }
 
 DEF_METHOD(NV097, SET_CONTEXT_DMA_ZETA)
 {
     pg->dma_zeta = parameter;
+    pg->surface_zeta.buffer_dirty = true;
 }
 
 DEF_METHOD(NV097, SET_CONTEXT_DMA_VERTEX_A)


### PR DESCRIPTION
* Fixes https://github.com/mborgerson/xemu/issues/615#issuecomment-1004352207
* Fixes #626 