### PR TITLE
nv2a: Fix handling of NV097_SET_VERTEX_DATA4S_M

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -3099,14 +3099,11 @@ DEF_METHOD(NV097, SET_VERTEX_DATA4S_M)
     int slot = (method - NV097_SET_VERTEX_DATA4S_M) / 4;
     unsigned int part = slot % 2;
     slot /= 2;
-    assert(false); /* FIXME: Untested! */
     VertexAttribute *attribute = &pg->vertex_attributes[slot];
     pgraph_allocate_inline_buffer_vertices(pg, slot);
-    /* FIXME: Is mapping to [-1,+1] correct? */
-    attribute->inline_value[part * 2 + 0] = ((int16_t)(parameter & 0xFFFF)
-                                                 * 2.0 + 1) / 65535.0;
-    attribute->inline_value[part * 2 + 1] = ((int16_t)(parameter >> 16)
-                                                 * 2.0 + 1) / 65535.0;
+
+    attribute->inline_value[part * 2 + 0] = (float)(int16_t)(parameter & 0xFFFF);
+    attribute->inline_value[part * 2 + 1] = (float)(int16_t)(parameter >> 16);
     if ((slot == 0) && (part == 1)) {
         pgraph_finish_inline_buffer_vertex(pg);
     }


### PR DESCRIPTION
Test at https://github.com/abaire/nxdk_pgraph_tests/blob/setvertexdata/tests/set_vertex_data_tests.cpp
Results from HW at https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-SetVertexData

Should fix #367 