### PR TITLE
nv2a: Make nv2a_dprintf toggleable

### DIFF
--- a/hw/xbox/nv2a/debug.c
+++ b/hw/xbox/nv2a/debug.c
@@ -38,6 +38,28 @@ static int32_t renderdoc_capture_frames = 0;
 static bool has_GL_GREMEDY_frame_terminator = false;
 static bool has_GL_KHR_debug = false;
 
+#ifdef DEBUG_NV2A
+#include <stdio.h>
+
+int (*nv2a_log)(const char* format, ...) = printf;
+
+static int nv2a_null_printf(const char* format, ...)
+{
+    return 0;
+}
+
+void nv2a_log_enable(void)
+{
+    nv2a_log = printf;
+}
+
+void nv2a_log_disable(void)
+{
+    nv2a_log = nv2a_null_printf;
+}
+
+#endif // DEBUG_NV2A
+
 void gl_debug_initialize(void)
 {
     has_GL_KHR_debug = glo_check_extension("GL_KHR_debug");
@@ -89,7 +111,7 @@ void gl_debug_message(bool cc, const char *fmt, ...)
 
     glDebugMessageInsert(GL_DEBUG_SOURCE_APPLICATION, GL_DEBUG_TYPE_MARKER,
                          0, GL_DEBUG_SEVERITY_NOTIFICATION, n, buffer);
-    if (cc) {
+    if (cc && nv2a_log != nv2a_null_printf) {
         fwrite(buffer, sizeof(char), n, stdout);
         fputc('\n', stdout);
     }
@@ -170,12 +192,12 @@ void gl_debug_frame_terminator(void)
 #ifdef ENABLE_RENDERDOC
 
 bool nv2a_dbg_renderdoc_available(void) {
-  return rdoc_api != NULL;
+    return rdoc_api != NULL;
 }
 
 void nv2a_dbg_renderdoc_capture_frames(uint32_t num_frames) {
-  renderdoc_capture_frames = num_frames;
+    renderdoc_capture_frames = num_frames;
 }
 #endif // ENABLE_RENDERDOC
 
-#endif
+#endif // DEBUG_NV2A_GL

--- a/hw/xbox/nv2a/debug.h
+++ b/hw/xbox/nv2a/debug.h
@@ -31,7 +31,10 @@
 
 // #define DEBUG_NV2A
 #ifdef DEBUG_NV2A
-# define NV2A_DPRINTF(format, ...)       printf("nv2a: " format, ## __VA_ARGS__)
+extern int (*nv2a_log)(const char* format, ...);
+void nv2a_log_enable(void);
+void nv2a_log_disable(void);
+# define NV2A_DPRINTF(format, ...)       nv2a_log("nv2a: " format, ## __VA_ARGS__)
 #else
 # define NV2A_DPRINTF(format, ...)       do { } while (0)
 #endif

--- a/ui/xemu-hud.cc
+++ b/ui/xemu-hud.cc
@@ -1887,6 +1887,10 @@ public:
 static MonitorWindow monitor_window;
 static DebugApuWindow apu_window;
 static DebugVideoWindow video_window;
+#ifdef DEBUG_NV2A
+static bool nv2a_log_enabled = true;
+static bool nv2a_log_enabled_last_frame = true;
+#endif
 static InputWindow input_window;
 static NetworkWindow network_window;
 static AboutWindow about_window;
@@ -2150,6 +2154,9 @@ static void ShowMainMenu()
             if (nv2a_dbg_renderdoc_available()) {
                 ImGui::MenuItem("RenderDoc: Capture", NULL, &capture_renderdoc_frame);
             }
+#endif
+#ifdef DEBUG_NV2A
+            ImGui::MenuItem("Toggle nv2a logging", NULL, &nv2a_log_enabled);
 #endif
             ImGui::EndMenu();
         }
@@ -2479,6 +2486,16 @@ void xemu_hud_render(void)
     network_window.Draw();
     compatibility_reporter_window.Draw();
     notification_manager.Draw();
+#ifdef DEBUG_NV2A
+    if (nv2a_log_enabled != nv2a_log_enabled_last_frame) {
+        if (nv2a_log_enabled) {
+            nv2a_log_enable();
+        } else {
+            nv2a_log_disable();
+        }
+        nv2a_log_enabled_last_frame = nv2a_log_enabled;
+    }
+#endif
 #if defined(_WIN32)
     update_window.Draw();
 #endif


### PR DESCRIPTION
Halo really does become intolerably slow w/ pgraph logging enabled. Added a trivial toggle in the UI so it can be enabled only when it's actually providing useful data. This is still guarded by the debug flag so it won't have any performance impact in normal builds.