### PR TITLE
nv2a: Improve RenderDoc triggering

### DIFF
--- a/hw/xbox/nv2a/debug.h
+++ b/hw/xbox/nv2a/debug.h
@@ -40,6 +40,9 @@
 // #define DEBUG_NV2A_GL
 #ifdef DEBUG_NV2A_GL
 
+// Improve frame capture boundaries with RenderDoc.
+// #define ENABLE_RENDERDOC
+
 #include <stdbool.h>
 #include "gl/gloffscreen.h"
 
@@ -148,6 +151,11 @@ extern NV2AStats g_nv2a_stats;
 
 const char *nv2a_profile_get_counter_name(unsigned int cnt);
 int nv2a_profile_get_counter_value(unsigned int cnt);
+
+#ifdef ENABLE_RENDERDOC
+bool nv2a_dbg_renderdoc_available(void);
+void nv2a_dbg_renderdoc_capture_frames(uint32_t num_frames);
+#endif
 
 #ifdef __cplusplus
 }

--- a/ui/xemu-hud.cc
+++ b/ui/xemu-hud.cc
@@ -1898,6 +1898,10 @@ static AutoUpdateWindow update_window;
 #endif
 static std::deque<const char *> g_errors;
 
+#ifdef ENABLE_RENDERDOC
+static bool capture_renderdoc_frame = false;
+#endif
+
 class FirstBootWindow
 {
 public:
@@ -2058,6 +2062,12 @@ static void process_keyboard_shortcuts(void)
     if (is_key_pressed(SDL_SCANCODE_GRAVE)) {
         monitor_window.toggle_open();
     }
+
+#ifdef ENABLE_RENDERDOC
+    if (is_key_pressed(SDL_SCANCODE_F10)) {
+        nv2a_dbg_renderdoc_capture_frames(1);
+    }
+#endif
 }
 
 #if defined(__APPLE__)
@@ -2136,6 +2146,11 @@ static void ShowMainMenu()
             ImGui::MenuItem("Monitor", "~", &monitor_window.is_open);
             ImGui::MenuItem("Audio", NULL, &apu_window.is_open);
             ImGui::MenuItem("Video", NULL, &video_window.is_open);
+#ifdef ENABLE_RENDERDOC
+            if (nv2a_dbg_renderdoc_available()) {
+                ImGui::MenuItem("RenderDoc: Capture", NULL, &capture_renderdoc_frame);
+            }
+#endif
             ImGui::EndMenu();
         }
 
@@ -2412,6 +2427,13 @@ void xemu_hud_render(void)
 
     ImGui::NewFrame();
     process_keyboard_shortcuts();
+
+#ifdef ENABLE_RENDERDOC
+    if (capture_renderdoc_frame) {
+        nv2a_dbg_renderdoc_capture_frames(1);
+        capture_renderdoc_frame = false;
+    }
+#endif
 
     bool show_main_menu = true;
 


### PR DESCRIPTION
Adds improved frame boundary detection for RenderDoc on Linux. 

I don't develop on Windows so I haven't implemented there, but it should be straightforward (https://renderdoc.org/docs/in_application_api.html just the `GetModuleHandleA` bit that needs to be brought in).

RenderDoc isn't actually supported on macOS so I haven't actually tried to test there yet.