### PR TITLE
nv2a: Fix slots for vertex attribute setters

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -2241,47 +2241,47 @@ DEF_METHOD_INC(NV097, SET_VERTEX4F)
     }
 }
 
-#define SET_VERTEX_ATTRIBUTE(command, attr_index, num_params) \
-    int slot = (method - (command)) / (num_params); \
-    VertexAttribute *attribute = &pg->vertex_attributes[(attr_index)]; \
-    pgraph_allocate_inline_buffer_vertices(pg, (attr_index)); \
-    attribute->inline_value[slot] = *(float*)&parameter
+#define SET_VERTEX_ATTRIBUTE(command, attr_index) \
+    do {                                                                   \
+        int slot = (method - (command)) / 4;                               \
+        VertexAttribute *attribute = &pg->vertex_attributes[(attr_index)]; \
+        pgraph_allocate_inline_buffer_vertices(pg, (attr_index));          \
+        attribute->inline_value[slot] = *(float*)&parameter;               \
+    } while (0)
 
 DEF_METHOD_INC(NV097, SET_NORMAL)
 {
-    SET_VERTEX_ATTRIBUTE(NV097_SET_NORMAL, NV2A_VERTEX_ATTR_NORMAL, 3);
+    SET_VERTEX_ATTRIBUTE(NV097_SET_NORMAL, NV2A_VERTEX_ATTR_NORMAL);
 }
 
 DEF_METHOD_INC(NV097, SET_DIFFUSE_COLOR4F)
 {
-    SET_VERTEX_ATTRIBUTE(NV097_SET_DIFFUSE_COLOR4F, NV2A_VERTEX_ATTR_DIFFUSE,
-                         4);
+    SET_VERTEX_ATTRIBUTE(NV097_SET_DIFFUSE_COLOR4F, NV2A_VERTEX_ATTR_DIFFUSE);
 }
 
 DEF_METHOD_INC(NV097, SET_SPECULAR_COLOR4F)
 {
-    SET_VERTEX_ATTRIBUTE(NV097_SET_SPECULAR_COLOR4F, NV2A_VERTEX_ATTR_SPECULAR,
-                         4);
+    SET_VERTEX_ATTRIBUTE(NV097_SET_SPECULAR_COLOR4F, NV2A_VERTEX_ATTR_SPECULAR);
 }
 
 DEF_METHOD_INC(NV097, SET_TEXCOORD0)
 {
-    SET_VERTEX_ATTRIBUTE(NV097_SET_TEXCOORD0, NV2A_VERTEX_ATTR_TEXTURE0, 2);
+    SET_VERTEX_ATTRIBUTE(NV097_SET_TEXCOORD0, NV2A_VERTEX_ATTR_TEXTURE0);
 }
 
 DEF_METHOD_INC(NV097, SET_TEXCOORD1)
 {
-    SET_VERTEX_ATTRIBUTE(NV097_SET_TEXCOORD1, NV2A_VERTEX_ATTR_TEXTURE1, 2);
+    SET_VERTEX_ATTRIBUTE(NV097_SET_TEXCOORD1, NV2A_VERTEX_ATTR_TEXTURE1);
 }
 
 DEF_METHOD_INC(NV097, SET_TEXCOORD2)
 {
-    SET_VERTEX_ATTRIBUTE(NV097_SET_TEXCOORD2, NV2A_VERTEX_ATTR_TEXTURE2, 2);
+    SET_VERTEX_ATTRIBUTE(NV097_SET_TEXCOORD2, NV2A_VERTEX_ATTR_TEXTURE2);
 }
 
 DEF_METHOD_INC(NV097, SET_TEXCOORD3)
 {
-    SET_VERTEX_ATTRIBUTE(NV097_SET_TEXCOORD3, NV2A_VERTEX_ATTR_TEXTURE3, 2);
+    SET_VERTEX_ATTRIBUTE(NV097_SET_TEXCOORD3, NV2A_VERTEX_ATTR_TEXTURE3);
 }
 
 #undef SET_VERTEX_ATTRIBUTE


### PR DESCRIPTION
The values my test was using were insufficient to detect that some of the attributes were not being set correctly in the PR for #671.

The [new testbed that will cover the integer setters](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/attribute_explicit_setter_tests.cpp) has a better selection, this fixes the setters from #672 .

