### PR TITLE
nv2a: Test Append_skinning_code

### DIFF
--- a/hw/xbox/nv2a/shaders.c
+++ b/hw/xbox/nv2a/shaders.c
@@ -273,7 +273,6 @@ static void append_skinning_code(MString* str, bool mix,
                 mstring_append_fmt(str, "%s += (%s * %s%d).%s * weight.%c;\n",
                                    output, input, matrix, i, swizzle, c);
             }
-            assert(false); /* FIXME: Untested */
         }
     }
 }


### PR DESCRIPTION
Removed the untested assert and 2 games got Ingame/Playable.
Championship Bowling
![Screenshot_2022-01-17_203430](https://user-images.githubusercontent.com/76413188/151450343-006063eb-e1c4-46dc-aec6-8afff1007904.png)

Magi Death Fight!
![Screenshot 2022-01-27 155514](https://user-images.githubusercontent.com/76413188/151450365-0e87ef2a-d9b9-4af6-9540-33e7cfe7aa14.png)

Fixes #331