### PR TITLE
nv2a: Fix swizzle_box for volumetric textures

### DIFF
--- a/hw/xbox/nv2a/swizzle.c
+++ b/hw/xbox/nv2a/swizzle.c
@@ -102,9 +102,9 @@ void swizzle_box(
             for (x = 0; x < width; x++) {
                 const uint8_t *src = src_buf
                                          + y * row_pitch + x * bytes_per_pixel;
-                uint8_t *dst = dst_buf + get_swizzled_offset(x, y, 0,
-                                                             mask_x, mask_y, 0,
-                                                             bytes_per_pixel);
+                uint8_t *dst = dst_buf +
+                    get_swizzled_offset(x, y, z, mask_x, mask_y, mask_z,
+                                        bytes_per_pixel);
                 memcpy(dst, src, bytes_per_pixel);
             }
         }


### PR DESCRIPTION
I don't think xemu actually uses this method in a way that exercises the bug, but anybody leveraging this to create volumetric testers in their xbe code will end up with corrupted results for slices beyond the first (and the first slice will be the last source slice).

I'm [currently leveraging this code](https://github.com/abaire/nxdk_pgraph_tests/blob/volumetric_texture/src/tests/volume_texture_tests.cpp) to create a repro case for #567 and can confirm that with this change the resultant (non-palettized) volumetric textures display correctly in xemu and on hw.