### PR TITLE
nv2a: Handle LSB mux flag

### DIFF
--- a/hw/xbox/nv2a/psh.c
+++ b/hw/xbox/nv2a/psh.c
@@ -469,8 +469,13 @@ static void add_stage_code(struct PixelShader *ps,
     if (output.muxsum_op == PS_COMBINEROUTPUT_AB_CD_SUM) {
         sum = mstring_from_fmt("(%s + %s)", mstring_get_str(ab), mstring_get_str(cd));
     } else {
-        sum = mstring_from_fmt("((r0.a >= 0.5) ? %s(%s) : %s(%s))",
-                               caster, mstring_get_str(cd), caster, mstring_get_str(ab));
+        if (ps->flags & PS_COMBINERCOUNT_MUX_MSB) {
+            sum = mstring_from_fmt("((r0.a >= 0.5) ? %s(%s) : %s(%s))",
+                                   caster, mstring_get_str(cd), caster, mstring_get_str(ab));
+        } else {
+            sum = mstring_from_fmt("(((uint(r0.a * 255.0) & 1u) == 1u) ? %s(%s) : %s(%s))",
+                                   caster, mstring_get_str(cd), caster, mstring_get_str(ab));
+        }
     }
 
     MString *sum_mapping = get_output(sum, output.mapping);


### PR DESCRIPTION
Fixes #716 

May fix some games as well; I'm not sure how often the muxer mode is set to LSB, 

In Halo I see it used in the opening cutscene for The Silent Cartographer, but it's rendering something extremely far in the distance so I didn't notice any effect (it looks like it uses a shield texture or something)..