### PR TITLE
nv2a: adjust display resolution in 1080i mode

### DIFF
--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -619,6 +619,10 @@
 #define NV_PCRTC_RASTER                                  0x00000808
 
 
+#define NV_PRMCIO_INTERLACE_MODE                         0x00000039
+#   define NV_PRMCIO_INTERLACE_MODE_DISABLED                    0xff
+
+
 #define NV_PVIDEO_INTR                                   0x00000100
 #   define NV_PVIDEO_INTR_BUFFER_0                              (1 << 0)
 #   define NV_PVIDEO_INTR_BUFFER_1                              (1 << 4)

--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -4907,6 +4907,11 @@ static void pgraph_render_display(NV2AState *d, SurfaceBinding *surface)
     d->vga.get_offsets(&d->vga, &pline_offset, &pstart_addr, &pline_compare);
     int line_offset = surface->pitch / pline_offset;
 
+    /* Adjust viewport height for interlaced mode, used only in 1080i */
+    if (d->vga.cr[NV_PRMCIO_INTERLACE_MODE] != NV_PRMCIO_INTERLACE_MODE_DISABLED) {
+        height *= 2;
+    }
+
     pgraph_apply_scaling_factor(pg, &width, &height);
 
     glBindFramebuffer(GL_FRAMEBUFFER, d->pgraph.disp_rndr.fbo);


### PR DESCRIPTION
Detects 1080i mode by resolution and sets the height to 1080 in its place. This code was a suggestion made by @abaire to fix XBMC issues at 1080i that @LoveMHz was experiencing.

I've looked into `vga_get_resolution` (and `vga_ioport_write` where the relevant registers are set) to see if the height can be set to 1080 when the resolution is set by the guest program. The height as stored by the vga registers is capped at 1024, however, making this infeasible.

Looking at the datasheet for the Conexant encoder, specifically table E-2 in the appendix, it's possible to determine the video mode from the encoder registers. However, this approach seems a bit excessive, and checking the resolution in pgraph is functionally identical. Supporting Xcalibur using this method will require reverse engineering as well.

Resolves #73 . Tested on UnleashX running at 1080i.