### PR TITLE
nv2a: Fix spelling error in renderdoc config

### DIFF
--- a/ui/meson.build
+++ b/ui/meson.build
@@ -63,7 +63,7 @@ xemu_ss.add(when: 'CONFIG_LINUX', if_true: [xemu_gtk, files('xemu-os-utils-linux
 xemu_ss.add(when: 'CONFIG_WIN32', if_true: files('xemu-os-utils-windows.c', 'noc_file_dialog_win32.c'))
 xemu_ss.add(when: 'CONFIG_DARWIN', if_true: files('xemu-os-utils-macos.m', 'noc_file_dialog_macos.m'))
 
-xemu_ss.add(whend: 'CONFIG_RENDERDOC', if_true: [libdl])
+xemu_ss.add(when: 'CONFIG_RENDERDOC', if_true: [libdl])
 
 softmmu_ss.add_all(xemu_ss)
 


### PR DESCRIPTION
Fixes issue @xDShot caught post-merge in https://github.com/mborgerson/xemu/commit/f3c7a3afd1afdeb2722fb90218a27b897d6bbbcd#comments