### PR TITLE
nv2a: Ignore color/depth mask in CLEAR_SURFACE

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -5918,9 +5918,9 @@ static void pgraph_update_surface(NV2AState *d, bool upload,
     pg->surface_shape.z_format = GET_MASK(pg->regs[NV_PGRAPH_SETUPRASTER],
                                           NV_PGRAPH_SETUPRASTER_Z_FORMAT);
 
-    /* FIXME: Does this apply to CLEARs too? */
-    color_write = color_write && pgraph_color_write_enabled(pg);
-    zeta_write = zeta_write && pgraph_zeta_write_enabled(pg);
+    color_write = color_write &&
+            (pg->clearing || pgraph_color_write_enabled(pg));
+    zeta_write = zeta_write && (pg->clearing || pgraph_zeta_write_enabled(pg));
 
     if (upload) {
         bool fb_dirty = pgraph_framebuffer_dirty(pg);


### PR DESCRIPTION
Fixes #730 and matches observed HW behavior where NV097_SET_COLOR_MASK/NV097_SET_DEPTH_MASK masking is not respected by `CLEAR_SURFACE` call (where masking is set via a parameter).

[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/clear_tests.cpp)
[Golden results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Clear)