### PR TITLE
nv2a/mcpx: fix freezing on loadvm failure

### DIFF
--- a/hw/xbox/mcpx/apu.c
+++ b/hw/xbox/mcpx/apu.c
@@ -2324,8 +2324,6 @@ static void mcpx_apu_vm_state_change(void *opaque, bool running, RunState state)
 
     if (state == RUN_STATE_SAVE_VM) {
         qemu_mutex_lock(&d->lock);
-    } else if (state == RUN_STATE_RESTORE_VM) {
-        mcpx_apu_reset(d);
     }
 }
 
@@ -2340,6 +2338,7 @@ static int mcpx_apu_post_save(void *opaque)
 static int mcpx_apu_pre_load(void *opaque)
 {
     MCPXAPUState *d = opaque;
+    mcpx_apu_reset(d);
     qemu_mutex_lock(&d->lock);
     return 0;
 }

--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -375,13 +375,16 @@ static void nv2a_vm_state_change(void *opaque, bool running, RunState state)
         nv2a_lock_fifo(d);
         qatomic_set(&d->pfifo.halt, true);
         nv2a_unlock_fifo(d);
+    } else if (state == RUN_STATE_RUNNING) {
+        nv2a_lock_fifo(d);
+        qatomic_set(&d->pfifo.halt, false);
+        nv2a_unlock_fifo(d);
     }
 }
 
 static int nv2a_post_save(void *opaque)
 {
     NV2AState *d = opaque;
-    qatomic_set(&d->pfifo.halt, false);
     nv2a_unlock_fifo(d);
     return 0;
 }
@@ -396,7 +399,6 @@ static int nv2a_pre_load(void *opaque)
 static int nv2a_post_load(void *opaque, int version_id)
 {
     NV2AState *d = opaque;
-    qatomic_set(&d->pfifo.halt, false);
     qatomic_set(&d->pgraph.flush_pending, true);
     nv2a_unlock_fifo(d);
     return 0;


### PR DESCRIPTION
Resolves #741 

Introduces a flag in the nv2a state that tracks whether we are in the process of loading a VM or not. This flag is set to true on state change to `RUN_STATE_RESTORE_VM`, and false once the load completes. If the state is changed to running with this flag enabled, then the pfifo is resumed, as the load must have failed.

In addition, move the MCPX APU reset to the pre-load hook. On failed loads, the APU will no longer be reset.

With the behavior of this PR, the emulator will be paused after a failed load. Changing this to allow the emulator to continue instead is trivial.