### PR TITLE
Fix serial-based Xbox kernel debugging on Windows

### DIFF
--- a/chardev/char-win.c
+++ b/chardev/char-win.c
@@ -110,7 +110,8 @@ int win_chr_serial_init(Chardev *chr, const char *filename, Error **errp)
     size = sizeof(COMMCONFIG);
     GetDefaultCommConfig(filename, &comcfg, &size);
     comcfg.dcb.DCBlength = sizeof(DCB);
-    CommConfigDialog(filename, NULL, &comcfg);
+    comcfg.dcb.BaudRate = CBR_115200;
+    //CommConfigDialog(filename, NULL, &comcfg);
 
     if (!SetCommState(s->file, &comcfg.dcb)) {
         error_setg(errp, "Failed SetCommState");

--- a/chardev/char-win.c
+++ b/chardev/char-win.c
@@ -111,7 +111,6 @@ int win_chr_serial_init(Chardev *chr, const char *filename, Error **errp)
     GetDefaultCommConfig(filename, &comcfg, &size);
     comcfg.dcb.DCBlength = sizeof(DCB);
     comcfg.dcb.BaudRate = CBR_115200;
-    //CommConfigDialog(filename, NULL, &comcfg);
 
     if (!SetCommState(s->file, &comcfg.dcb)) {
         error_setg(errp, "Failed SetCommState");

--- a/util/main-loop.c
+++ b/util/main-loop.c
@@ -490,16 +490,6 @@ static int os_host_main_loop_wait(int64_t timeout)
 
     g_main_context_acquire(context);
 
-    /* XXX: need to suppress polling by better using win32 events */
-    ret = 0;
-    for (pe = first_polling_entry; pe != NULL; pe = pe->next) {
-        ret |= pe->func(pe->opaque);
-    }
-    if (ret != 0) {
-        g_main_context_release(context);
-        return ret;
-    }
-
     FD_ZERO(&rfds);
     FD_ZERO(&wfds);
     FD_ZERO(&xfds);
@@ -560,6 +550,16 @@ static int os_host_main_loop_wait(int64_t timeout)
 
     if (g_main_context_check(context, max_priority, poll_fds, n_poll_fds)) {
         g_main_context_dispatch(context);
+    }
+
+    /* XXX: need to suppress polling by better using win32 events */
+    ret = 0;
+    for (pe = first_polling_entry; pe != NULL; pe = pe->next) {
+        ret |= pe->func(pe->opaque);
+    }
+    if (ret != 0) {
+        g_main_context_release(context);
+        return ret;
     }
 
     g_main_context_release(context);

--- a/util/main-loop.c
+++ b/util/main-loop.c
@@ -557,12 +557,12 @@ static int os_host_main_loop_wait(int64_t timeout)
     for (pe = first_polling_entry; pe != NULL; pe = pe->next) {
         ret |= pe->func(pe->opaque);
     }
+    
+    g_main_context_release(context);
+    
     if (ret != 0) {
-        g_main_context_release(context);
         return ret;
     }
-
-    g_main_context_release(context);
 
     return select_ret || g_poll_ret;
 }


### PR DESCRIPTION
This PR contains two commits.

* The first commit explicitly 'fixes' the QEMU lockup that occurs on Windows when attempting to connect to the serial port for kernel debugging with WinDbg. (Issue #498) 
* The second commit sets default parameters for the connection so that you don't have to click/close the COM config dialog every launch (it gets annoying, I promise).

Without going into excessive detail, the crux of the issue is that QEMU does not provide ample opportunity for the emulated system (in this case, the Xbox kernel) to process data received on the serial port.

When the 'received data' buffer (which is LITERALLY 1 byte) is 'full' and QEMU sees that there is more data available on the COM port (almost a certainty!) it will return early from the main QEMU / emulation loop -- meaning the Xbox kernel will never execute, thus the single received byte is never processed. This is our impasse.

While the fix is technically probably not the 'correct' long-term solution for QEMU at large (note their XXX comment, a proper set of async polling/buffering infrastructure should be built out instead), it works for our purposes.

I have successfully been using WinDbg and WinDbg Preview (requests much more data, so can be a lot slower) using these fixes for the past month or so.

![xemu](https://user-images.githubusercontent.com/9522648/156057401-d188da57-d864-46b2-8a70-6859314fda30.gif)

