### PR TITLE
xemu: Add wireframe mode shortcuts

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -34,6 +34,8 @@ GloContext *g_nv2a_context_display;
 
 NV2AStats g_nv2a_stats;
 
+extern bool *wireframe;
+
 static void nv2a_profile_increment(void)
 {
     int64_t now = qemu_clock_get_us(QEMU_CLOCK_REALTIME);
@@ -4634,7 +4636,11 @@ static void pgraph_render_surface_to(NV2AState *d, SurfaceBinding *surface,
     glDisable(GL_STENCIL_TEST);
     glDisable(GL_CULL_FACE);
     glDisable(GL_DEPTH_TEST);
-    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    if (*wireframe) {
+        glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+    } else {
+        glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    }
     glClearColor(0.0f, 0.0f, 1.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT);
     glDrawArrays(GL_TRIANGLES, 0, 3);

--- a/ui/xemu-hud.cc
+++ b/ui/xemu-hud.cc
@@ -74,6 +74,7 @@ ImFont *g_fixed_width_font;
 float g_main_menu_height;
 float g_ui_scale = 1.0;
 bool g_trigger_style_update = true;
+bool *wireframe = (bool *)malloc(sizeof(bool));
 
 class NotificationManager
 {
@@ -2059,6 +2060,10 @@ static void process_keyboard_shortcuts(void)
         action_shutdown();
     }
 
+    if (is_shortcut_key_pressed(SDL_SCANCODE_F5)) {
+        *wireframe = !*wireframe;
+    }
+
     if (is_key_pressed(SDL_SCANCODE_GRAVE)) {
         monitor_window.toggle_open();
     }
@@ -2307,6 +2312,8 @@ void xemu_hud_init(SDL_Window* window, void* sdl_gl_context)
         update_window.check_for_updates_and_prompt_if_available();
     }
 #endif
+
+    *wireframe = false;
 }
 
 void xemu_hud_cleanup(void)


### PR DESCRIPTION
Adds support to use CTRL+F5 to enable wireframe.

Should probably be edited to invalidate all of the surfaces. Also doesn't seem to work on all surfaces.