### PR TITLE
xbox: Add a dummy device in place of memory controller

### DIFF
--- a/hw/xbox/xbox.c
+++ b/hw/xbox/xbox.c
@@ -353,6 +353,9 @@ void xbox_init_common(MachineState *machine,
     /* GPU! */
     nv2a_init(agp_bus, PCI_DEVFN(0, 0), ram_memory);
 
+    /* FIXME: Stub the memory controller */
+    pci_create_simple(pci_bus, PCI_DEVFN(0, 3), "pci-testdev");
+
     if (pci_bus_out) {
         *pci_bus_out = pci_bus;
     }


### PR DESCRIPTION
This is required for the kernel to correctly calculate clock speeds. This should be fixed in a later commit to add the correct device.

See https://github.com/mborgerson/xemu/issues/638 for missing devices.

Before:
![before](https://user-images.githubusercontent.com/858612/156872559-fe84331c-9069-47fe-9c51-c7e0c99a4409.png)

After:
![after](https://user-images.githubusercontent.com/858612/156872562-75478c19-636b-43db-a86f-ce0bef52353a.png)

Assumption is that the kernel was trying to read the FSB register that's present at 0x6C on this device and improperly calculating clocks based on the fail response of `0xFFFFFFFF`. I don't know if this has any real implications, if the kernel is doing it's own time keeping based off of these numbers, etc.
