### PR TITLE
ui: Add snapshot management UI

### DIFF
--- a/block.c
+++ b/block.c
@@ -2599,6 +2599,12 @@ static void bdrv_default_perms_for_storage(BlockDriverState *bs, BdrvChild *c,
         shared |= BLK_PERM_WRITE | BLK_PERM_RESIZE;
     }
 
+#ifdef XBOX
+    if (bs->open_flags & BDRV_O_RO_WRITE_SHARE) {
+        shared |= BLK_PERM_WRITE | BLK_PERM_RESIZE;
+    }
+#endif
+
     *nperm = perm;
     *nshared = shared;
 }

--- a/block/file-win32.c
+++ b/block/file-win32.c
@@ -36,6 +36,7 @@
 #include "qapi/qmp/qstring.h"
 #include <windows.h>
 #include <winioctl.h>
+#include <assert.h>
 
 #define FTYPE_FILE 0
 #define FTYPE_CD     1
@@ -341,6 +342,9 @@ static int raw_open(BlockDriverState *bs, QDict *options, int flags,
     bool use_aio;
     OnOffAuto locking;
     int ret;
+#ifdef XBOX
+    int sharing_flags;
+#endif
 
     s->type = FTYPE_FILE;
 
@@ -396,9 +400,21 @@ static int raw_open(BlockDriverState *bs, QDict *options, int flags,
     if (!filename) {
         goto fail;
     }
+
+#ifdef XBOX
+    sharing_flags = FILE_SHARE_READ;
+    if (flags & BDRV_O_RO_WRITE_SHARE) {
+        assert(access_flags == GENERIC_READ);
+        sharing_flags = FILE_SHARE_READ | FILE_SHARE_WRITE;
+    }
+    s->hfile = CreateFileW(wfilename, access_flags,
+                          sharing_flags, NULL,
+                          OPEN_EXISTING, overlapped, NULL);
+#else
     s->hfile = CreateFileW(wfilename, access_flags,
                           FILE_SHARE_READ, NULL,
                           OPEN_EXISTING, overlapped, NULL);
+#endif
     g_free(wfilename);
     if (s->hfile == INVALID_HANDLE_VALUE) {
         int err = GetLastError();

--- a/config_spec.yml
+++ b/config_spec.yml
@@ -11,6 +11,13 @@ general:
   # throttle_io: bool
   last_viewed_menu_index: integer
   user_token: string
+  snapshots:
+    shortcuts:
+      f5: string
+      f6: string
+      f7: string
+      f8: string
+    filter_current_game: bool
 
 input:
   bindings:

--- a/include/block/block.h
+++ b/include/block/block.h
@@ -123,6 +123,10 @@ typedef struct HDGeometry {
 #define BDRV_O_AUTO_RDONLY 0x20000 /* degrade to read-only if opening read-write fails */
 #define BDRV_O_IO_URING    0x40000 /* use io_uring instead of the thread pool */
 
+#ifdef XBOX
+#define BDRV_O_RO_WRITE_SHARE 0x80000 /* allow the file to open RO alongside an existing RW handle */
+#endif
+
 #define BDRV_O_CACHE_MASK  (BDRV_O_NOCACHE | BDRV_O_NO_FLUSH)
 
 

--- a/ui/meson.build
+++ b/ui/meson.build
@@ -26,6 +26,8 @@ xemu_ss.add(files(
 
   'xemu.c',
   'xemu-data.c',
+  'xemu-snapshots.c',
+  'xemu-thumbnail.cc',
 ))
 
 subdir('xui')

--- a/ui/thirdparty/meson.build
+++ b/ui/thirdparty/meson.build
@@ -5,6 +5,7 @@ imgui_files = files(
   'imgui/imgui_widgets.cpp',
   'imgui/backends/imgui_impl_sdl.cpp',
   'imgui/backends/imgui_impl_opengl3.cpp',
+  'imgui/misc/cpp/imgui_stdlib.cpp',
   #'imgui/imgui_demo.cpp',
 )
 

--- a/ui/xemu-settings.h
+++ b/ui/xemu-settings.h
@@ -26,6 +26,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,8 +59,9 @@ void xemu_settings_save(void);
 
 static inline void xemu_settings_set_string(const char **str, const char *new_str)
 {
-	free((char*)*str);
-	*str = strdup(new_str);
+    assert(new_str);
+    free((char*)*str);
+    *str = strdup(new_str);
 }
 
 void add_net_nat_forward_ports(int host, int guest, CONFIG_NET_NAT_FORWARD_PORTS_PROTOCOL protocol);

--- a/ui/xemu-snapshots.c
+++ b/ui/xemu-snapshots.c
@@ -1,0 +1,319 @@
+/*
+ * xemu User Interface
+ *
+ * Copyright (C) 2020-2022 Matt Borgerson
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "xemu-snapshots.h"
+#include "xemu-settings.h"
+#include "xemu-xbe.h"
+
+#include <SDL2/SDL.h>
+#include <epoxy/gl.h>
+
+#include "block/aio.h"
+#include "block/block_int.h"
+#include "block/qapi.h"
+#include "block/qdict.h"
+#include "migration/qemu-file.h"
+#include "migration/snapshot.h"
+#include "qapi/error.h"
+#include "sysemu/runstate.h"
+#include "qemu-common.h"
+
+#include "ui/console.h"
+#include "ui/input.h"
+
+static QEMUSnapshotInfo *xemu_snapshots_metadata = NULL;
+static XemuSnapshotData *xemu_snapshots_extra_data = NULL;
+static int xemu_snapshots_len = 0;
+static bool xemu_snapshots_dirty = true;
+
+const char **g_snapshot_shortcut_index_key_map[] = {
+    &g_config.general.snapshots.shortcuts.f5,
+    &g_config.general.snapshots.shortcuts.f6,
+    &g_config.general.snapshots.shortcuts.f7,
+    &g_config.general.snapshots.shortcuts.f8,
+};
+
+static bool xemu_snapshots_load_thumbnail(BlockDriverState *bs_ro,
+                                          XemuSnapshotData *data,
+                                          int64_t *offset)
+{
+    int res = bdrv_load_vmstate(bs_ro, (uint8_t *)&data->thumbnail, *offset,
+                                sizeof(TextureBuffer) -
+                                    sizeof(data->thumbnail.buffer));
+    if (res != sizeof(TextureBuffer) - sizeof(data->thumbnail.buffer))
+        return false;
+    *offset += res;
+
+    data->thumbnail.buffer = g_malloc(data->thumbnail.size);
+
+    res = bdrv_load_vmstate(bs_ro, (uint8_t *)data->thumbnail.buffer, *offset,
+                            data->thumbnail.size);
+    if (res != data->thumbnail.size) {
+        return false;
+    }
+    *offset += res;
+
+    return true;
+}
+
+static void xemu_snapshots_load_data(BlockDriverState *bs_ro,
+                                     QEMUSnapshotInfo *info,
+                                     XemuSnapshotData *data, Error **err)
+{
+    int res;
+    XemuSnapshotHeader header;
+    int64_t offset = 0;
+
+    data->xbe_title_present = false;
+    data->thumbnail_present = false;
+    res = bdrv_snapshot_load_tmp(bs_ro, info->id_str, info->name, err);
+    if (res < 0)
+        return;
+
+    res = bdrv_load_vmstate(bs_ro, (uint8_t *)&header, offset, sizeof(header));
+    if (res != sizeof(header))
+        goto error;
+    offset += res;
+
+    if (header.magic != XEMU_SNAPSHOT_DATA_MAGIC)
+        goto error;
+
+    res = bdrv_load_vmstate(bs_ro, (uint8_t *)&data->xbe_title_len, offset,
+                            sizeof(data->xbe_title_len));
+    if (res != sizeof(data->xbe_title_len))
+        goto error;
+    offset += res;
+
+    data->xbe_title = (char *)g_malloc(data->xbe_title_len);
+
+    res = bdrv_load_vmstate(bs_ro, (uint8_t *)data->xbe_title, offset,
+                            data->xbe_title_len);
+    if (res != data->xbe_title_len)
+        goto error;
+    offset += res;
+
+    data->xbe_title_present = (offset <= sizeof(header) + header.size);
+
+    if (offset == sizeof(header) + header.size)
+        return;
+
+    if (!xemu_snapshots_load_thumbnail(bs_ro, data, &offset)) {
+        goto error;
+    }
+
+    data->thumbnail_present = (offset <= sizeof(header) + header.size);
+
+    if (data->thumbnail_present) {
+        glGenTextures(1, &data->gl_thumbnail);
+        xemu_snapshots_render_thumbnail(data->gl_thumbnail, &data->thumbnail);
+    }
+    return;
+
+error:
+    g_free(data->xbe_title);
+    data->xbe_title_present = false;
+
+    g_free(data->thumbnail.buffer);
+    data->thumbnail_present = false;
+}
+
+static void xemu_snapshots_all_load_data(QEMUSnapshotInfo **info,
+                                         XemuSnapshotData **data,
+                                         int snapshots_len, Error **err)
+{
+    BlockDriverState *bs_ro;
+    QDict *opts = qdict_new();
+
+    assert(info && data);
+
+    if (*data) {
+        for (int i = 0; i < xemu_snapshots_len; ++i) {
+            if ((*data)[i].xbe_title_present) {
+                g_free((*data)[i].xbe_title);
+            }
+
+            if ((*data)[i].thumbnail_present) {
+                g_free((*data)[i].thumbnail.buffer);
+                glDeleteTextures(1, &((*data)[i].gl_thumbnail));
+            }
+        }
+        g_free(*data);
+    }
+
+    *data =
+        (XemuSnapshotData *)g_malloc(sizeof(XemuSnapshotData) * snapshots_len);
+    memset(*data, 0, sizeof(XemuSnapshotData) * snapshots_len);
+
+    qdict_put_bool(opts, BDRV_OPT_READ_ONLY, true);
+    bs_ro = bdrv_open(g_config.sys.files.hdd_path, NULL, opts,
+                      BDRV_O_RO_WRITE_SHARE | BDRV_O_AUTO_RDONLY, err);
+    if (!bs_ro) {
+        return;
+    }
+
+    for (int i = 0; i < snapshots_len; ++i) {
+        xemu_snapshots_load_data(bs_ro, (*info) + i, (*data) + i, err);
+        if (*err) {
+            break;
+        }
+    }
+
+    bdrv_flush(bs_ro);
+    bdrv_drain(bs_ro);
+    bdrv_unref(bs_ro);
+    assert(bs_ro->refcnt == 0);
+    if (!(*err))
+        xemu_snapshots_dirty = false;
+}
+
+int xemu_snapshots_list(QEMUSnapshotInfo **info, XemuSnapshotData **extra_data,
+                        Error **err)
+{
+    BlockDriverState *bs;
+    AioContext *aio_context;
+    int snapshots_len;
+    assert(err);
+
+    if (!xemu_snapshots_dirty && xemu_snapshots_extra_data &&
+        xemu_snapshots_metadata) {
+        goto done;
+    }
+
+    if (xemu_snapshots_metadata)
+        g_free(xemu_snapshots_metadata);
+
+    bs = bdrv_all_find_vmstate_bs(NULL, false, NULL, err);
+    if (!bs) {
+        return -1;
+    }
+
+    aio_context = bdrv_get_aio_context(bs);
+
+    aio_context_acquire(aio_context);
+    snapshots_len = bdrv_snapshot_list(bs, &xemu_snapshots_metadata);
+    aio_context_release(aio_context);
+    xemu_snapshots_all_load_data(&xemu_snapshots_metadata,
+                                 &xemu_snapshots_extra_data, snapshots_len,
+                                 err);
+    if (*err) {
+        return -1;
+    }
+
+    xemu_snapshots_len = snapshots_len;
+
+done:
+    if (info) {
+        *info = xemu_snapshots_metadata;
+    }
+
+    if (extra_data) {
+        *extra_data = xemu_snapshots_extra_data;
+    }
+
+    return xemu_snapshots_len;
+}
+
+void xemu_snapshots_load(const char *vm_name, Error **err)
+{
+    bool vm_running = runstate_is_running();
+    vm_stop(RUN_STATE_RESTORE_VM);
+    if (load_snapshot(vm_name, NULL, false, NULL, err) && vm_running) {
+        vm_start();
+    }
+}
+
+void xemu_snapshots_save(const char *vm_name, Error **err)
+{
+    save_snapshot(vm_name, true, NULL, false, NULL, err);
+}
+
+void xemu_snapshots_delete(const char *vm_name, Error **err)
+{
+    delete_snapshot(vm_name, false, NULL, err);
+}
+
+void xemu_snapshots_save_extra_data(QEMUFile *f)
+{
+    struct xbe *xbe_data = xemu_get_xbe_info();
+
+    int64_t xbe_title_len = 0;
+    char *xbe_title = g_utf16_to_utf8(xbe_data->cert->m_title_name, 40, NULL,
+                                      &xbe_title_len, NULL);
+    xbe_title_len++;
+
+    XemuSnapshotHeader header = { XEMU_SNAPSHOT_DATA_MAGIC, 0 };
+
+    header.size += sizeof(xbe_title_len);
+    header.size += xbe_title_len;
+
+    TextureBuffer *thumbnail = xemu_snapshots_extract_thumbnail();
+    if (thumbnail && thumbnail->buffer) {
+        header.size += sizeof(TextureBuffer) - sizeof(thumbnail->buffer);
+        header.size += thumbnail->size;
+    }
+
+    qemu_put_buffer(f, (const uint8_t *)&header, sizeof(header));
+    qemu_put_buffer(f, (const uint8_t *)&xbe_title_len, sizeof(xbe_title_len));
+    qemu_put_buffer(f, (const uint8_t *)xbe_title, xbe_title_len);
+
+    if (thumbnail && thumbnail->buffer) {
+        qemu_put_buffer(f, (const uint8_t *)thumbnail,
+                        sizeof(TextureBuffer) - sizeof(thumbnail->buffer));
+        qemu_put_buffer(f, (const uint8_t *)thumbnail->buffer, thumbnail->size);
+    }
+
+    g_free(xbe_title);
+
+    if (thumbnail && thumbnail->buffer) {
+        g_free(thumbnail->buffer);
+    }
+
+    g_free(thumbnail);
+
+    xemu_snapshots_dirty = true;
+}
+
+bool xemu_snapshots_offset_extra_data(QEMUFile *f)
+{
+    size_t ret;
+    XemuSnapshotHeader header;
+    ret = qemu_get_buffer(f, (uint8_t *)&header, sizeof(header));
+    if (ret != sizeof(header)) {
+        return false;
+    }
+
+    if (header.magic == XEMU_SNAPSHOT_DATA_MAGIC) {
+        /*
+         * qemu_file_skip only works if you aren't skipping past its buffer.
+         * Unfortunately, it's not usable here.
+         */
+        void *buf = g_malloc(header.size);
+        qemu_get_buffer(f, buf, header.size);
+        g_free(buf);
+    } else {
+        qemu_file_skip(f, -((int)sizeof(header)));
+    }
+
+    return true;
+}
+
+void xemu_snapshots_mark_dirty(void)
+{
+    xemu_snapshots_dirty = true;
+}

--- a/ui/xemu-snapshots.h
+++ b/ui/xemu-snapshots.h
@@ -1,0 +1,79 @@
+/*
+ * xemu User Interface
+ *
+ * Copyright (C) 2020-2022 Matt Borgerson
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef XEMU_SNAPSHOTS_H
+#define XEMU_SNAPSHOTS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "qemu/osdep.h"
+#include "block/snapshot.h"
+
+#define XEMU_SNAPSHOT_DATA_MAGIC 0x78656d75
+#define XEMU_SNAPSHOT_HEIGHT 120
+#define XEMU_SNAPSHOT_WIDTH 160
+
+extern const char **g_snapshot_shortcut_index_key_map[];
+
+#pragma pack(1)
+typedef struct TextureBuffer {
+    int channels;
+    unsigned long size;
+    void *buffer;
+} TextureBuffer;
+#pragma pack()
+
+typedef struct XemuSnapshotHeader {
+    uint32_t magic;
+    uint32_t size;
+} XemuSnapshotHeader;
+
+typedef struct XemuSnapshotData {
+    int64_t xbe_title_len;
+    char *xbe_title;
+    bool xbe_title_present;
+    TextureBuffer thumbnail;
+    bool thumbnail_present;
+    unsigned int gl_thumbnail;
+} XemuSnapshotData;
+
+// Implemented in xemu-snapshots.c
+int xemu_snapshots_list(QEMUSnapshotInfo **info, XemuSnapshotData **extra_data,
+                        Error **err);
+void xemu_snapshots_load(const char *vm_name, Error **err);
+void xemu_snapshots_save(const char *vm_name, Error **err);
+void xemu_snapshots_delete(const char *vm_name, Error **err);
+
+void xemu_snapshots_save_extra_data(QEMUFile *f);
+bool xemu_snapshots_offset_extra_data(QEMUFile *f);
+void xemu_snapshots_mark_dirty(void);
+
+// Implemented in xemu-thumbnail.cc
+void xemu_snapshots_set_framebuffer_texture(unsigned int tex, bool flip);
+void xemu_snapshots_render_thumbnail(unsigned int tex,
+                                     TextureBuffer *thumbnail);
+TextureBuffer *xemu_snapshots_extract_thumbnail(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/ui/xemu-thumbnail.cc
+++ b/ui/xemu-thumbnail.cc
@@ -1,0 +1,92 @@
+/*
+ * xemu User Interface
+ *
+ * Copyright (C) 2020-2022 Matt Borgerson
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdint>
+#include <fpng.h>
+#include <vector>
+
+#include "xemu-snapshots.h"
+#include "xui/gl-helpers.hh"
+
+static GLuint display_tex = 0;
+static bool display_flip = false;
+
+void xemu_snapshots_set_framebuffer_texture(GLuint tex, bool flip)
+{
+    display_tex = tex;
+    display_flip = flip;
+}
+
+void xemu_snapshots_render_thumbnail(GLuint tex, TextureBuffer *thumbnail)
+{
+    std::vector<uint8_t> pixels;
+    unsigned int width, height, channels;
+    if (fpng::fpng_decode_memory(
+            thumbnail->buffer, thumbnail->size, pixels, width, height, channels,
+            thumbnail->channels) != fpng::FPNG_DECODE_SUCCESS) {
+        return;
+    }
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, tex);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB,
+                 GL_UNSIGNED_BYTE, pixels.data());
+}
+
+TextureBuffer *xemu_snapshots_extract_thumbnail()
+{
+    /*
+     * Avoids crashing if a snapshot is made on a thread with no GL context
+     * Normally, this is not an issue, but it is better to fail safe than assert
+     * here.
+     * FIXME: Allow for dispatching a thumbnail request to the UI thread to
+     * remove this altogether.
+     */
+    if (!SDL_GL_GetCurrentContext() || display_tex == 0) {
+        return NULL;
+    }
+
+    // Render at 2x the base size to account for potential UI scaling
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, display_tex);
+    int thumbnail_width = XEMU_SNAPSHOT_WIDTH * 2;
+    int tex_width;
+    int tex_height;
+    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &tex_width);
+    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &tex_height);
+    int thumbnail_height = (int)(((float)tex_height / (float)tex_width) * (float)thumbnail_width);
+
+    std::vector<uint8_t> png;
+    if (!ExtractFramebufferPixels(display_tex, display_flip, png, thumbnail_width, thumbnail_height)) {
+        return NULL;
+    }
+
+    TextureBuffer *thumbnail = (TextureBuffer *)g_malloc(sizeof(TextureBuffer));
+    thumbnail->buffer = g_malloc(png.size() * sizeof(uint8_t));
+
+    thumbnail->channels = 3;
+    thumbnail->size = png.size() * sizeof(uint8_t);
+    memcpy(thumbnail->buffer, png.data(), thumbnail->size);
+    return thumbnail;
+}

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -47,6 +47,7 @@
 #include "xemu-input.h"
 #include "xemu-settings.h"
 // #include "xemu-shaders.h"
+#include "xemu-snapshots.h"
 #include "xemu-version.h"
 #include "xemu-os-utils.h"
 
@@ -1199,6 +1200,7 @@ void sdl2_gl_refresh(DisplayChangeListener *dcl)
 
     glClearColor(0, 0, 0, 0);
     glClear(GL_COLOR_BUFFER_BIT);
+    xemu_snapshots_set_framebuffer_texture(tex, flip_required);
     xemu_hud_set_framebuffer_texture(tex, flip_required);
     xemu_hud_render();
 
@@ -1548,6 +1550,7 @@ int main(int argc, char **argv)
 
     while (1) {
         sdl2_gl_refresh(&sdl2_console[0].dcl);
+        assert(glGetError() == GL_NO_ERROR);
     }
 
     // rcu_unregister_thread();

--- a/ui/xui/actions.hh
+++ b/ui/xui/actions.hh
@@ -24,3 +24,4 @@ void ActionTogglePause();
 void ActionReset();
 void ActionShutdown();
 void ActionScreenshot();
+void ActionActivateBoundSnapshot(int slot, bool save);

--- a/ui/xui/common.hh
+++ b/ui/xui/common.hh
@@ -28,6 +28,7 @@
 #include <imgui_impl_sdl.h>
 #include <imgui_impl_opengl3.h>
 #include <implot.h>
+#include <misc/cpp/imgui_stdlib.h>
 #include <stb_image.h>
 
 extern "C" {

--- a/ui/xui/gl-helpers.hh
+++ b/ui/xui/gl-helpers.hh
@@ -17,6 +17,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 #pragma once
+#include <vector>
 #include "common.hh"
 #include "../xemu-input.h"
 
@@ -38,6 +39,7 @@ public:
 };
 
 extern Fbo *controller_fbo, *logo_fbo;
+extern GLuint g_icon_tex;
 
 void InitCustomRendering(void);
 void RenderLogo(uint32_t time);
@@ -45,5 +47,6 @@ void RenderController(float frame_x, float frame_y, uint32_t primary_color,
                       uint32_t secondary_color, ControllerState *state);
 void RenderControllerPort(float frame_x, float frame_y, int i,
                           uint32_t port_color);
-void RenderFramebuffer(GLint tex, int width, int height, bool flip);
+void RenderFramebuffer(GLint tex, int width, int height, bool flip, bool apply_scaling_factor = true);
+bool ExtractFramebufferPixels(GLuint tex, bool flip, std::vector<uint8_t> &png, int width = 0, int height = 0);
 void SaveScreenshot(GLuint tex, bool flip);

--- a/ui/xui/main-menu.hh
+++ b/ui/xui/main-menu.hh
@@ -24,6 +24,7 @@
 #include "widgets.hh"
 #include "scene.hh"
 #include "scene-components.hh"
+#include "../xemu-snapshots.h"
 
 extern "C" {
 #include "net/pcap.h"
@@ -102,8 +103,24 @@ public:
 
 class MainMenuSnapshotsView : public virtual MainMenuTabView
 {
+protected:
+    QEMUSnapshotInfo *m_snapshots;
+    XemuSnapshotData *m_extra_data;
+    int m_snapshots_len;
+    uint32_t m_current_title_id;
+    char *m_current_title_name;
+    std::string m_search_buf;
+    std::string m_create_buf;
+    bool m_load_failed;
+
+private:
+    void Load();
+
 public:
-    void SnapshotBigButton(const char *name, const char *title_name,
+    GRegex *m_search_regex;
+    MainMenuSnapshotsView();
+    ~MainMenuSnapshotsView();
+    void SnapshotBigButton(QEMUSnapshotInfo *snapshot, const char *title_name,
                            GLuint screenshot);
     void Draw() override;
 };
@@ -153,7 +170,7 @@ protected:
                                     m_display_button,
                                     m_audio_button,
                                     m_network_button,
-                                    // m_snapshots_button,
+                                    m_snapshots_button,
                                     m_system_button,
                                     m_about_button;
     std::vector<MainMenuTabView*>   m_views;
@@ -162,7 +179,7 @@ protected:
     MainMenuDisplayView             m_display_view;
     MainMenuAudioView               m_audio_view;
     MainMenuNetworkView             m_network_view;
-    // MainMenuSnapshotsView        m_snapshots_view;
+    MainMenuSnapshotsView           m_snapshots_view;
     MainMenuSystemView              m_system_view;
     MainMenuAboutView               m_about_view;
 
@@ -174,7 +191,7 @@ public:
     void ShowDisplay();
     void ShowAudio();
     void ShowNetwork();
-    // void ShowSnapshots();
+    void ShowSnapshots();
     void ShowSystem();
     void ShowAbout();
     void SetNextViewIndexWithFocus(int i);

--- a/ui/xui/main.cc
+++ b/ui/xui/main.cc
@@ -31,6 +31,7 @@
 #include <string>
 #include <memory>
 
+#include "actions.hh"
 #include "common.hh"
 #include "xemu-hud.h"
 #include "misc.hh"
@@ -276,6 +277,14 @@ void xemu_hud_render(void)
                    (ImGui::IsMouseClicked(ImGuiMouseButton_Right) &&
                     !ImGui::IsAnyItemFocused() && !ImGui::IsAnyItemHovered())) {
             g_scene_mgr.PushScene(g_popup_menu);
+        }
+        
+        bool mod_key_down = ImGui::IsKeyDown(ImGuiKey_ModShift);
+        for (int f_key = 0; f_key < 4; ++f_key) {
+            if (ImGui::IsKeyPressed(f_key + ImGuiKey_F5)) {
+                ActionActivateBoundSnapshot(f_key, mod_key_down);
+                break;
+            }
         }
     }
 

--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
+#include "ui/xemu-notifications.h"
 #include "common.hh"
 #include "main-menu.hh"
 #include "menubar.hh"
@@ -88,6 +89,48 @@ void ShowMainMenu()
             if (ImGui::MenuItem(running ? "Pause" : "Resume", SHORTCUT_MENU_TEXT(P))) ActionTogglePause();
             if (ImGui::MenuItem("Screenshot", "F12")) ActionScreenshot();
 
+            if (ImGui::BeginMenu("Snapshot")) {
+                if (ImGui::MenuItem("Create Snapshot")) {
+                    xemu_snapshots_save(NULL, NULL);
+                    xemu_queue_notification("Created new snapshot");
+                }
+
+                for (int i = 0; i < 4; ++i) {
+                    char *hotkey = g_strdup_printf("Shift+F%d", i + 5);
+
+                    char *load_name;
+                    char *save_name;
+
+                    assert(g_snapshot_shortcut_index_key_map[i]);
+                    bool bound = *(g_snapshot_shortcut_index_key_map[i]) &&
+                            (**(g_snapshot_shortcut_index_key_map[i]) != 0);
+
+                    if (bound) {
+                        load_name = g_strdup_printf("Load '%s'", *(g_snapshot_shortcut_index_key_map[i]));
+                        save_name = g_strdup_printf("Save '%s'", *(g_snapshot_shortcut_index_key_map[i]));
+                    } else {
+                        load_name = g_strdup_printf("Load F%d (Unbound)", i + 5);
+                        save_name = g_strdup_printf("Save F%d (Unbound)", i + 5);
+                    }
+
+                    ImGui::Separator();
+
+                    if (ImGui::MenuItem(load_name, hotkey + sizeof("Shift+") - 1, false, bound)) {
+                        ActionActivateBoundSnapshot(i, false);
+                    }
+
+                    if (ImGui::MenuItem(save_name, hotkey, false, bound)) {
+                        ActionActivateBoundSnapshot(i, false);
+                    }
+
+                    g_free(hotkey);
+                    g_free(load_name);
+                    g_free(save_name);
+                }
+
+                ImGui::EndMenu();
+            }
+
             ImGui::Separator();
 
             if (ImGui::MenuItem("Eject Disc", SHORTCUT_MENU_TEXT(E))) ActionEjectDisc();
@@ -101,6 +144,7 @@ void ShowMainMenu()
             if (ImGui::MenuItem(" Display")) g_main_menu.ShowDisplay();
             if (ImGui::MenuItem(" Audio")) g_main_menu.ShowAudio();
             if (ImGui::MenuItem(" Network")) g_main_menu.ShowNetwork();
+            if (ImGui::MenuItem(" Snapshots")) g_main_menu.ShowSnapshots();
             if (ImGui::MenuItem(" System")) g_main_menu.ShowSystem();
 
             ImGui::Separator();

--- a/ui/xui/popup-menu.cc
+++ b/ui/xui/popup-menu.cc
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
+#include "ui/xemu-notifications.h"
 #include <string>
 #include <vector>
 #include "misc.hh"
@@ -27,6 +28,8 @@
 #include "input-manager.hh"
 #include "xemu-hud.h"
 #include "IconsFontAwesome6.h"
+#include "../xemu-snapshots.h"
+#include "main-menu.hh"
 
 PopupMenuItemDelegate::~PopupMenuItemDelegate() {}
 void PopupMenuItemDelegate::PushMenu(PopupMenu &menu) {}
@@ -269,7 +272,7 @@ public:
     }
 };
 
-extern Scene g_main_menu;
+extern MainMenuScene g_main_menu;
 
 class SettingsPopupMenu : public virtual PopupMenu {
 protected:
@@ -291,6 +294,11 @@ public:
         if (PopupMenuSubmenuButton("Display Mode", ICON_FA_EXPAND)) {
             nav.PushFocus();
             nav.PushMenu(display_mode);
+        }
+        if (PopupMenuButton("Snapshots...", ICON_FA_CLOCK_ROTATE_LEFT)) {
+            nav.ClearMenuStack();
+            g_scene_mgr.PushScene(g_main_menu);
+            g_main_menu.ShowSnapshots();
         }
         if (PopupMenuButton("All settings...", ICON_FA_SLIDERS)) {
             nav.ClearMenuStack();
@@ -336,6 +344,11 @@ public:
         }
         if (PopupMenuButton("Screenshot", ICON_FA_CAMERA)) {
             ActionScreenshot();
+            pop = true;
+        }
+        if (PopupMenuButton("Save Snapshot", ICON_FA_DOWNLOAD)) {
+            xemu_snapshots_save(NULL, NULL);
+            xemu_queue_notification("Created new snapshot");
             pop = true;
         }
         if (PopupMenuButton("Eject Disc", ICON_FA_EJECT)) {


### PR DESCRIPTION
Enables the snapshots menu in the new UI, complete with thumbnails, game title information, searching, and the ability to bind snapshots to F5-F8 keys for ease of use.

For anyone who wishes to test this before merge, keep in mind that snapshots created or saved with this branch are not backwards compatible with previous xemu versions. That is, those snapshots will not work on any other version of xemu. Snapshots created on previous or current xemu versions will work fine with this branch, however.

https://user-images.githubusercontent.com/25046221/168232353-fe025b84-39c4-4621-bf7b-60ed884a9025.mp4
