### PR TITLE
Fixes intermixed use of DRAW_ARRAYS and ARRAY_ELEMENTx

### DIFF
--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -501,10 +501,10 @@ static const VMStateDescription vmstate_nv2a = {
         VMSTATE_UINT32(pgraph.inline_elements_length, NV2AState), // fixme
         VMSTATE_UINT32_ARRAY(pgraph.inline_elements, NV2AState, NV2A_MAX_BATCH_LENGTH),
         VMSTATE_UINT32(pgraph.inline_buffer_length, NV2AState), // fixme
-        VMSTATE_UINT32(pgraph.draw_arrays_length, NV2AState), // fixme
-        VMSTATE_UINT32(pgraph.draw_arrays_max_count, NV2AState), // fixme
-        // GLint gl_draw_arrays_start[1250]; // fixme
-        // GLsizei gl_draw_arrays_count[1250]; // fixme
+        VMSTATE_UINT32(pgraph.draw_arrays_length, NV2AState),
+        VMSTATE_UINT32(pgraph.draw_arrays_max_count, NV2AState),
+        VMSTATE_INT32_ARRAY(pgraph.gl_draw_arrays_start, NV2AState, 1250),
+        VMSTATE_INT32_ARRAY(pgraph.gl_draw_arrays_count, NV2AState, 1250),
         VMSTATE_UINT32_ARRAY(pgraph.regs, NV2AState, 0x2000),
         VMSTATE_UINT32(pmc.pending_interrupts, NV2AState),
         VMSTATE_UINT32(pmc.enabled_interrupts, NV2AState),

--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -374,6 +374,7 @@ typedef struct PGRAPHState {
     unsigned int draw_arrays_min_start;
     unsigned int draw_arrays_max_count;
     /* FIXME: Unknown size, possibly endless, 1250 will do for now */
+    /* Keep in sync with size used in nv2a.c */
     GLint gl_draw_arrays_start[1250];
     GLsizei gl_draw_arrays_count[1250];
     bool draw_arrays_prevent_connect;


### PR DESCRIPTION
Finishes the work started in your `fix/arrays` branch.

[test](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/overlapping_draw_modes_tests.cpp)
[HW results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Overlapping_draw_modes)

fixes #329 