### PR TITLE
nv2a: Move snapshot surface download into savevm hook 

### DIFF
--- a/hw/xbox/nv2a/nv2a.h
+++ b/hw/xbox/nv2a/nv2a.h
@@ -28,5 +28,6 @@ void nv2a_set_surface_scale_factor(unsigned int scale);
 unsigned int nv2a_get_surface_scale_factor(void);
 const uint8_t *nv2a_get_dac_palette(void);
 int nv2a_get_screen_off(void);
+void nv2a_save_vm_state(void);
 
 #endif

--- a/migration/savevm.c
+++ b/migration/savevm.c
@@ -68,6 +68,7 @@
 #include "yank_functions.h"
 
 #include "ui/xemu-snapshots.h"
+#include "hw/xbox/nv2a/nv2a.h"
 
 const unsigned int postcopy_ram_discard_version;
 
@@ -2854,6 +2855,9 @@ bool save_snapshot(const char *name, bool overwrite, const char *vmstate,
         return false;
     }
     vm_stop(RUN_STATE_SAVE_VM);
+#ifdef XBOX
+    nv2a_save_vm_state();
+#endif
 
     bdrv_drain_all_begin();
 


### PR DESCRIPTION
When the vm is paused, the `nv2a_vm_state_change` function is not called when saving or loading the VM. As such, the surface download that is normally triggered here never happens. This change will perform the download when the state changes to paused to mitigate this.

Resolves #818 