### PR TITLE
nv2a: Upload blitted surfaces used as textures

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -6327,7 +6327,11 @@ static void pgraph_bind_textures(NV2AState *d)
         SurfaceBinding *surface = pgraph_surface_get(d, texture_vram_offset);
         if (surface != NULL) {
             surf_to_tex = pgraph_check_surface_to_texture_compatibility(
-                surface, &state);
+                    surface, &state);
+
+            if (surf_to_tex && surface->upload_pending) {
+                pgraph_upload_surface_data(d, surface, false);
+            }
         }
 
         if (!surf_to_tex) {


### PR DESCRIPTION
Fixes #786 (may require #831 as well to have the full effect)

[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/b64de98e2c87d8b979991d95eddb2d67e4625860/src/tests/texture_framebuffer_blit_tests.cpp#L214)
[HW Results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Texture_Framebuffer_Blit#fbtooldrendertargetpng)