### PR TITLE
nv2a: Fix renderdoc detection on macOS

### DIFF
--- a/hw/xbox/nv2a/debug.c
+++ b/hw/xbox/nv2a/debug.c
@@ -62,7 +62,13 @@ void gl_debug_initialize(void)
     }
 
 #ifdef CONFIG_RENDERDOC
-    void* renderdoc = dlopen("librenderdoc.so", RTLD_NOW | RTLD_NOLOAD);
+    const char *renderdoc_lib;
+#ifdef __APPLE__
+    renderdoc_lib = "librenderdoc.dylib";
+#else
+    renderdoc_lib = "librenderdoc.so";
+#endif
+    void* renderdoc = dlopen(renderdoc_lib, RTLD_NOW | RTLD_NOLOAD);
     if (renderdoc) {
         pRENDERDOC_GetAPI RENDERDOC_GetAPI = (pRENDERDOC_GetAPI)dlsym(
             renderdoc, "RENDERDOC_GetAPI");


### PR DESCRIPTION
Renderdoc seems to work on M1 macs now, this fixes the dlopen so xemu can properly detect that it has been launched via renderdoc to enable the improved capture API.