### PR TITLE
Update Windows SDL build to 2.0.22

### DIFF
--- a/ubuntu-win64-cross/sdl2-2-link-order.patch
+++ b/ubuntu-win64-cross/sdl2-2-link-order.patch
@@ -1,18 +1,28 @@
---- SDL2-2.0.20/CMakeLists.txt
-+++ SDL2-2.0.20/CMakeLists.txt
-@@ -1784,10 +1784,9 @@ elseif(WINDOWS)
+From 6ed44eb604bb6f4070dcc75b0f243a661d0b0eff Mon Sep 17 00:00:00 2001
+From: Matt Borgerson <contact@mborgerson.com>
+Date: Sat, 23 Apr 2022 07:44:03 -0700
+Subject: [PATCH] Fix link order
+
+---
+ CMakeLists.txt | 27 ++++++++-------------------
+ 1 file changed, 8 insertions(+), 19 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 644715aae..cc422c356 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1813,9 +1813,8 @@ elseif(WINDOWS)
    file(GLOB VERSION_SOURCES ${SDL2_SOURCE_DIR}/src/main/windows/*.rc)
    file(GLOB SDLMAIN_SOURCES ${SDL2_SOURCE_DIR}/src/main/windows/*.c)
    if(MINGW OR CYGWIN)
 -    list(APPEND EXTRA_LIBS mingw32)
      list(APPEND EXTRA_LDFLAGS "-mwindows")
-     set(SDL_CFLAGS "${SDL_CFLAGS} -Dmain=SDL_main")
--    list(APPEND SDL_LIBS "-lmingw32" "-lSDL2main" "-mwindows")
-+    list(APPEND SDL_LIBS "-lmingw32" "-lSDL2main")
-   endif()
- 
- elseif(APPLE)
-@@ -2582,23 +2581,13 @@ Libs.private:")
+-    list(APPEND SDL_LIBS "-lmingw32" "-mwindows")
++    list(APPEND SDL_LIBS "-lmingw32")
+     if(NOT SDL2_DISABLE_SDL2MAIN)
+       set(SDL_CFLAGS "${SDL_CFLAGS} -Dmain=SDL_main")
+       list(APPEND SDL_LIBS "-lSDL2main")
+@@ -2697,23 +2696,13 @@ Libs.private:")
    endif()
  
    # Clean up the different lists
@@ -43,3 +53,6 @@
  
    # MESSAGE(STATUS "SDL_LIBS: ${SDL_LIBS}")
    # MESSAGE(STATUS "SDL_STATIC_LIBS: ${SDL_STATIC_LIBS}")
+-- 
+2.25.1
+

--- a/ubuntu-win64-cross/sdl2.mk
+++ b/ubuntu-win64-cross/sdl2.mk
@@ -4,8 +4,8 @@ PKG             := sdl2
 $(PKG)_WEBSITE  := https://www.libsdl.org/
 $(PKG)_DESCR    := SDL2
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.0.20
-$(PKG)_CHECKSUM := 2a026753af9b03fca043824bca8341f74921a836d28729e0c31aa262202a83c6
+$(PKG)_VERSION  := 2.0.22
+$(PKG)_CHECKSUM := 826e83c7a602b2025647e93c6585908379179f68d479dfc1d9b03d2b9570c8d9
 $(PKG)_GH_CONF  := libsdl-org/SDL/releases/tag,release-,,
 $(PKG)_DEPS     := cc libiconv libsamplerate
 


### PR DESCRIPTION
Needs to be tested before merge; I have only tried the SDL RC a few days ago not the final release.