### PR TITLE
nv2a: Fix glsl ambiguous overload to prevent renderdoc failure

### DIFF
--- a/hw/xbox/nv2a/debug.c
+++ b/hw/xbox/nv2a/debug.c
@@ -169,14 +169,19 @@ void gl_debug_frame_terminator(void)
         if (rdoc_api->IsTargetControlConnected()) {
             if (rdoc_api->IsFrameCapturing()) {
                 rdoc_api->EndFrameCapture(NULL, NULL);
-                CHECK_GL_ERROR();
+                GLenum error = glGetError();
+                if (error != GL_NO_ERROR) {
+                    fprintf(stderr,
+                            "Renderdoc EndFrameCapture triggered GL error 0x%X - ignoring\n",
+                            error);
+                }
             }
             if (renderdoc_capture_frames) {
                 rdoc_api->StartFrameCapture(NULL, NULL);
                 GLenum error = glGetError();
                 if (error != GL_NO_ERROR) {
                     fprintf(stderr,
-                            "Renderdoc frame capture triggered GL error 0x%X - ignoring\n",
+                            "Renderdoc StartFrameCapture triggered GL error 0x%X - ignoring\n",
                             error);
                 }
                 --renderdoc_capture_frames;

--- a/hw/xbox/nv2a/psh.c
+++ b/hw/xbox/nv2a/psh.c
@@ -653,8 +653,8 @@ static MString* psh_convert(struct PixelShader *ps)
         mstring_append(clip, "bool clipContained = false;\n");
     }
     mstring_append(clip, "for (int i = 0; i < 8; i++) {\n"
-                         "  bvec4 clipTest = bvec4(lessThan(gl_FragCoord.xy-0.5, clipRegion[i].xy),\n"
-                         "                         greaterThan(gl_FragCoord.xy-0.5, clipRegion[i].zw));\n"
+                         "  bvec4 clipTest = bvec4(lessThan(gl_FragCoord.xy-0.5, vec2(clipRegion[i].xy)),\n"
+                         "                         greaterThan(gl_FragCoord.xy-0.5, vec2(clipRegion[i].zw)));\n"
                          "  if (!any(clipTest)) {\n");
     if (ps->state.window_clip_exclusive) {
         mstring_append(clip, "    discard;\n");


### PR DESCRIPTION
macOS does not provide `ARB_program_interface_query`, so renderdoc falls back to recompiling shaders to allow it to do introspection. Unfortunately this recompilation seems to be less forgiving than the compilation in xemu itself, and blows up on an ambiguous function signature in the pixel shader where a combination of a float vector and an integer vector are passed to `lessThan` and `greaterThan`.

From https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/lessThan.xhtml it looks like this mix of types should not be supported, so I'm inclined to fix the shader by explicitly treating both params as float vectors rather than try to figure out why it's not blowing up in xemu/why it is blowing up in renderdoc.

As a bonus, I also relaxed the assert when ending a frame capture since I encountered some errors there (unfortunately they're not consistently reproducible so I don't have a fix yet, but like the start capture error, a significant amount of renderdoc functionality seems to work even with whatever is failing).

With this change (and a bleeding edge renderdoc build) I'm able to successfully capture the shadow map test on M1 and look at the input and output textures (both color and depth).
