### PR TITLE
ui: Use SDL_GL_GetDrawableSize when rendering framebuffer

### DIFF
--- a/ui/xui/main.cc
+++ b/ui/xui/main.cc
@@ -197,7 +197,9 @@ void xemu_hud_render(void)
     }
 
     if (!first_boot_window.is_open) {
-        RenderFramebuffer(g_tex, io.DisplaySize.x, io.DisplaySize.y, g_flip_req);
+        int ww, wh;
+        SDL_GL_GetDrawableSize(g_sdl_window, &ww, &wh);
+        RenderFramebuffer(g_tex, ww, wh, g_flip_req);
     }
 
     ImGui_ImplOpenGL3_NewFrame();


### PR DESCRIPTION
Should fix #905 