### PR TITLE
ui: Fix compilation with --enable-renderdoc

### DIFF
--- a/ui/xui/gl-helpers.cc
+++ b/ui/xui/gl-helpers.cc
@@ -33,7 +33,7 @@ Fbo *controller_fbo,
 GLuint g_controller_tex,
        g_logo_tex;
 
-enum ShaderType {
+enum class ShaderType {
     Blit,
     BlitGamma, // FIMXE: Move to nv2a_get_framebuffer_surface
     Mask,

--- a/ui/xui/main.cc
+++ b/ui/xui/main.cc
@@ -213,9 +213,9 @@ void xemu_hud_render(void)
     ProcessKeyboardShortcuts();
 
 #if defined(DEBUG_NV2A_GL) && defined(CONFIG_RENDERDOC)
-    if (capture_renderdoc_frame) {
+    if (g_capture_renderdoc_frame) {
         nv2a_dbg_renderdoc_capture_frames(1);
-        capture_renderdoc_frame = false;
+        g_capture_renderdoc_frame = false;
     }
 #endif
 

--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -31,7 +31,7 @@
 extern float g_main_menu_height; // FIXME
 
 #ifdef CONFIG_RENDERDOC
-static bool capture_renderdoc_frame = false;
+bool g_capture_renderdoc_frame = false;
 #endif
 
 #if defined(__APPLE__)
@@ -167,7 +167,7 @@ void ShowMainMenu()
             ImGui::MenuItem("Video", NULL, &video_window.m_is_open);
 #if defined(DEBUG_NV2A_GL) && defined(CONFIG_RENDERDOC)
             if (nv2a_dbg_renderdoc_available()) {
-                ImGui::MenuItem("RenderDoc: Capture", NULL, &capture_renderdoc_frame);
+                ImGui::MenuItem("RenderDoc: Capture", NULL, &g_capture_renderdoc_frame);
             }
 #endif
             ImGui::EndMenu();

--- a/ui/xui/menubar.hh
+++ b/ui/xui/menubar.hh
@@ -20,3 +20,7 @@
 
 void ProcessKeyboardShortcuts(void);
 void ShowMainMenu();
+
+#ifdef CONFIG_RENDERDOC
+extern bool g_capture_renderdoc_frame;
+#endif


### PR DESCRIPTION
The split into main/menubar left main referencing a static var defined in menubar, and there's a conflicting definition of `Mask` in `gl-helpers.cc`.

This issue was only visible when building with `--enable-renderdoc` + `DEBUG_NV2A_GL` defined.