### PR TITLE
nv2a: Adjust NaN handling to be similar to HW

### DIFF
--- a/hw/xbox/nv2a/vsh.c
+++ b/hw/xbox/nv2a/vsh.c
@@ -614,17 +614,6 @@ static const char* vsh_header =
      * https://www.opengl.org/registry/specs/NV/vertex_program1_1.txt
      */
     "\n"
-//QQQ #ifdef NICE_CODE
-    "/* Converts the input to vec4, pads with last component */\n"
-    "vec4 _in(float v) { return vec4(v); }\n"
-    "vec4 _in(vec2 v) { return v.xyyy; }\n"
-    "vec4 _in(vec3 v) { return v.xyzz; }\n"
-    "vec4 _in(vec4 v) { return v.xyzw; }\n"
-//#else
-//    "/* Make sure input is always a vec4 */\n"
-//   "#define _in(v) vec4(v)\n"
-//#endif
-    "\n"
     "#define INFINITY (1.0 / 0.0)\n"
     "\n"
     "#define MOV(dest, mask, src) dest.mask = _MOV(_in(src)).mask\n"


### PR DESCRIPTION
Fixes #365 by forcing treatment of NaN values generated in the vertex shader to follow the same pattern as HW.

Unfortunately this does not address the fact that on HW, `+/- NaN` `*` `0` (or very close to 0) should be `0`. This difference in behavior is also responsible for #1008.

This also does not address the same issue for `+/- inf` and the shader version currently used by xemu explicitly notes that operations on inf/NaN's are undefined (which may explain why Otogi textures are not blacked out on M1 mac).

[Tests](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/attribute_float_tests.cpp)
[HW results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Attrib_float)