### PR TITLE
nv2a: Invalidate zeta when constructing non-matching color surface.

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -5901,6 +5901,10 @@ static void pgraph_update_surface_part(NV2AState *d, bool upload, bool color)
             pg->surface_binding_dim.height = entry.height;
             pg->surface_binding_dim.clip_y = entry.shape.clip_y;
             pg->surface_binding_dim.clip_height = entry.shape.clip_height;
+
+            if (color && pg->zeta_binding && (pg->zeta_binding->width != entry.width || pg->zeta_binding->height != entry.height)) {
+                pg->surface_zeta.buffer_dirty = true;
+            }
         }
 
         NV2A_XPRINTF(DBG_SURFACES,


### PR DESCRIPTION
Fixes #420 
Fixes #841 
Fixes #931 

[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/surface_clip_tests.cpp)
[HW results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Surface_clip)

Note that HW results differ substantially from xemu due to the fact that xemu treats the color surface format as the definitive output whereas this seems to be configured separately on nv2a (it's possible to instruct the HW to write to the backbuffer in R5G5B5 format but still display the content as ARGB, resulting in a squashed, color shifted framebuffer).