### PR TITLE
nv2a: Handle invalid w in fixed function pipeline

### DIFF
--- a/hw/xbox/nv2a/shaders.c
+++ b/hw/xbox/nv2a/shaders.c
@@ -693,8 +693,13 @@ GLSL_DEFINE(materialEmissionColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_CM_COL) ".xyz
                            state->surface_scale_factor);
     }
 
-    mstring_append(body, "  vtx.inv_w = 1.0 / oPos.w;\n");
 
+    mstring_append(body,
+                   "  if (oPos.w == 0.0 || isinf(oPos.w)) {\n"
+                   "    vtx.inv_w = 1.0;\n"
+                   "  } else {\n"
+                   "    vtx.inv_w = 1.0 / oPos.w;\n"
+                   "  }\n");
 }
 
 static MString *generate_vertex_shader(const ShaderState *state,


### PR DESCRIPTION
Partially fixes #801 

[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/w_param_tests.cpp)
[HW result](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-W_param)

Note that this does not match the HW behavior when rendering quads due to #912 and does not precisely match HW behavior in general.