### PR TITLE
nv2a: Use width to calculate swizzled surface pitch

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -5741,7 +5741,8 @@ static void pgraph_populate_surface_binding_entry_sized(NV2AState *d,
     entry->vram_addr = dma.address + surface->offset;
     entry->width = width;
     entry->height = height;
-    entry->pitch = surface->pitch;
+    entry->pitch = entry->swizzle ? (entry->width * entry->fmt.bytes_per_pixel)
+                                  : surface->pitch;
     entry->size = height * surface->pitch;
     entry->upload_pending = true;
     entry->download_pending = false;
@@ -5751,6 +5752,8 @@ static void pgraph_populate_surface_binding_entry_sized(NV2AState *d,
     entry->frame_time = pg->frame_time;
     entry->draw_time = pg->draw_time;
     entry->cleared = false;
+
+    assert(entry->pitch >= (entry->width * entry->fmt.bytes_per_pixel));
 }
 
 static void pgraph_populate_surface_binding_entry(NV2AState *d, bool color,


### PR DESCRIPTION
I forget the case that prompted this change. Would like a test case to confirm hardware behavior wrt pitch on swizzled surfaces