### PR TITLE
nv2a: Do not force oFog to 1.0

### DIFF
--- a/hw/xbox/nv2a/shaders.c
+++ b/hw/xbox/nv2a/shaders.c
@@ -727,21 +727,7 @@ GLSL_DEFINE(texMat3, GLSL_C_MAT4(NV_IGRAPH_XF_XFCTX_T3MAT))
 "vec4 oB0 = vec4(0.0,0.0,0.0,1.0);\n"
 "vec4 oB1 = vec4(0.0,0.0,0.0,1.0);\n"
 "vec4 oPts = vec4(0.0,0.0,0.0,1.0);\n"
-/* FIXME: NV_vertex_program says: "FOGC is the transformed vertex's fog
- * coordinate. The register's first floating-point component is interpolated
- * across the assembled primitive during rasterization and used as the fog
- * distance to compute per-fragment the fog factor when fog is enabled.
- * However, if both fog and vertex program mode are enabled, but the FOGC
- * vertex result register is not written, the fog factor is overridden to
- * 1.0. The register's other three components are ignored."
- *
- * That probably means it will read back as vec4(0.0, 0.0, 0.0, 1.0) but
- * will be set to 1.0 AFTER the VP if it was never written?
- * We should test on real hardware..
- *
- * We'll force 1.0 for oFog.x for now.
- */
-"vec4 oFog = vec4(1.0,0.0,0.0,1.0);\n"
+"vec4 oFog = vec4(0.0,0.0,0.0,1.0);\n"
 "vec4 oT0 = vec4(0.0,0.0,0.0,1.0);\n"
 "vec4 oT1 = vec4(0.0,0.0,0.0,1.0);\n"
 "vec4 oT2 = vec4(0.0,0.0,0.0,1.0);\n"


### PR DESCRIPTION
Fixes #876

WARNING: This does not exactly follow HW behavior and it's possible that it will cause regressions in any games that happen to set the oFog to something high before using it unmodified in a subsequent shader.


The code being removed was added ~7 years ago in [this commit](https://github.com/xqemu/xqemu/commit/97be3f598683721bc43e354d7804221152e21f02)

From what I can see from the [HW test results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Fog_coord_vec4) the behavior on nv2a is more subtle than the cited `NV_vertex_program` documentation.

In practice the register more or less retains its value until it is explicitly modified.[The test](https://github.com/abaire/nxdk_pgraph_tests/blob/4cff2b2ebe49c29eb24caea9c058b3d6ddaa3a16/src/tests/fog_tests.cpp#L432) renders something with an explicitly set oFog.x, then renders again with a shader that does not modify oFog.x but references it in the pixel shader. The value carries over rather than being forced to 1.0.

~~Interestingly, this test is apparently not hermetic; running the other vec4_coord test (that explictly set various components of oFog) lead to unusual behavior where the fogging effect is not uniform across all vertices, despite never being set. Even more interestingly, re-running the test once it's in this state will often produce variations as to which vertices are apparently using a stale/incorrect fog value.~~ (See comment thread, this may have been due to HW parallelization and was resolved by doing repeated draws before using the shader that does not set the fog coord.)