### PR TITLE
nv2a: Ignore excess inline array data

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -6784,7 +6784,6 @@ static unsigned int pgraph_bind_inline_array(NV2AState *d)
 
     unsigned int vertex_size = offset;
     unsigned int index_count = pg->inline_array_length*4 / vertex_size;
-    assert((index_count*vertex_size) == (pg->inline_array_length*4));
 
     NV2A_DPRINTF("draw inline array %d, %d\n", vertex_size, index_count);
 
@@ -6792,7 +6791,7 @@ static unsigned int pgraph_bind_inline_array(NV2AState *d)
     glBindBuffer(GL_ARRAY_BUFFER, pg->gl_inline_array_buffer);
     glBufferData(GL_ARRAY_BUFFER, NV2A_MAX_BATCH_LENGTH * sizeof(uint32_t),
                  NULL, GL_STREAM_DRAW);
-    glBufferSubData(GL_ARRAY_BUFFER, 0, pg->inline_array_length*4, pg->inline_array);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, index_count * vertex_size, pg->inline_array);
     pgraph_bind_vertex_attributes(d, 0, index_count-1, true, vertex_size,
                                   index_count-1);
 


### PR DESCRIPTION
Fixes #424 
May also address #926 but I don't have those games to test

Testing on hardware shows that excess inline array data is gracefully ignored and discarded. The test draws triangle primitives, passing a triplet of valid vertices as well as a fourth and part of a fifth, then completes the draw. To verify that the excess data is dropped, it performs a second "triangles" draw with the remaining data, which does not result in a second triangle being drawn.

[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/inline_array_size_mismatch.cpp)
[HW results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Inline_array_size_mismatch)