### PR TITLE
nv2a: Gracefully ignore draws with no target bindings

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -2685,6 +2685,7 @@ DEF_METHOD(NV097, SET_BEGIN_END)
     bool mask_red = control_0 & NV_PGRAPH_CONTROL_0_RED_WRITE_ENABLE;
     bool mask_green = control_0 & NV_PGRAPH_CONTROL_0_GREEN_WRITE_ENABLE;
     bool mask_blue = control_0 & NV_PGRAPH_CONTROL_0_BLUE_WRITE_ENABLE;
+    bool color_write = mask_alpha || mask_red || mask_green || mask_blue;
 
     bool depth_test = control_0 & NV_PGRAPH_CONTROL_0_ZENABLE;
     bool stencil_test =
@@ -2693,6 +2694,12 @@ DEF_METHOD(NV097, SET_BEGIN_END)
     if (parameter == NV097_SET_BEGIN_END_OP_END) {
 
         nv2a_profile_inc_counter(NV2A_PROF_BEGIN_ENDS);
+
+        if (!(pg->color_binding || pg->zeta_binding)) {
+            // TODO: Factor out the end handling (done in PR #805).
+            NV2A_GL_DGROUP_END();
+            return;
+        }
 
         assert(pg->shader_binding);
 
@@ -2833,6 +2840,18 @@ DEF_METHOD(NV097, SET_BEGIN_END)
         assert(parameter <= NV097_SET_BEGIN_END_OP_POLYGON);
 
         pgraph_update_surface(d, true, true, depth_test || stencil_test);
+
+        if (!(color_write || depth_test || stencil_test)) {
+            // FIXME: Check PGRAPH register 0x880.
+            // HW uses bit 11 in 0x880 to enable or disable a color/zeta limit
+            // check that will raise an exception in the case that a draw should
+            // modify the color and/or zeta buffer but the target(s) are masked
+            // off. This check only seems to trigger during the fragment
+            // processing, it is legal to attempt a draw that is entirely
+            // clipped regardless of 0x880. See xemu#635 for context.
+            return;
+        }
+
         assert(pg->color_binding || pg->zeta_binding);
 
         pg->primitive_mode = parameter;


### PR DESCRIPTION
Fixes #635 

[Test that triggers the assert without the fix](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/color_zeta_disable_tests.cpp)
[Tests of stencil behavior more generally](https://github.com/antangelo/nxdk_pgraph_tests/blob/stencil-tests/src/tests/stencil_tests.cpp)
