### PR TITLE
nv2a: Assert on unimplemented writable const register path

### DIFF
--- a/hw/xbox/nv2a/vsh.c
+++ b/hw/xbox/nv2a/vsh.c
@@ -424,7 +424,7 @@ static MString* decode_opcode(const uint32_t *shader_token,
 
         bool write_fog_register = false;
         if (vsh_get_field(shader_token, FLD_OUT_ORB) == OUTPUT_C) {
-            /* TODO : Emulate writeable const registers */
+            assert(!"TODO: Emulate writeable const registers");
             mstring_append(ret, "c");
             mstring_append_int(ret,
                 convert_c_register(
@@ -870,4 +870,3 @@ void vsh_translate(uint16_t version,
     );
 
 }
-


### PR DESCRIPTION
Produces a more meaningful error for the NHL 2002 shader compilation failure in #315

NHL2002 in particular seems to modify `c107` and then not use it, which makes me assume its value would persist across draws, so I think implementing this will need something more than trivial introduction of intermediary variables.