### PR TITLE
nv2a: Implement z16 float shadow comparison

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -299,6 +299,11 @@ static const ColorFormatInfo kelvin_color_format_map[66] = {
     [NV097_SET_TEXTURE_FORMAT_COLOR_LC_IMAGE_YB8CR8YA8CB8] =
         {2, true, GL_RGBA8,  GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV},
 
+    /* Additional information is passed to the pixel shader via the swizzle:
+     * RED: The depth value.
+     * GREEN: 0 for 16-bit, 1 for 24 bit
+     * BLUE: 0 for fixed, 1 for float
+     */
     [NV097_SET_TEXTURE_FORMAT_COLOR_SZ_DEPTH_Y16_FIXED] =
         {2, false, GL_DEPTH_COMPONENT16, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT,
          {GL_RED, GL_ZERO, GL_ZERO, GL_ZERO}, true},
@@ -313,8 +318,8 @@ static const ColorFormatInfo kelvin_color_format_map[66] = {
         {2, true, GL_DEPTH_COMPONENT16, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT,
          {GL_RED, GL_ZERO, GL_ZERO, GL_ZERO}, true},
     [NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_DEPTH_Y16_FLOAT] =
-        {2, true, GL_DEPTH_COMPONENT16, GL_DEPTH_COMPONENT, GL_FLOAT,
-          {GL_RED, GL_ZERO, GL_ZERO, GL_ZERO}, true},
+        {2, true, GL_DEPTH_COMPONENT16, GL_DEPTH_COMPONENT, GL_HALF_FLOAT,
+          {GL_RED, GL_ZERO, GL_ONE, GL_ZERO}, true},
 
     [NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_Y16] =
         {2, true, GL_R16, GL_RED, GL_UNSIGNED_SHORT,

--- a/hw/xbox/nv2a/psh.c
+++ b/hw/xbox/nv2a/psh.c
@@ -640,6 +640,8 @@ static void psh_append_shadowmap(const struct PixelShader *ps, int i, bool compa
                        i, i, i, i, i);
 
     const char *comparison = shadow_comparison_map[ps->state.shadow_depth_func];
+
+    // Depth.y != 0 indicates 24 bit; depth.z != 0 indicates float.
     if (compare_z) {
         mstring_append_fmt(
             vars,
@@ -647,13 +649,13 @@ static void psh_append_shadowmap(const struct PixelShader *ps, int i, bool compa
             "if (t%d_depth.y > 0) {\n"
             "  t%d_max_depth = 0xFFFFFF;\n"
             "} else {\n"
-            "  t%d_max_depth = 0xFFFF; // TODO: Support float max.\n"
+            "  t%d_max_depth = t%d_depth.z > 0 ? 511.9375 : 0xFFFF;\n"
             "}\n"
             "t%d_depth.x *= t%d_max_depth;\n"
             "pT%d.z = clamp(pT%d.z / pT%d.w, 0, t%d_max_depth);\n"
             "vec4 t%d = vec4(t%d_depth.x %s pT%d.z ? 1.0 : 0.0);\n",
             i, i, i, i, i,
-            i, i, i, i, i,
+            i, i, i, i, i, i,
             i, i, comparison, i);
     } else {
         mstring_append_fmt(


### PR DESCRIPTION
Fixes #829 

Before:
![master](https://user-images.githubusercontent.com/448413/171258289-da1a6eaf-cf83-41f6-a3e1-8c3ea46aae01.png)

After:
![pr](https://user-images.githubusercontent.com/448413/171258296-7750095c-08ec-4ed0-a1c1-8a1e5a4c70b7.png)
