### PR TITLE
ui: Make monitor text selectable

### DIFF
--- a/ui/xemu-monitor.c
+++ b/ui/xemu-monitor.c
@@ -35,8 +35,8 @@
 #define TYPE_CHARDEV_XEMU_MONITOR "chardev-xemu-monitor"
 
 static Chardev *mon_chr;
-static char mon_buffer[8*4096];
-static const size_t mon_buffer_size = 8*4096;
+static char mon_buffer[12*4096];
+static const size_t mon_buffer_size = sizeof(mon_buffer);
 static size_t offset;
 
 static void char_xemu_class_init(ObjectClass *oc, void *data);


### PR DESCRIPTION
ImGui has some unusual missing functionality around multiline text input, but that seems to be the only widget that would allow text selection. The alternative would be to add a button (or maybe a focus handler, I'm not that familiar w/ imgui) on the entire window that attempts to automatically copy to clipboard, but that feels like it'd be surprising to the user. Even as a frequent monitor user I still often reflexively try to select things and end up moving the window around.

This PR also bumps up the buffer size a bit; I ran into some issues where "help" commands were overflowing scrollback.