### PR TITLE
nv2a: Fix assert in single DrawArray + ArrayElement case

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -3210,11 +3210,11 @@ static void pgraph_expand_draw_arrays(NV2AState *d)
     if (pg->draw_arrays_length > 1) {
         pgraph_flush_draw(d);
     }
-
     assert((pg->inline_elements_length + count) < NV2A_MAX_BATCH_LENGTH);
     for (unsigned int i = 0; i < count; i++) {
         pg->inline_elements[pg->inline_elements_length++] = start + i;
     }
+    pg->draw_arrays_length = 0;
 }
 
 static void pgraph_check_within_begin_end_block(PGRAPHState *pg)


### PR DESCRIPTION
Missed an edge case in the tests, I assume this is what is triggering the newly reported asserts in 0.7.39.

[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/overlapping_draw_modes_tests.cpp#L233)
[HW Results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Overlapping_draw_modes)