### PR TITLE
ui: Rename Settings parameters to match Docs

### DIFF
--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -779,11 +779,11 @@ void MainMenuSystemView::Draw()
     }
 
     SectionTitle("Files");
-    if (FilePicker("Boot ROM", &g_config.sys.files.bootrom_path,
+    if (FilePicker("MCPX Boot ROM", &g_config.sys.files.bootrom_path,
                    rom_file_filters)) {
         m_dirty = true;
     }
-    if (FilePicker("Flash ROM", &g_config.sys.files.flashrom_path,
+    if (FilePicker("Flash ROM (BIOS)", &g_config.sys.files.flashrom_path,
                    rom_file_filters)) {
         m_dirty = true;
     }


### PR DESCRIPTION
FIxes: https://github.com/mborgerson/xemu/issues/1078

![immagine](https://user-images.githubusercontent.com/30447649/174485185-0fa49ad3-73ab-4e8d-9c0a-d47c5b70f93c.png)
