### PR TITLE
tomlplusplus: Allow using system library

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -838,9 +838,9 @@ if 'CONFIG_OPENGL' in config_host
 endif
 
 tomllib = static_library('tomlpp', sources: files('toml.cpp'),
-                         include_directories: 'tomlplusplus')
+                         include_directories: 'tomlplusplus/include')
 toml = declare_dependency(compile_args: ['-DTOML_HEADER_ONLY=0'],
-                          include_directories: 'tomlplusplus',
+                          include_directories: 'tomlplusplus/include',
                           link_with: tomllib)
 
 genconfig = declare_dependency(include_directories: 'genconfig')

--- a/toml.cpp
+++ b/toml.cpp
@@ -1,3 +1,3 @@
 #define TOML_HEADER_ONLY 0
 #define TOML_IMPLEMENTATION
-#include <toml.hpp>
+#include <toml++/toml.h>

--- a/ui/xemu-settings.cc
+++ b/ui/xemu-settings.cc
@@ -25,7 +25,7 @@
 #include <stdbool.h>
 #include <assert.h>
 #include <stdio.h>
-#include <toml.hpp>
+#include <toml++/toml.h>
 #include <cnode.h>
 #include <sstream>
 #include <iostream>


### PR DESCRIPTION
The `toml++` library as packaged by distros doesn't provide the single file `toml.hpp`, but only the directory `include/toml++`.

Also needs https://github.com/mborgerson/genconfig/pull/4.