### PR TITLE
nv2a: Stop passing ShaderState by value

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -4539,7 +4539,7 @@ static void pgraph_bind_shaders(PGRAPHState *pg)
     if (cached_shader) {
         pg->shader_binding = cached_shader;
     } else {
-        pg->shader_binding = generate_shaders(state);
+        pg->shader_binding = generate_shaders(&state);
         nv2a_profile_inc_counter(NV2A_PROF_SHADER_GEN);
 
         /* cache it */

--- a/hw/xbox/nv2a/shaders.h
+++ b/hw/xbox/nv2a/shaders.h
@@ -134,6 +134,6 @@ typedef struct ShaderBinding {
     GLint material_alpha_loc;
 } ShaderBinding;
 
-ShaderBinding* generate_shaders(const ShaderState state);
+ShaderBinding* generate_shaders(const ShaderState *state);
 
 #endif


### PR DESCRIPTION
Noticed this while working on #1086, based on the departure from xemu style I assume it was intended to be passed by a const pointer but the "*" was forgotten?