### PR TITLE
nv2a: Fallback to recreating texture on surface size mismatch.

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -5306,6 +5306,12 @@ static bool pgraph_check_surface_to_texture_compatibility(
 {
     // FIXME: Better checks/handling on formats and surface-texture compat
 
+    if (surface->pitch != shape->pitch ||
+        surface->width != shape->width ||
+        surface->height != shape->height) {
+        return false;
+    }
+
     int surface_fmt = surface->shape.color_format;
     int texture_fmt = shape->color_format;
 


### PR DESCRIPTION
There is no requirement that a surface and texture using the same VRAM address
match with respect to size (in particular pitch). This change prevents
incorrect reuse of a surface binding in the event that the texture size does
not match.

Fixes #1127

[Tests](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/antialiasing_tests.cpp)
[HW results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Antialiasing_tests)