### PR TITLE
nv2a: Handle framebuffer CPU blit and PVIDEO only rendering

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/display.c
+++ b/hw/xbox/nv2a/pgraph/gl/display.c
@@ -352,8 +352,9 @@ static void render_display(NV2AState *d, SurfaceBinding *surface)
     int framebuffer_bytes_per_pixel;
     get_vga_buffer_format(d, &format, &framebuffer_bytes_per_pixel);
 
-    if (surface && surface->color && surface->width == width &&
-        surface->height == height) {
+    if (surface && surface->color &&
+        surface->width * pg->surface_scale_factor == width &&
+        surface->height * pg->surface_scale_factor == height) {
         line_offset = vga_display_params.line_offset ?
                           surface->pitch / vga_display_params.line_offset :
                           1;

--- a/hw/xbox/nv2a/pgraph/gl/renderer.h
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.h
@@ -221,6 +221,7 @@ typedef struct PGRAPHGLState {
         GLuint display_size_loc;
         GLuint line_offset_loc;
         GLuint tex_loc;
+        GLuint vga_framebuffer_tex;
         GLuint pvideo_tex;
         GLint pvideo_enable_loc;
         GLint pvideo_tex_loc;
@@ -294,5 +295,16 @@ int pgraph_gl_get_framebuffer_surface(NV2AState *d);
 /**  Note: The caller must set up a clean GL context before invoking. */
 void pgraph_gl_determine_gpu_properties(void);
 GPUProperties *pgraph_gl_get_gpu_properties(void);
+void pgraph_gl_download_surfaces_in_range_if_dirty(PGRAPHState *pg,
+                                                   hwaddr start, hwaddr size);
+/**
+ * Uploads pixel data at vram_addr into the currently bound texture.
+ */
+void pgraph_gl_upload_vram_to_bound_texture(NV2AState *d, hwaddr vram_addr,
+                                            bool swizzle,
+                                            unsigned int surface_width,
+                                            unsigned int surface_height,
+                                            unsigned int pitch, size_t size,
+                                            const SurfaceFormatInfo *fmt);
 
 #endif

--- a/hw/xbox/nv2a/pgraph/gl/texture.c
+++ b/hw/xbox/nv2a/pgraph/gl/texture.c
@@ -302,15 +302,8 @@ void pgraph_gl_bind_textures(NV2AState *d)
             // FIXME: Restructure to support rendering surfaces to cubemap faces
 
             // Writeback any surfaces which this texture may index
-            hwaddr tex_vram_end = texture_vram_offset + length - 1;
-            QTAILQ_FOREACH(surface, &r->surfaces, entry) {
-                hwaddr surf_vram_end = surface->vram_addr + surface->size - 1;
-                bool overlapping = !(surface->vram_addr >= tex_vram_end
-                                     || texture_vram_offset >= surf_vram_end);
-                if (overlapping) {
-                    pgraph_gl_surface_download_if_dirty(d, surface);
-                }
-            }
+            pgraph_gl_download_surfaces_in_range_if_dirty(
+                pg, texture_vram_offset, length);
         }
 
         TextureKey key;


### PR DESCRIPTION
Handles two edge cases:
1) CPU blits to the framebuffer without using 3D rendering or after 3D rendering was previously done with a surface shape that does not match the framebuffer (e.g., a different pitch).
2) Fullscreen PVIDEO rendering without any 3D rendering.

In both cases this change prevents the pgraph code from returning early,
bypassing the special case VGA handling in `sdl2_gl_refresh` and instead
using a special framebuffer texture to render the contents of VRAM.

Fixes #652
Fixes #1165
Fixes #2220
Fixes #2443

[Tests](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/antialiasing_tests.cpp)
[HW results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Antialiasing_tests)

