### PR TITLE
nv2a: Fix incorrect use of bytes for GL_UNPACK_ROW_LENGTH

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -7216,7 +7216,7 @@ static void upload_gl_texture(GLenum gl_target,
                 unsigned int physical_width = (width + 3) & ~3,
                              physical_height = (height + 3) & ~3;
                 if (physical_width != width) {
-                    glPixelStorei(GL_UNPACK_ROW_LENGTH, physical_width * 4);
+                    glPixelStorei(GL_UNPACK_ROW_LENGTH, physical_width);
                 }
                 uint8_t *converted = decompress_2d_texture_data(
                     f.gl_internal_format, texture_data, physical_width,


### PR DESCRIPTION
`GL_UNPACK_ROW_LENGTH` is supposed to set the length in pixels, but the DXT
path is setting it to bytes, causing it to read beyond the end of the texture.
[Reference](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glPixelStore.xhtml)

Fixes #1002

[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/texture_format_dxt_tests.cpp)
[HW Results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Texture_DXT)