### PR TITLE
nv2a: Handle value in NV_PVIDEO_STOP writes

### DIFF
--- a/hw/xbox/nv2a/pvideo.c
+++ b/hw/xbox/nv2a/pvideo.c
@@ -62,7 +62,11 @@ void pvideo_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
         pvideo_vga_invalidate(d);
         break;
     case NV_PVIDEO_STOP:
-        d->pvideo.regs[NV_PVIDEO_BUFFER] = 0;
+        // PVIDEO_STOP may be set many times during the course of video playback
+        // but the overlay is only torn down if the 0th bit is 1.
+        if (val & 0x01) {
+            d->pvideo.regs[NV_PVIDEO_BUFFER] = 0;
+        }
         // d->vga.enable_overlay = false;
         pvideo_vga_invalidate(d);
         break;


### PR DESCRIPTION
Interprets the value written to the `NV_PVIDEO_STOP` register in a manner more
consistent with hardware. Specifically, if the low bit of the value is not set,
the PVIDEO overlay should remain active.

Fixes #1049

[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/pvideo_tests.cpp)
Note that, as this is testing video behavior, this test is interactive and
the value passed to the final SetPvideoStop call needs to be mutated and the
behavior observed.