### PR TITLE
nv2a: Handles depth borders in 3D bordered textures

### DIFF
--- a/hw/xbox/nv2a/psh.c
+++ b/hw/xbox/nv2a/psh.c
@@ -679,10 +679,10 @@ static void apply_border_adjustment(const struct PixelShader *ps, MString *vars,
 
     mstring_append_fmt(
         vars,
-        "vec2 t%dLogicalSize = vec2(%f, %f);\n"
-        "%s.xy = (%s.xy * t%dLogicalSize + vec2(4, 4)) * vec2(%f, %f);\n",
-        i, ps->state.border_logical_size[i][0], ps->state.border_logical_size[i][1],
-        var_name, var_name, i, ps->state.border_inv_real_size[i][0], ps->state.border_inv_real_size[i][1]);
+        "vec3 t%dLogicalSize = vec3(%f, %f, %f);\n"
+        "%s.xyz = (%s.xyz * t%dLogicalSize + vec3(4, 4, 4)) * vec3(%f, %f, %f);\n",
+        i, ps->state.border_logical_size[i][0], ps->state.border_logical_size[i][1], ps->state.border_logical_size[i][2],
+        var_name, var_name, i, ps->state.border_inv_real_size[i][0], ps->state.border_inv_real_size[i][1], ps->state.border_inv_real_size[i][2]);
 }
 
 static MString* psh_convert(struct PixelShader *ps)

--- a/hw/xbox/nv2a/psh.h
+++ b/hw/xbox/nv2a/psh.h
@@ -68,8 +68,8 @@ typedef struct PshState {
     bool alphakill[4];
     enum ConvolutionFilter conv_tex[4];
 
-    float border_logical_size[4][2];
-    float border_inv_real_size[4][2];
+    float border_logical_size[4][3];
+    float border_inv_real_size[4][3];
 
     bool shadow_map[4];
     enum PshShadowDepthFunc shadow_depth_func;


### PR DESCRIPTION
3D textures with texture borders have 4 layers of border on either side of the
content layers in addition to the normal 4 pixel border per layer. This change
handles those extra depth layers in roughly the same way that the per-layer
border texels are handled.

Fixes #1171

[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/texture_border_tests.cpp)
[HW results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Texture_border)