### PR TITLE
nv2a: Handle SIZE_IN > SIZE_OUT case

### DIFF
--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -278,6 +278,7 @@ static void nv2a_reset(NV2AState *d)
 
     memset(d->pfifo.regs, 0, sizeof(d->pfifo.regs));
     memset(d->pgraph.regs, 0, sizeof(d->pgraph.regs));
+    memset(d->pvideo.regs, 0, sizeof(d->pvideo.regs));
 
     d->pcrtc.start = 0;
     d->pramdac.core_clock_coeff = 0x00011C01; /* 189MHz...? */

--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -266,7 +266,9 @@ typedef struct PGRAPHState {
         GLuint pvideo_tex;
         GLint pvideo_enable_loc;
         GLint pvideo_tex_loc;
+        GLint pvideo_in_pos_loc;
         GLint pvideo_pos_loc;
+        GLint pvideo_scale_loc;
         GLint pvideo_color_key_enable_loc;
         GLint pvideo_color_key_loc;
         GLint palette_loc[256];

--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -655,6 +655,7 @@
 #   define NV_PVIDEO_POINT_IN_T                               0xFFFE0000
 #define NV_PVIDEO_DS_DX                                  0x00000938
 #define NV_PVIDEO_DT_DY                                  0x00000940
+#   define NV_PVIDEO_DIN_DOUT_UNITY                           0x00100000
 #define NV_PVIDEO_POINT_OUT                              0x00000948
 #   define NV_PVIDEO_POINT_OUT_X                              0x00000FFF
 #   define NV_PVIDEO_POINT_OUT_Y                              0x0FFF0000

--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -5068,7 +5068,17 @@ static void pgraph_render_display_pvideo_overlay(NV2AState *d)
 {
     PGRAPHState *pg = &d->pgraph;
 
-    bool enabled = d->pvideo.regs[NV_PVIDEO_BUFFER] & NV_PVIDEO_BUFFER_0_USE;
+    // FIXME: This check against PVIDEO_SIZE_IN does not match HW behavior.
+    // Many games seem to pass this value when initializing or tearing down
+    // PVIDEO. On its own, this generally does not result in the overlay being
+    // hidden, however there are certain games (e.g., Ultimate Beach Soccer)
+    // that use an unknown mechanism to hide the overlay without explicitly
+    // stopping it.
+    // Since the value seems to be set to 0xFFFFFFFF only in cases where the
+    // content is not valid, it is probably good enough to treat it as an
+    // implicit stop. 
+    bool enabled = (d->pvideo.regs[NV_PVIDEO_BUFFER] & NV_PVIDEO_BUFFER_0_USE)
+        && d->pvideo.regs[NV_PVIDEO_SIZE_IN] != 0xFFFFFFFF;
     glUniform1ui(d->pgraph.disp_rndr.pvideo_enable_loc, enabled);
     if (!enabled) {
         return;


### PR DESCRIPTION
`NV_PVIDEO_SIZE_IN` is set to 0xFFFFFFFF during initialization and teardown of the PVIDEO overlay. In some cases this can happen before the overlay is explicitly stopped, leading to an assert.

On hardware any SIZE_IN > SIZE_OUT is silently capped to SIZE_OUT.

Fixes #330

[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/pvideo_tests.cpp)