### PR TITLE
nv2a: Fix missing flat qualifier for inv_w param

### DIFF
--- a/hw/xbox/nv2a/psh.c
+++ b/hw/xbox/nv2a/psh.c
@@ -801,10 +801,17 @@ static MString* psh_convert(struct PixelShader *ps)
 
     /* calculate perspective-correct inputs */
     MString *vars = mstring_new();
-    mstring_append(vars, "vec4 pD0 = vtxD0 / vtx_inv_w;\n");
-    mstring_append(vars, "vec4 pD1 = vtxD1 / vtx_inv_w;\n");
-    mstring_append(vars, "vec4 pB0 = vtxB0 / vtx_inv_w;\n");
-    mstring_append(vars, "vec4 pB1 = vtxB1 / vtx_inv_w;\n");
+    if (ps->state.smooth_shading) {
+        mstring_append(vars, "vec4 pD0 = vtxD0 / vtx_inv_w;\n");
+        mstring_append(vars, "vec4 pD1 = vtxD1 / vtx_inv_w;\n");
+        mstring_append(vars, "vec4 pB0 = vtxB0 / vtx_inv_w;\n");
+        mstring_append(vars, "vec4 pB1 = vtxB1 / vtx_inv_w;\n");
+    } else {
+        mstring_append(vars, "vec4 pD0 = vtxD0 / vtx_inv_w_flat;\n");
+        mstring_append(vars, "vec4 pD1 = vtxD1 / vtx_inv_w_flat;\n");
+        mstring_append(vars, "vec4 pB0 = vtxB0 / vtx_inv_w_flat;\n");
+        mstring_append(vars, "vec4 pB1 = vtxB1 / vtx_inv_w_flat;\n");
+    }
     mstring_append(vars, "vec4 pFog = vec4(fogColor.rgb, clamp(vtxFog / vtx_inv_w, 0.0, 1.0));\n");
     mstring_append(vars, "vec4 pT0 = vtxT0 / vtx_inv_w;\n");
     mstring_append(vars, "vec4 pT1 = vtxT1 / vtx_inv_w;\n");

--- a/hw/xbox/nv2a/shaders.c
+++ b/hw/xbox/nv2a/shaders.c
@@ -262,7 +262,7 @@ static MString* generate_geometry_shader(
                        "void emit_vertex(int index, int provoking_index) {\n"
                        "  gl_Position = gl_in[index].gl_Position;\n"
                        "  gl_PointSize = gl_in[index].gl_PointSize;\n"
-                       "  vtx_inv_w = v_vtx_inv_w[index];\n"
+                       "  vtx_inv_w = v_vtx_inv_w[provoking_index];\n"
                        "  vtxD0 = v_vtxD0[provoking_index];\n"
                        "  vtxD1 = v_vtxD1[provoking_index];\n"
                        "  vtxB0 = v_vtxB0[provoking_index];\n"

--- a/hw/xbox/nv2a/shaders_common.h
+++ b/hw/xbox/nv2a/shaders_common.h
@@ -24,7 +24,8 @@
 #include "debug.h"
 
 #define DEF_VERTEX_DATA(qualifier, in_out, prefix, suffix) \
-    qualifier " " in_out " float " prefix "vtx_inv_w" suffix ";\n" \
+    "noperspective " in_out " float " prefix "vtx_inv_w" suffix ";\n" \
+    "flat " in_out " float " prefix "vtx_inv_w_flat" suffix ";\n" \
     qualifier " " in_out " vec4 " prefix "vtxD0" suffix ";\n" \
     qualifier " " in_out " vec4 " prefix "vtxD1" suffix ";\n" \
     qualifier " " in_out " vec4 " prefix "vtxB0" suffix ";\n" \

--- a/hw/xbox/nv2a/shaders_common.h
+++ b/hw/xbox/nv2a/shaders_common.h
@@ -24,7 +24,7 @@
 #include "debug.h"
 
 #define DEF_VERTEX_DATA(qualifier, in_out, prefix, suffix) \
-    "noperspective " in_out " float " prefix "vtx_inv_w" suffix ";\n" \
+    qualifier " " in_out " float " prefix "vtx_inv_w" suffix ";\n" \
     qualifier " " in_out " vec4 " prefix "vtxD0" suffix ";\n" \
     qualifier " " in_out " vec4 " prefix "vtxD1" suffix ";\n" \
     qualifier " " in_out " vec4 " prefix "vtxB0" suffix ";\n" \

--- a/hw/xbox/nv2a/vsh.c
+++ b/hw/xbox/nv2a/vsh.c
@@ -825,6 +825,7 @@ void vsh_translate(uint16_t version,
         "  } else {\n"
         "    vtx_inv_w = 1.0 / oPos.w;\n"
         "  }\n"
+        "  vtx_inv_w_flat = vtx_inv_w;\n"
     );
 
     mstring_append(body,


### PR DESCRIPTION
`vtx_inv_w` should also be flat, since interpolating it causes incorrect values
for the flat shaded colors.

Fixes #1179

[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/shade_model_tests.cpp)
[HW results](https://github.com/abaire/nxdk_pgraph_tests_golden_results/wiki/Results-Shade_model)