### PR TITLE
vl: Initialize usb daughterboard at machine start

### DIFF
--- a/softmmu/vl.c
+++ b/softmmu/vl.c
@@ -2966,6 +2966,10 @@ void qemu_init(int argc, char **argv, char **envp)
     fake_argv[fake_argc++] = strdup("-display");
     fake_argv[fake_argc++] = strdup("xemu");
 
+    // Create USB Daughterboard for 1.0 Xbox. This is connected to Port 1 of the Root hub.
+    fake_argv[fake_argc++] = strdup("-device");
+    fake_argv[fake_argc++] = strdup("usb-hub,port=1,ports=4");
+
 #ifdef _WIN32
     // FIXME: Create this dummy device to prevent logspam
     fake_argv[fake_argc++] = strdup("-audiodev");

--- a/ui/xemu-input.c
+++ b/ui/xemu-input.c
@@ -148,15 +148,6 @@ void xemu_input_init(void)
         }
     }
 
-    // Create USB Daughterboard for 1.0 Xbox. This is connected to Port 1 of the Root hub.
-    QDict *usbhub_qdict = qdict_new();
-    qdict_put_str(usbhub_qdict, "driver", "usb-hub");
-    qdict_put_int(usbhub_qdict, "port", 1);
-    qdict_put_int(usbhub_qdict, "ports", 4);
-    QemuOpts *usbhub_opts = qemu_opts_from_qdict(qemu_find_opts("device"), usbhub_qdict, &error_fatal);
-    DeviceState *usbhub_dev = qdev_device_add(usbhub_opts, &error_fatal);
-    assert(usbhub_dev);
-
     // Check to see if we should auto-bind the keyboard
     int port = xemu_input_get_controller_default_bind_port(new_con, 0);
     if (port >= 0) {


### PR DESCRIPTION
Creating the USB daughterboard when the UI initializes input prevents `-device` command line arguments from working correctly (as the daughterboard does not exist when they are parsed, they will not succeed).

Moving this into `vl.c` creates the device on machine start, so the ports will be available for other `-device` commands to use immediately.