### PR TITLE
ui: Display MCPX, BIOS md5 hashes in About view

### DIFF
--- a/ui/xui/main-menu.hh
+++ b/ui/xui/main-menu.hh
@@ -120,7 +120,11 @@ public:
 
 class MainMenuAboutView : public virtual MainMenuTabView
 {
+protected:
+    char *m_config_info_text;
 public:
+    MainMenuAboutView();
+    void UpdateConfigInfoText();
     void Draw() override;
 };
 
@@ -179,6 +183,7 @@ public:
     bool IsAnimating() override;
     void SetNextViewIndex(int i);
     void HandleInput();
+    void UpdateAboutViewConfigInfo();
     bool Draw() override;
 };
 

--- a/ui/xui/misc.hh
+++ b/ui/xui/misc.hh
@@ -104,3 +104,23 @@ int PushWindowTransparencySettings(bool transparent, float alpha_transparent = 0
 
         return 5;
 }
+
+static inline gchar *GetFileMD5Checksum(const char *path)
+{
+    auto *checksum = g_checksum_new(G_CHECKSUM_MD5);
+
+    auto *file = qemu_fopen(path, "rb");
+    if (!file) return nullptr;
+
+    guchar buf[512];
+    size_t nread;
+    while ((nread = fread(buf, 1, sizeof(buf), file))) {
+        g_checksum_update(checksum, buf, nread);
+    }
+
+    gchar *checksum_str = g_strdup(g_checksum_get_string(checksum));
+    fclose(file);
+    g_checksum_free(checksum);
+    return checksum_str;
+}
+


### PR DESCRIPTION
Displays the hashes of the MCPX and BIOS ROM files (if available) in the about view. Should remove the need for users to determine this hash themselves in the event that they are debugging mismatched or corrupted ROM files.