### PR TITLE
build: optimize for x86-64-v3 rather than ivybridge

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -231,7 +231,7 @@ case "$platform" in # Adjust compilation options based on platform
         export LDFLAGS="-arch ${target_arch} \
                         -isysroot ${sdk}"
         if [ "$target_arch" == "x86_64" ]; then
-            sys_cflags='-march=ivybridge'
+            sys_cflags='-march=x86-64-v3'
         fi
         sys_ldflags='-headerpad_max_install_names'
         export PKG_CONFIG_PATH="${lib_prefix}/lib/pkgconfig"


### PR DESCRIPTION
This optimizes for a generic x64 target with `AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT, MOVBE, XSAVE x86-64-v4: AVX512F, AVX512BW, AVX512CD, AVX512DQ, AVX512VL` rather than Ivy Bridge specifically

This should prevent Intel specific optimisations that harm AMD processors, while still taking advantage of newer instruction sets.

Note that this does require at least GCC11 or CLANG12, so it may not build with older toolchains.