### PR TITLE
UX: Temporarily disable DSP toggle

### DIFF
--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -351,10 +351,16 @@ void MainMenuAudioView::Draw()
              (int)(g_config.audio.volume_limit * 100));
     Slider("Output volume limit", &g_config.audio.volume_limit, buf);
 
+    if (g_config.audio.use_dsp) {
+        g_config.audio.use_dsp = false;
+    }
+    
+    /*
+    FIXME: DSP Emulation implementation.
     SectionTitle("Quality");
     Toggle("Real-time DSP processing", &g_config.audio.use_dsp,
            "Enable improved audio accuracy (experimental)");
-
+    */
 }
 
 NetworkInterface::NetworkInterface(pcap_if_t *pcap_desc, char *_friendlyname)


### PR DESCRIPTION
A lot of times the user reports crashes regarding xemu, mostly because it enables the DSP option which is not implemented yet. To avoid this i've temporarily disabled the DSP toggle by commenting the code, and resetting the `use_dsp` flag to false just in case in a previous boot it was activated.

![DSP](https://user-images.githubusercontent.com/30447649/207833316-cc28e215-2012-4d95-85df-0c483e79998f.jpg)
