### PR TITLE
UI: Hide mouse cursor option

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -136,6 +136,9 @@ display:
     show_notifications:
       type: bool
       default: true
+    hide_cursor:
+      type: bool
+      default: true
     use_animations:
       type: bool
       default: true

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -316,6 +316,8 @@ void MainMenuDisplayView::Draw()
            "Show main menu bar when mouse is activated");
     Toggle("Show notifications", &g_config.display.ui.show_notifications,
            "Display notifications in upper-right corner");
+    Toggle("Hide mouse cursor", &g_config.display.ui.hide_cursor,
+           "Hide the mouse cursor when it is not moving");
 
     int ui_scale_idx;
     if (g_config.display.ui.auto_scale) {

--- a/ui/xui/main.cc
+++ b/ui/xui/main.cc
@@ -256,6 +256,16 @@ void xemu_hud_render(void)
         }
     }
 
+    static uint32_t last_mouse_move = 0;
+    if (g_input_mgr.MouseMoved()) {
+        last_mouse_move = now;
+    }
+
+    // FIXME: Handle time wrap around
+    if (g_config.display.ui.hide_cursor && (now - last_mouse_move) > 3000) {
+        ImGui::SetMouseCursor(ImGuiMouseCursor_None);
+    }
+
     if (!ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow) &&
         !g_scene_mgr.IsDisplayingScene()) {
 


### PR DESCRIPTION
Fixes #825 

Hides the cursor when option is enabled and outside of UI:



https://user-images.githubusercontent.com/30447649/212203521-c04e0454-9d48-469f-bcea-58c00f5d53f0.mp4


