### PR TITLE
ci: Pin macOS runner to macOS-11 for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
 
   macOS:
     name: Build for macOS (${{ matrix.arch }}, ${{ matrix.configuration }})
-    runs-on: macOS-latest
+    runs-on: macOS-11
     needs: Init
     strategy:
       matrix:
@@ -258,7 +258,7 @@ jobs:
 
   macOSUniversal:
     name: Build macOS Universal Bundle (${{ matrix.configuration }})
-    runs-on: macOS-latest
+    runs-on: macOS-11
     needs: [macOS]
     strategy:
       matrix:


### PR DESCRIPTION
Apparently GitHub has decided to [migrate this repo's `macOS-latest` tag to `macOS-12`](https://github.com/actions/runner-images/issues/6384), which has some build issues to fix. Pin it to `macOS-11` until I have a chance to resolve the issues.