### PR TITLE
ci: Use bot to push releases and trigger site update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -347,6 +347,7 @@ jobs:
     - name: Publish release
       uses: softprops/action-gh-release@v1
       with:
+        token: ${{ secrets.XEMU_ROBOT_TOKEN }}
         tag_name: v${{ env.XEMU_VERSION }}
         name: v${{ env.XEMU_VERSION }}
         prerelease: false

--- a/.github/workflows/trigger-website-update.yml
+++ b/.github/workflows/trigger-website-update.yml
@@ -13,5 +13,5 @@ jobs:
       with:
         workflow: build.yml
         repo: xemu-project/xemu-website
-        token: ${{ secrets.XEMU_WEBSITE_TOKEN }}
+        token: ${{ secrets.XEMU_ROBOT_TOKEN }}
         ref: master


### PR DESCRIPTION
Apparently using the default actions token will not allow triggering workflows. Use bot access token instead to publish the release.