### PR TITLE
nv2a: Offset vertices to match HW rounding

### DIFF
--- a/hw/xbox/nv2a/shaders.c
+++ b/hw/xbox/nv2a/shaders.c
@@ -753,7 +753,9 @@ GLSL_DEFINE(materialEmissionColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_CM_COL) ".xyz
     }
 
     mstring_append(body,
-    "   oPos = invViewport * (tPosition * compositeMat);\n"
+    "   oPos = tPosition * compositeMat;\n"
+    "   oPos.xy = adjust_pixel_center(oPos.xy, oPos.w);\n"
+    "   oPos = invViewport * oPos;\n"
     "   oPos.z = oPos.z * 2.0 - oPos.w;\n");
 
     /* FIXME: Testing */
@@ -856,6 +858,26 @@ GLSL_DEFINE(texMat3, GLSL_C_MAT4(NV_IGRAPH_XF_XFCTX_T3MAT))
         }
     }
     mstring_append(header, "\n");
+
+    mstring_append_fmt(header, "\n"
+            "vec2 adjust_pixel_center(vec2 screen_pos, float w) {\n"
+            "  if (w == 0.0 || isinf(w)) {\n"
+            "    w = 1.0;\n"
+            "  }\n"
+
+            "  screen_pos /= w;\n"
+            "  vec2 pixel = floor(screen_pos);\n"
+            "  vec2 subpixel = screen_pos - pixel;\n"
+            "  vec2 round_down = vec2(lessThan(subpixel, vec2(0.5625)));\n"
+
+            "  subpixel -= vec2(0.0625);\n"
+
+            "  vec2 bias = vec2(0.002);\n"
+            "  subpixel += mix(bias, -bias, round_down);\n"
+
+            "  return w * (pixel + subpixel);\n"
+            "}\n"
+            );
 
     MString *body = mstring_from_str("void main() {\n");
 
@@ -985,12 +1007,10 @@ GLSL_DEFINE(texMat3, GLSL_C_MAT4(NV_IGRAPH_XF_XFCTX_T3MAT))
                        shade_model_mult,
                        shade_model_mult);
 
-
     /* Return combined header + source */
     mstring_append(header, mstring_get_str(body));
     mstring_unref(body);
     return header;
-
 }
 
 static GLuint create_gl_shader(GLenum gl_shader_type,

--- a/hw/xbox/nv2a/vsh.c
+++ b/hw/xbox/nv2a/vsh.c
@@ -840,10 +840,9 @@ void vsh_translate(uint16_t version,
     mstring_append(body,
         /* the shaders leave the result in screen space, while
          * opengl expects it in clip space.
-         * TODO: the pixel-center co-ordinate differences should handled
          */
-        "  oPos.x = 2.0 * (oPos.x - surfaceSize.x * 0.5) / surfaceSize.x;\n"
-        "  oPos.y = -2.0 * (oPos.y - surfaceSize.y * 0.5) / surfaceSize.y;\n"
+        "  oPos.xy = 2.0 * adjust_pixel_center(oPos.xy, 1.0) / surfaceSize - vec2(1.0);\n"
+        "  oPos.y *= -1;\n"
     );
     if (z_perspective) {
         mstring_append(body, "  oPos.z = oPos.w;\n");


### PR DESCRIPTION
This is a continuation of the work done in #735 . Hardware will round vertices at 0.5625 instead of OpenGL's 0.5.

The approach taken in this PR shifts each vertex up and to the left by 0.0625, so that the HW rounding point 0.5625 is mapped to 0.5. A small bias is then added based on whether the subpixel was above or below the boundary, to correct for precision errors. This passes all but one of the [test cases](https://github.com/abaire/nxdk_pgraph_tests/blob/main/src/tests/vertex_shader_rounding_tests.cpp) that abaire made (specifically, the projected adjacent geometry test with a bias of 0.5625 is not entirely matching HW), which is why I'm leaving it in draft for now.

This approach does not work at resolution scales higher than 1x. I'm not sure that there is a general solution that both works above 1x and does not introduce z-fighting or flickering.

Known Issues:

- [ ]  Morrowind Water