### PR TITLE
UX: Add Overclock setting and Override CPU clock-speed setting

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -253,3 +253,9 @@ perf:
   cache_shaders:
     type: bool
     default: true
+  override_clockspeed: 
+    type: bool
+    default: false
+  cpu_clockspeed:
+    type: number
+    default: 0.5

--- a/config_spec.yml
+++ b/config_spec.yml
@@ -258,4 +258,4 @@ perf:
     default: false
   cpu_clockspeed:
     type: number
-    default: 0.5
+    default: 1

--- a/config_spec.yml
+++ b/config_spec.yml
@@ -256,6 +256,6 @@ perf:
   override_clockspeed: 
     type: bool
     default: false
-  cpu_clockspeed:
+  cpu_clockspeed_scale:
     type: number
     default: 1

--- a/hw/i386/x86.c
+++ b/hw/i386/x86.c
@@ -541,6 +541,7 @@ uint64_t cpu_get_tsc(CPUX86State *env)
     
     if (g_config.perf.override_clockspeed) {
         cpu_clock_hz *= clock_multiplier;
+        printf(clock_multiplier)
     }
     printf(cpu_clock_hz)
     return muldiv64(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL), cpu_clock_hz, NANOSECONDS_PER_SECOND);

--- a/hw/i386/x86.c
+++ b/hw/i386/x86.c
@@ -540,13 +540,11 @@ uint64_t cpu_get_tsc(CPUX86State *env)
     float OVERCLOCK_VALUE = g_config.perf.cpu_clockspeed; /* 0.5 is 100% */
     float PERCENTAGE_OUTPUT = OVERCLOCK_VALUE * 2;
     
+    float cpu_clock_hz = 733333333;
     if (g_config.perf.override_clockspeed) {
-        float clockOutput = DEFAULT_CPU_CLOCK * PERCENTAGE_OUTPUT;
-        return muldiv64(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL), clockOutput, NANOSECONDS_PER_SECOND);
-    } else {
-        float clockOutput = DEFAULT_CPU_CLOCK;
-        return muldiv64(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL), clockOutput, NANOSECONDS_PER_SECOND);
+      cpu_clock_hz *= clock_multiplier;
     }
+    return muldiv64(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL), cpu_clock_hz, NANOSECONDS_PER_SECOND);
 #else
     return cpus_get_elapsed_ticks();
 #endif

--- a/hw/i386/x86.c
+++ b/hw/i386/x86.c
@@ -541,9 +541,9 @@ uint64_t cpu_get_tsc(CPUX86State *env)
     
     if (g_config.perf.override_clockspeed) {
         cpu_clock_hz *= clock_multiplier;
-        printf(clock_multiplier)
+        printf(clock_multiplier);
     }
-    printf(cpu_clock_hz)
+    printf(cpu_clock_hz);
     return muldiv64(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL), cpu_clock_hz, NANOSECONDS_PER_SECOND);
 #else
     return cpus_get_elapsed_ticks();

--- a/hw/i386/x86.c
+++ b/hw/i386/x86.c
@@ -536,8 +536,8 @@ static long get_file_size(FILE *f)
 uint64_t cpu_get_tsc(CPUX86State *env)
 {
 #ifdef XBOX
-    float clock_multiplier = g_config.perf.cpu_clockspeed * 2.0;
-    float cpu_clock_hz = 733333333.0;
+    float clock_multiplier = g_config.perf.cpu_clockspeed;
+    int cpu_clock_hz = 733333333;
     
     if (g_config.perf.override_clockspeed) {
         cpu_clock_hz *= clock_multiplier;

--- a/hw/i386/x86.c
+++ b/hw/i386/x86.c
@@ -59,8 +59,9 @@
 #include CONFIG_DEVICES
 #include "kvm/kvm_i386.h"
 
+#ifdef XBOX
 #include "ui/xemu-settings.h"
-
+#endif
 
 /* Physical Address of PVH entry point read from kernel ELF NOTE */
 static size_t pvh_start_addr;
@@ -535,14 +536,12 @@ static long get_file_size(FILE *f)
 uint64_t cpu_get_tsc(CPUX86State *env)
 {
 #ifdef XBOX
-    int DEFAULT_CPU_CLOCK = 733333333; /* 733333333 hz */
-    float clockOutput;
-    float OVERCLOCK_VALUE = g_config.perf.cpu_clockspeed; /* 0.5 is 100% */
-    float PERCENTAGE_OUTPUT = OVERCLOCK_VALUE * 2;
-    
+    float clockOutput; 
+    float clock_multiplier = g_config.perf.cpu_clockspeed * 2;
     float cpu_clock_hz = 733333333;
+    
     if (g_config.perf.override_clockspeed) {
-      cpu_clock_hz *= clock_multiplier;
+        cpu_clock_hz *= clock_multiplier;
     }
     return muldiv64(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL), cpu_clock_hz, NANOSECONDS_PER_SECOND);
 #else

--- a/hw/i386/x86.c
+++ b/hw/i386/x86.c
@@ -541,9 +541,7 @@ uint64_t cpu_get_tsc(CPUX86State *env)
     
     if (g_config.perf.override_clockspeed) {
         cpu_clock_hz *= clock_multiplier;
-        printf(clock_multiplier);
     }
-    printf(cpu_clock_hz);
     return muldiv64(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL), cpu_clock_hz, NANOSECONDS_PER_SECOND);
 #else
     return cpus_get_elapsed_ticks();

--- a/hw/i386/x86.c
+++ b/hw/i386/x86.c
@@ -536,7 +536,6 @@ static long get_file_size(FILE *f)
 uint64_t cpu_get_tsc(CPUX86State *env)
 {
 #ifdef XBOX
-    float clockOutput; 
     float clock_multiplier = g_config.perf.cpu_clockspeed * 2;
     float cpu_clock_hz = 733333333;
     

--- a/hw/i386/x86.c
+++ b/hw/i386/x86.c
@@ -536,11 +536,10 @@ static long get_file_size(FILE *f)
 uint64_t cpu_get_tsc(CPUX86State *env)
 {
 #ifdef XBOX
-    float clock_multiplier = g_config.perf.cpu_clockspeed;
     int cpu_clock_hz = 733333333;
     
     if (g_config.perf.override_clockspeed) {
-        cpu_clock_hz *= clock_multiplier;
+        cpu_clock_hz *= g_config.perf.cpu_clockspeed_scale;
     }
     return muldiv64(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL), cpu_clock_hz, NANOSECONDS_PER_SECOND);
 #else

--- a/hw/i386/x86.c
+++ b/hw/i386/x86.c
@@ -536,12 +536,13 @@ static long get_file_size(FILE *f)
 uint64_t cpu_get_tsc(CPUX86State *env)
 {
 #ifdef XBOX
-    float clock_multiplier = g_config.perf.cpu_clockspeed * 2;
-    float cpu_clock_hz = 733333333;
+    float clock_multiplier = g_config.perf.cpu_clockspeed * 2.0;
+    float cpu_clock_hz = 733333333.0;
     
     if (g_config.perf.override_clockspeed) {
         cpu_clock_hz *= clock_multiplier;
     }
+    printf(cpu_clock_hz)
     return muldiv64(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL), cpu_clock_hz, NANOSECONDS_PER_SECOND);
 #else
     return cpus_get_elapsed_ticks();

--- a/ui/xui/compat.cc
+++ b/ui/xui/compat.cc
@@ -218,9 +218,8 @@ void CompatibilityReporter::Draw()
             is_open = false;
         }
     }
-    if (g_config.perf.override_clockspeed)
-    {
-        ImGui::Text("Reports using Emulated CPU clock override is not allowed.");
+    if (g_config.perf.override_clockspeed) {
+        ImGui::Text("Reports cannot be made while using altered CPU clock speeds");
         ImGui::PopItemFlag();
         ImGui::PopStyleVar();
     }

--- a/ui/xui/compat.cc
+++ b/ui/xui/compat.cc
@@ -206,8 +206,7 @@ void CompatibilityReporter::Draw()
     ImGui::SetCursorPosX(ImGui::GetWindowWidth()-(120+10)*g_viewport_mgr.m_scale);
 
     ImGui::SetItemDefaultFocus();
-    if (g_config.perf.override_clockspeed)
-    {
+    if (g_config.perf.override_clockspeed) {
         ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
         ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
     }

--- a/ui/xui/compat.cc
+++ b/ui/xui/compat.cc
@@ -203,13 +203,17 @@ void CompatibilityReporter::Draw()
         ImGui::SameLine();
     }
 
-    ImGui::SetCursorPosX(ImGui::GetWindowWidth()-(120+10)*g_viewport_mgr.m_scale);
-
-    ImGui::SetItemDefaultFocus();
     if (g_config.perf.override_clockspeed) {
         ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
         ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+
+        ImGui::Text("Reports cannot be made while using altered CPU clock speeds");
+        ImGui::SameLine();
     }
+
+    ImGui::SetCursorPosX(ImGui::GetWindowWidth()-(120+10)*g_viewport_mgr.m_scale);
+
+    ImGui::SetItemDefaultFocus();
     if (ImGui::Button("Send", ImVec2(120*g_viewport_mgr.m_scale, 0))) {
         did_send = true;
         send_result = report.Send();

--- a/ui/xui/compat.cc
+++ b/ui/xui/compat.cc
@@ -206,6 +206,11 @@ void CompatibilityReporter::Draw()
     ImGui::SetCursorPosX(ImGui::GetWindowWidth()-(120+10)*g_viewport_mgr.m_scale);
 
     ImGui::SetItemDefaultFocus();
+    if (g_config.perf.override_clockspeed)
+    {
+        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+        ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+    }
     if (ImGui::Button("Send", ImVec2(120*g_viewport_mgr.m_scale, 0))) {
         did_send = true;
         send_result = report.Send();
@@ -213,7 +218,12 @@ void CompatibilityReporter::Draw()
             is_open = false;
         }
     }
-
+    if (g_config.perf.override_clockspeed)
+    {
+        ImGui::Text("Reports using Emulated CPU clock override is not allowed.");
+        ImGui::PopItemFlag();
+        ImGui::PopStyleVar();
+    }
     ImGui::End();
 }
 

--- a/ui/xui/compat.cc
+++ b/ui/xui/compat.cc
@@ -222,7 +222,6 @@ void CompatibilityReporter::Draw()
         }
     }
     if (g_config.perf.override_clockspeed) {
-        ImGui::Text("Reports cannot be made while using altered CPU clock speeds");
         ImGui::PopItemFlag();
         ImGui::PopStyleVar();
     }

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -73,8 +73,7 @@ void MainMenuGeneralView::Draw()
 
 
     
-    snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)",
-             (int)(g_config.perf.cpu_clockspeed * 200), (733333333.0 * g_config.perf.cpu_clockspeed * 2.0)/1000000);
+    snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 100), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
     Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf);
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,13 +70,15 @@ void MainMenuGeneralView::Draw()
            "Enables to override default CPU clock speed");
     
     char buf[32];
-
+    float min = 0.01;
+    float max = 2;
+    float gpspeed = 0.01;
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 100), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf);
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, min , max, gpspeed, buf);
 
-    if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
+    if ((g_config.perf.cpu_clockspeed-0.999)*(g_config.perf.cpu_clockspeed-1.009) <= 0) {g_config.perf.cpu_clockspeed = 1;}
     
     SectionTitle("Miscellaneous");
     Toggle("Skip startup animation", &g_config.general.skip_boot_anim,
@@ -549,9 +551,12 @@ void MainMenuAudioView::Draw()
 {
     SectionTitle("Volume");
     char buf[32];
+    float min = 0;
+    float max = 1;
+    float gpspeed = 0.05;
     snprintf(buf, sizeof(buf), "Limit output volume (%d%%)",
              (int)(g_config.audio.volume_limit * 100));
-    Slider("Output volume limit", &g_config.audio.volume_limit, buf);
+    Slider("Output volume limit", &g_config.audio.volume_limit, min, max, gpspeed, buf);
 
     SectionTitle("Quality");
     Toggle("Real-time DSP processing", &g_config.audio.use_dsp,

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -71,7 +71,7 @@ void MainMenuGeneralView::Draw()
     
     char buf[32];
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 100), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf,0.01f , 2.f, 0.01f);
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf, 0.01f, 2.f, 0.01f);
 
     if ((g_config.perf.cpu_clockspeed-0.999)*(g_config.perf.cpu_clockspeed-1.009) <= 0) {g_config.perf.cpu_clockspeed = 1;}
     

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,8 +70,8 @@ void MainMenuGeneralView::Draw()
            "Enables to override default CPU clock speed");
     
     char buf[32];
-    snprintf(buf, sizeof(buf), "Clock Speed (%d%%)",
-             (int)(g_config.perf.cpu_clockspeed * 200));
+    snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)",
+             (int)(g_config.perf.cpu_clockspeed * 200), (733333333.0 * g_config.perf.cpu_clockspeed * 2.0)/1000000);
     Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf);
 
     

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -66,6 +66,15 @@ void MainMenuGeneralView::Draw()
     Toggle("Cache shaders to disk", &g_config.perf.cache_shaders,
            "Reduce stutter in games by caching previously generated shaders");
 
+    Toggle("Emulated CPU clock override", &g_config.perf.override_clockspeed,
+           "Enables to override default CPU clock speed");
+    
+    char buf[32];
+    snprintf(buf, sizeof(buf), "Clock Speed (%d%%)",
+             (int)(g_config.perf.cpu_clockspeed * 200));
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf);
+
+    
     SectionTitle("Miscellaneous");
     Toggle("Skip startup animation", &g_config.general.skip_boot_anim,
            "Skip the full Xbox boot animation sequence");

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,11 +70,11 @@ void MainMenuGeneralView::Draw()
            "Enables to override default CPU clock speed");
     
     char buf[32];
-    snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 100), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf, 0.01f, 2.f, 0.01f);
+    snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed_scale * 100), (733333333 * g_config.perf.cpu_clockspeed_scale) / 1000000);
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed_scale, buf, 0.01f, 2.f, 0.01f);
 
-    if (fabs(g_config.perf.cpu_clockspeed - 1.f) <= 0.0099f) {
-        g_config.perf.cpu_clockspeed = 1;
+    if (fabs(g_config.perf.cpu_clockspeed_scale - 1.f) <= 0.0099f) {
+        g_config.perf.cpu_clockspeed_scale = 1;
     }
     
     SectionTitle("Miscellaneous");

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,13 +70,8 @@ void MainMenuGeneralView::Draw()
            "Enables to override default CPU clock speed");
     
     char buf[32];
-    float min = 0.01;
-    float max = 2;
-    float gpspeed = 0.01;
-
-    
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 100), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, min , max, gpspeed, buf);
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf,0.01f , 2.f, 0.01f);
 
     if ((g_config.perf.cpu_clockspeed-0.999)*(g_config.perf.cpu_clockspeed-1.009) <= 0) {g_config.perf.cpu_clockspeed = 1;}
     
@@ -551,12 +546,9 @@ void MainMenuAudioView::Draw()
 {
     SectionTitle("Volume");
     char buf[32];
-    float min = 0;
-    float max = 1;
-    float gpspeed = 0.05;
     snprintf(buf, sizeof(buf), "Limit output volume (%d%%)",
              (int)(g_config.audio.volume_limit * 100));
-    Slider("Output volume limit", &g_config.audio.volume_limit, min, max, gpspeed, buf);
+    Slider("Output volume limit", &g_config.audio.volume_limit, buf);
 
     SectionTitle("Quality");
     Toggle("Real-time DSP processing", &g_config.audio.use_dsp,

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -73,7 +73,9 @@ void MainMenuGeneralView::Draw()
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 100), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
     Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf, 0.01f, 2.f, 0.01f);
 
-    if ((g_config.perf.cpu_clockspeed-0.999)*(g_config.perf.cpu_clockspeed-1.009) <= 0) {g_config.perf.cpu_clockspeed = 1;}
+    if (fabs(g_config.perf.cpu_clockspeed - 1.f) <= 0.0099f) {
+        g_config.perf.cpu_clockspeed = 1;
+    }
     
     SectionTitle("Miscellaneous");
     Toggle("Skip startup animation", &g_config.general.skip_boot_anim,

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,10 +70,14 @@ void MainMenuGeneralView::Draw()
            "Enables to override default CPU clock speed");
     
     char buf[32];
+
+
+    
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)",
              (int)(g_config.perf.cpu_clockspeed * 200), (733333333.0 * g_config.perf.cpu_clockspeed * 2.0)/1000000);
     Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf);
 
+    if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
     
     SectionTitle("Miscellaneous");
     Toggle("Skip startup animation", &g_config.general.skip_boot_anim,

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -22,6 +22,7 @@
 #include "viewport-manager.hh"
 #include "ui/xemu-os-utils.h"
 #include "gl-helpers.hh"
+#include <algorithm>
 
 void Separator()
 {
@@ -222,9 +223,8 @@ bool Toggle(const char *str_id, bool *v, const char *description)
     return status;
 }
 
-void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description)
-{
-    float x = *v / max;
+void Slider(const char *str_id, float *v, const char *description, float min, float max, float increment) {
+    float x = (*v - min) / (max - min);
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 
     ImGuiStyle &style = ImGui::GetStyle();
@@ -262,13 +262,13 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickLeft)) {
-                x -= gpspeed / max;
+                x -= increment / max;
         }
         if (ImGui::IsKeyPressed(ImGuiKey_RightArrow) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickRight)) {
-                x += gpspeed / max;
+                x += increment / max;
         }
 
         if (
@@ -289,8 +289,8 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
         ImVec2 mouse = ImGui::GetMousePos();
         x = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
     }
-    x = fmax(0, fmin(x, 1));
-    *v = fmax(min,fmin(x * max,max));
+    x = std::clamp(x, 0.f, 1.f);
+    *v = x * (max - min) + min;
     DrawSlider(x, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -284,7 +284,7 @@ void Slider(const char *str_id, float *v, const char *description, float min, fl
             ImGui::NavMoveRequestCancel();
         }
     }
-    
+
     if (ImGui::IsItemActive()) {
         ImVec2 mouse = ImGui::GetMousePos();
         x = GetSliderValueForMousePos(mouse, slider_pos, slider_size);

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -223,7 +223,8 @@ bool Toggle(const char *str_id, bool *v, const char *description)
     return status;
 }
 
-void Slider(const char *str_id, float *v, const char *description, float min, float max, float increment) {
+void Slider(const char *str_id, float *v, const char *description, float min, float max, float increment)
+{
     float x = (*v - min) / (max - min);
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -222,8 +222,9 @@ bool Toggle(const char *str_id, bool *v, const char *description)
     return status;
 }
 
-void Slider(const char *str_id, float *v, const char *description)
+void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description)
 {
+    float x = *v / max;
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 
     ImGuiStyle &style = ImGui::GetStyle();
@@ -261,13 +262,13 @@ void Slider(const char *str_id, float *v, const char *description)
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickLeft)) {
-                *v -= 0.05;
+                x -= gpspeed / max;
         }
         if (ImGui::IsKeyPressed(ImGuiKey_RightArrow) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickRight)) {
-                *v += 0.05;
+                x += gpspeed / max;
         }
 
         if (
@@ -283,13 +284,14 @@ void Slider(const char *str_id, float *v, const char *description)
             ImGui::NavMoveRequestCancel();
         }
     }
-
+    
     if (ImGui::IsItemActive()) {
         ImVec2 mouse = ImGui::GetMousePos();
-        *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
+        x = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
     }
-    *v = fmax(0, fmin(*v, 1));
-    DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
+    x = fmax(0, fmin(x, 1));
+    *v = fmax(min,fmin(x * max,max));
+    DrawSlider(x, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 
     ImVec2 slider_max = ImVec2(slider_pos.x + slider_size.x, slider_pos.y + slider_size.y);

--- a/ui/xui/widgets.hh
+++ b/ui/xui/widgets.hh
@@ -34,7 +34,7 @@ float GetSliderValueForMousePos(ImVec2 mouse, ImVec2 pos, ImVec2 size);
 void DrawSlider(float v, bool hovered, ImVec2 pos, ImVec2 size);
 void DrawToggle(bool enabled, bool hovered, ImVec2 pos, ImVec2 size);
 bool Toggle(const char *str_id, bool *v, const char *description = nullptr);
-void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description = nullptr);
+void Slider(const char *str_id, float *v, const char *description = nullptr, float min = 0, float max = 1, float increment = 0.05);
 bool FilePicker(const char *str_id, const char **buf, const char *filters,
                 bool dir = false);
 void DrawComboChevron();

--- a/ui/xui/widgets.hh
+++ b/ui/xui/widgets.hh
@@ -34,7 +34,7 @@ float GetSliderValueForMousePos(ImVec2 mouse, ImVec2 pos, ImVec2 size);
 void DrawSlider(float v, bool hovered, ImVec2 pos, ImVec2 size);
 void DrawToggle(bool enabled, bool hovered, ImVec2 pos, ImVec2 size);
 bool Toggle(const char *str_id, bool *v, const char *description = nullptr);
-void Slider(const char *str_id, float *v, const char *description = nullptr);
+void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description = nullptr);
 bool FilePicker(const char *str_id, const char **buf, const char *filters,
                 bool dir = false);
 void DrawComboChevron();


### PR DESCRIPTION
Fixes https://github.com/xemu-project/xemu/issues/1429

This adds the ability to override the current clock speed and adjust it to help optimize a game. 

Changing this value like other emulators when increasing the value increases the clock-speed cpu timing which can benefit variable-refresh rate games or mods that require higher clocks and or lower can trigger a games frame skip feature if it has one to increase performance.



Adjusting clock-speed can sometimes cause issues in some games so is to be warned about doing it and maybe shouldn’t be used in compatibility reports.

Increasing clock-speed seems to get some games to allow to go over 60 fps which could be useful if the game properly handles it.

A game I find improvements on personally is in Burnout 3 turning it down makes it more usable in menus on steamdeck from 4fps to 23fps adjusting to 47% and a bit ingame. In Jet Set Radio future with a 10 fps increase in more demanding areas.


![IMG_7386](https://github.com/xemu-project/xemu/assets/64176728/b4e2c073-3bf7-42fe-b71c-a85aa93ee61f)

