### PR TITLE
ci: Add clang-format lint check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+      - '!.github/workflows/lint.yml'
+      - 'README.md'
+      - 'ubuntu-win64-cross/**'
+
+jobs:
+  Check:
+    name: Check formatting and lints
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Clone tree
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check formatting/lints
+        uses: cpp-linter/cpp-linter-action@v2.13.4
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: '16'
+          style: file
+          lines-changed-only: true
+          format-review: true
+      - name: Report result
+        if: steps.linter.outputs.checks-failed > 0
+        run: exit 1
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Clone tree
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
       - name: Check formatting/lints

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,11 +17,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Clone tree
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - name: Check formatting/lints
-        uses: cpp-linter/cpp-linter-action@v2.13.4
+        uses: cpp-linter/cpp-linter-action@832a609fe16e1c98ea764641f07dec5d39db5a56 # v2.13.4
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Checks formatting and lints for PR changes in CI, using this github action: https://github.com/marketplace/actions/c-c-linter

I left the default clang-tidy checks enabled, if this is undesirable they can be set to read from a .clang-tidy file, although there isn't one in the repo currently.

I've also set it to comment on the pull request thread with the results, so that they are more visible. However, this does introduce noise to the PR thread so I'm open to disabling it. In either case, it will comment on the most recent commit with the results.

Unfortunately there aren't many actions available to run clang-format on only the files changed in a PR from what I can find, and this one does not indicate the exact formatting errors that are found (only that the files are not formatted correctly).

A dummy PR with failing lints is available here: https://github.com/antangelo/xemu/pull/3