### PR TITLE
vl: Prevent selection of HDD image as DVD image

### DIFF
--- a/softmmu/vl.c
+++ b/softmmu/vl.c
@@ -2853,7 +2853,7 @@ void qemu_init(int argc, char **argv)
     }
 
     if (strlen(dvd_path) > 0) {
-        if (xemu_check_file(dvd_path)) {
+        if (xemu_check_file(dvd_path) || strcmp(dvd_path, hdd_path) == 0) {
             char *msg = g_strdup_printf("Failed to open DVD image file '%s'. Please check machine settings.", dvd_path);
             xemu_queue_error_message(msg);
             g_free(msg);


### PR DESCRIPTION
Someone in discord managed to set their DVD and HDD images in the config to the same path, causing xemu to crash silently on startup while failing to open the second handle on the image. The only solution at this point is to edit the config manually to remove one of the image files.

With this PR, xemu will fail gracefully and refuse to load the DVD image, presenting an error message to the user.

The UI already fails gracefully in this case. I have tested reusing the same image as HDD and bios, and with HDD and MCPX rom, and the same issue is not exhibited.