### PR TITLE
ui: Apply correct snapshot activation action for save menuitem

### DIFF
--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -120,7 +120,7 @@ void ShowMainMenu()
                     }
 
                     if (ImGui::MenuItem(save_name, hotkey, false, bound)) {
-                        ActionActivateBoundSnapshot(i, false);
+                        ActionActivateBoundSnapshot(i, true);
                     }
 
                     g_free(hotkey);


### PR DESCRIPTION
Currently loads snapshot instead of saving because it passes `false` to `ActionActivateBoundSnapshot`