### PR TITLE
nv2a: Improve inverse viewport z scaling and clipping

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -2945,6 +2945,10 @@ DEF_METHOD(NV097, SET_BEGIN_END)
             glDisable(GL_CULL_FACE);
         }
 
+        /* Clipping */
+        glEnable(GL_CLIP_DISTANCE0);
+        glEnable(GL_CLIP_DISTANCE1);
+
         /* Front-face select */
         glFrontFace(pg->regs[NV_PGRAPH_SETUPRASTER]
                         & NV_PGRAPH_SETUPRASTER_FRONTFACE
@@ -4179,7 +4183,6 @@ static void pgraph_shader_update_constants(PGRAPHState *pg,
                     *(float*)&pg->regs[NV_PGRAPH_FOGPARAM1]);
     }
 
-    /* FIXME: Handle NV_PGRAPH_ZCLIPMIN, NV_PGRAPH_ZCLIPMAX */
     float zmax;
     switch (pg->surface_shape.zeta_format) {
     case NV097_SET_SURFACE_FORMAT_ZETA_Z16:
@@ -4289,7 +4292,9 @@ static void pgraph_shader_update_constants(PGRAPHState *pg,
     }
 
     if (binding->clip_range_loc != -1) {
-        glUniform2f(binding->clip_range_loc, 0, zmax);
+        float zclip_min = *(float*)&pg->regs[NV_PGRAPH_ZCLIPMIN] / zmax * 2.0 - 1.0;
+        float zclip_max = *(float*)&pg->regs[NV_PGRAPH_ZCLIPMAX] / zmax * 2.0 - 1.0;
+        glUniform4f(binding->clip_range_loc, 0, zmax, zclip_min, zclip_max);
     }
 
     /* Clipping regions */

--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -28,6 +28,9 @@
 #include "ui/xemu-settings.h"
 #include "qemu/fast-hash.h"
 
+const float f16_max = 511.9375f;
+const float f24_max = 1.0E30;
+
 static NV2AState *g_nv2a;
 GloContext *g_nv2a_context_render;
 GloContext *g_nv2a_context_display;
@@ -3493,10 +3496,6 @@ DEF_METHOD(NV097, CLEAR_SURFACE)
         GLint gl_clear_stencil;
         GLfloat gl_clear_depth;
 
-        /* FIXME: Put these in some lookup table */
-        const float f16_max = 511.9375f;
-        const float f24_max = 1.0E30;
-
         switch(pg->surface_shape.zeta_format) {
         case NV097_SET_SURFACE_FORMAT_ZETA_Z16: {
             uint16_t z = clear_zstencil & 0xFFFF;
@@ -4180,8 +4179,18 @@ static void pgraph_shader_update_constants(PGRAPHState *pg,
                     *(float*)&pg->regs[NV_PGRAPH_FOGPARAM1]);
     }
 
-    float zclip_max = *(float*)&pg->regs[NV_PGRAPH_ZCLIPMAX];
-    float zclip_min = *(float*)&pg->regs[NV_PGRAPH_ZCLIPMIN];
+    /* FIXME: Handle NV_PGRAPH_ZCLIPMIN, NV_PGRAPH_ZCLIPMAX */
+    float zmax;
+    switch (pg->surface_shape.zeta_format) {
+    case NV097_SET_SURFACE_FORMAT_ZETA_Z16:
+        zmax = pg->surface_shape.z_format ? f16_max : (float)0xFFFF;
+        break;
+    case NV097_SET_SURFACE_FORMAT_ZETA_Z24S8:
+        zmax = pg->surface_shape.z_format ? f24_max : (float)0xFFFFFF;
+        break;
+    default:
+        assert(0);
+    }
 
     if (fixed_function) {
         /* update lighting constants */
@@ -4238,19 +4247,15 @@ static void pgraph_shader_update_constants(PGRAPHState *pg,
 
         float m11 = 0.5 * (pg->surface_binding_dim.width/aa_width);
         float m22 = -0.5 * (pg->surface_binding_dim.height/aa_height);
-        float m33 = zclip_max - zclip_min;
+        float m33 = zmax;
         float m41 = *(float*)&pg->vsh_constants[NV_IGRAPH_XF_XFCTX_VPOFF][0];
         float m42 = *(float*)&pg->vsh_constants[NV_IGRAPH_XF_XFCTX_VPOFF][1];
-        float m43 = zclip_min;
-        if (m33 == 0.0) {
-            m33 = 1.0;
-        }
 
         float invViewport[16] = {
             1.0/m11, 0, 0, 0,
             0, 1.0/m22, 0, 0,
             0, 0, 1.0/m33, 0,
-            -1.0+m41/m11, 1.0+m42/m22, -m43/m33, 1.0
+            -1.0+m41/m11, 1.0+m42/m22, 0, 1.0
         };
 
         if (binding->inv_viewport_loc != -1) {
@@ -4284,7 +4289,7 @@ static void pgraph_shader_update_constants(PGRAPHState *pg,
     }
 
     if (binding->clip_range_loc != -1) {
-        glUniform2f(binding->clip_range_loc, zclip_min, zclip_max);
+        glUniform2f(binding->clip_range_loc, 0, zmax);
     }
 
     /* Clipping regions */

--- a/hw/xbox/nv2a/shaders.c
+++ b/hw/xbox/nv2a/shaders.c
@@ -267,6 +267,8 @@ static MString* generate_geometry_shader(
                        "void emit_vertex(int index, int _unused) {\n"
                        "  gl_Position = gl_in[index].gl_Position;\n"
                        "  gl_PointSize = gl_in[index].gl_PointSize;\n"
+                       "  gl_ClipDistance[0] = gl_in[index].gl_ClipDistance[0];\n"
+                       "  gl_ClipDistance[1] = gl_in[index].gl_ClipDistance[1];\n"
                        "  vtx_inv_w = v_vtx_inv_w[index];\n"
                        "  vtx_inv_w_flat = v_vtx_inv_w[index];\n"
                        "  vtxD0 = v_vtxD0[index];\n"
@@ -289,6 +291,8 @@ static MString* generate_geometry_shader(
                        "void emit_vertex(int index, int provoking_index) {\n"
                        "  gl_Position = gl_in[index].gl_Position;\n"
                        "  gl_PointSize = gl_in[index].gl_PointSize;\n"
+                       "  gl_ClipDistance[0] = gl_in[index].gl_ClipDistance[0];\n"
+                       "  gl_ClipDistance[1] = gl_in[index].gl_ClipDistance[1];\n"
                        "  vtx_inv_w = v_vtx_inv_w[index];\n"
                        "  vtx_inv_w_flat = v_vtx_inv_w[provoking_index];\n"
                        "  vtxD0 = v_vtxD0[provoking_index];\n"
@@ -784,7 +788,7 @@ static MString *generate_vertex_shader(const ShaderState *state,
     MString *header = mstring_from_str(
 "#version 400\n"
 "\n"
-"uniform vec2 clipRange;\n"
+"uniform vec4 clipRange;\n"
 "uniform vec2 surfaceSize;\n"
 "\n"
 /* All constants in 1 array declaration */
@@ -864,7 +868,6 @@ GLSL_DEFINE(texMat3, GLSL_C_MAT4(NV_IGRAPH_XF_XFCTX_T3MAT))
 
     if (state->fixed_function) {
         generate_fixed_function(state, header, body);
-
     } else if (state->vertex_program) {
         vsh_translate(VSH_VERSION_XVS,
                       (uint32_t*)state->program_data,
@@ -973,6 +976,8 @@ GLSL_DEFINE(texMat3, GLSL_C_MAT4(NV_IGRAPH_XF_XFCTX_T3MAT))
                       "  vtxT3 = oT3 * vtx_inv_w;\n"
                       "  gl_Position = oPos;\n"
                       "  gl_PointSize = oPts.x;\n"
+                      "  gl_ClipDistance[0] = oPos.z - oPos.w*clipRange.z;\n" // Near
+                      "  gl_ClipDistance[1] = oPos.w*clipRange.w - oPos.z;\n" // Far
                       "\n"
                       "}\n",
                        shade_model_mult,

--- a/hw/xbox/nv2a/vsh.c
+++ b/hw/xbox/nv2a/vsh.c
@@ -849,11 +849,6 @@ void vsh_translate(uint16_t version,
         mstring_append(body, "  oPos.z = oPos.w;\n");
     }
     mstring_append(body,
-        /* Map the clip range into clip space so z is clipped correctly.
-         * Note this makes the values in the depth buffer wrong. This should be
-         * handled with gl_ClipDistance instead, but that has performance issues
-         * on OS X.
-         */
         "  if (clipRange.y != clipRange.x) {\n"
         "    oPos.z = (oPos.z - clipRange.x)/(0.5*(clipRange.y - clipRange.x)) - 1;\n"
         "  }\n"


### PR DESCRIPTION
Fixes some depth issues.

* Fixes #802 
  * ![image](https://github.com/xemu-project/xemu/assets/8210/9fae05b2-5858-4a08-9b65-44180b870635)
* Fixes #891 
  * ![image](https://github.com/xemu-project/xemu/assets/8210/67df0033-ba0b-47cd-9773-3c77b4070993)
* Fixes depth issues mentioned in #1016 for Driv3r, Chicago Enforcer, and maybe more
  * ![image](https://github.com/xemu-project/xemu/assets/8210/c63a1527-8207-48d4-ab52-8bc465a2cab9)
* Fixes an issue with Halo 2 cutscene DoF effect (but not other depth issues in game--cause of which is known but pending)
   * ![image](https://github.com/xemu-project/xemu/assets/8210/d68f0d56-59e2-4816-a9dc-3a62bf20dce6) ![image](https://github.com/xemu-project/xemu/assets/8210/aa57bafc-bca5-424b-a77c-46c1ff39c339)
   * ![image](https://github.com/xemu-project/xemu/assets/8210/36065704-e6b4-4b89-891d-349650e851db) ![image](https://github.com/xemu-project/xemu/assets/8210/cefacbbc-d977-48bf-bfbf-3ce9a4713a84)

- [x] ~~Test macOS to make sure it's not crippled by change~~ Performance is apparently unaffected.

