### PR TITLE
.clang-tidy: Add basic .clang-tidy for identifier naming

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,24 @@
+---
+Checks: '-*,readability-identifier-naming'
+WarningsAsErrors: true
+CheckOptions:
+  - key:    readability-identifier-naming.VariableCase
+    value:  lower_case
+  - key:    readability-identifier-naming.MemberCase
+    value:  lower_case
+  - key:    readability-identifier-naming.ClassMemberPrefix
+    value:  m_
+  - key:    readability-identifier-naming.GlobalVariablePrefix
+    value:  g_
+  - key:    readability-identifier-naming.ConstantPrefix
+    value:  ''
+  - key:    readability-identifier-naming.EnumConstantCase
+    value:  UPPER_CASE
+  - key:    readability-identifier-naming.FunctionCase
+    value:  lower_case
+  - key:    readability-identifier-naming.MethodCase
+    value:  CamelCase
+  - key:    readability-identifier-naming.StructCase
+    value:  CamelCase
+  - key:    readability-identifier-naming.UnionCase
+    value:  CamelCase


### PR DESCRIPTION
Adds a `.clang-tidy` config that covers most identifier naming conventions. Ideally we can offload this component of PR reviews to CI along with formatting in #1510 .

Unfortunately it doesn't seem like clang-tidy supports having a separate option for global static variables vs global non-static variables (from what I can tell the `StaticVariable` option only applies to locals), so one limitation of this config is that it will recommend the `g_` prefix for global static variables. The alternative is not to enforce a naming convention on the clang-tidy level, but we'd have to continue doing so manually in PR reviews.