### PR TITLE
ui: Handle snapshots with empty names in snapshot menu

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -14,9 +14,13 @@ general:
   snapshots:
     shortcuts:
       f5: string
+      f5_present: bool
       f6: string
+      f6_present: bool
       f7: string
+      f7_present: bool
       f8: string
+      f8_present: bool
     filter_current_game: bool
 
 input:

--- a/ui/xemu-snapshots.c
+++ b/ui/xemu-snapshots.c
@@ -42,13 +42,6 @@ static XemuSnapshotData *xemu_snapshots_extra_data = NULL;
 static int xemu_snapshots_len = 0;
 static bool xemu_snapshots_dirty = true;
 
-const char **g_snapshot_shortcut_index_key_map[] = {
-    &g_config.general.snapshots.shortcuts.f5,
-    &g_config.general.snapshots.shortcuts.f6,
-    &g_config.general.snapshots.shortcuts.f7,
-    &g_config.general.snapshots.shortcuts.f8,
-};
-
 static void xemu_snapshots_load_data(BlockDriverState *bs_ro,
                                      QEMUSnapshotInfo *info,
                                      XemuSnapshotData *data, Error **err)

--- a/ui/xemu-snapshots.h
+++ b/ui/xemu-snapshots.h
@@ -34,8 +34,6 @@ extern "C" {
 #define XEMU_SNAPSHOT_THUMBNAIL_WIDTH 160
 #define XEMU_SNAPSHOT_THUMBNAIL_HEIGHT 120
 
-extern const char **g_snapshot_shortcut_index_key_map[];
-
 typedef struct XemuSnapshotData {
     char *disc_path;
     char *xbe_title_name;

--- a/ui/xui/actions.cc
+++ b/ui/xui/actions.cc
@@ -80,9 +80,8 @@ void ActionScreenshot(void)
 
 void ActionActivateBoundSnapshot(int slot, bool save)
 {
-    assert(slot < 4 && slot >= 0);
-    const char *snapshot_name = *(g_snapshot_shortcut_index_key_map[slot]);
-    if (!snapshot_name || !(snapshot_name[0])) {
+    auto snapshot_name = g_snapshot_mgr.GetSnapshotShortcut(slot);
+    if (!snapshot_name) {
         char *msg = g_strdup_printf("F%d is not bound to a snapshot", slot + 5);
         xemu_queue_notification(msg);
         g_free(msg);
@@ -91,9 +90,9 @@ void ActionActivateBoundSnapshot(int slot, bool save)
 
     Error *err = NULL;
     if (save) {
-        xemu_snapshots_save(snapshot_name, &err);
+        xemu_snapshots_save(*snapshot_name, &err);
     } else {
-        ActionLoadSnapshotChecked(snapshot_name);
+        ActionLoadSnapshotChecked(*snapshot_name);
     }
 
     if (err) {

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -32,13 +32,14 @@
 #include "actions.hh"
 
 #include "../xemu-input.h"
-#include "../xemu-monitor.h"
-#include "../xemu-net.h"
 #include "../xemu-notifications.h"
-#include "../xemu-os-utils.h"
 #include "../xemu-settings.h"
+#include "../xemu-monitor.h"
 #include "../xemu-version.h"
+#include "../xemu-net.h"
+#include "../xemu-os-utils.h"
 #include "../xemu-xbe.h"
+
 #include <optional>
 
 #include "../thirdparty/fatx/fatx.h"

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -32,13 +32,14 @@
 #include "actions.hh"
 
 #include "../xemu-input.h"
-#include "../xemu-notifications.h"
-#include "../xemu-settings.h"
 #include "../xemu-monitor.h"
-#include "../xemu-version.h"
 #include "../xemu-net.h"
+#include "../xemu-notifications.h"
 #include "../xemu-os-utils.h"
+#include "../xemu-settings.h"
+#include "../xemu-version.h"
 #include "../xemu-xbe.h"
+#include <optional>
 
 #include "../thirdparty/fatx/fatx.h"
 
@@ -1031,11 +1032,13 @@ void MainMenuSnapshotsView::Draw()
                              &OnSearchTextUpdate, this);
 
     bool snapshot_with_create_name_exists = false;
-    for (int i = 0; i < g_snapshot_mgr.m_snapshots_len; ++i) {
-        if (g_strcmp0(m_search_buf.c_str(),
-                      g_snapshot_mgr.m_snapshots[i].name) == 0) {
-            snapshot_with_create_name_exists = true;
-            break;
+    if (!m_search_buf.empty()) {
+        for (int i = 0; i < g_snapshot_mgr.m_snapshots_len; ++i) {
+            if (g_strcmp0(m_search_buf.c_str(),
+                          g_snapshot_mgr.m_snapshots[i].name) == 0) {
+                snapshot_with_create_name_exists = true;
+                break;
+            }
         }
     }
 
@@ -1100,8 +1103,9 @@ void MainMenuSnapshotsView::Draw()
 
         int current_snapshot_binding = -1;
         for (int i = 0; i < 4; ++i) {
-            if (g_strcmp0(*(g_snapshot_shortcut_index_key_map[i]),
-                          snapshot->name) == 0) {
+            auto shortcut_name = g_snapshot_mgr.GetSnapshotShortcut(i);
+            if (shortcut_name &&
+                g_strcmp0(*shortcut_name, snapshot->name) == 0) {
                 assert(current_snapshot_binding == -1);
                 current_snapshot_binding = i;
             }
@@ -1167,12 +1171,10 @@ void MainMenuSnapshotsView::DrawSnapshotContextMenu(
 
             if (ImGui::MenuItem(item_name)) {
                 if (current_snapshot_binding >= 0) {
-                    xemu_settings_set_string(g_snapshot_shortcut_index_key_map
-                                                 [current_snapshot_binding],
-                                             "");
+                    g_snapshot_mgr.SetSnapshotShortcut(current_snapshot_binding,
+                                                       std::nullopt);
                 }
-                xemu_settings_set_string(g_snapshot_shortcut_index_key_map[i],
-                                         snapshot->name);
+                g_snapshot_mgr.SetSnapshotShortcut(i, snapshot->name);
                 current_snapshot_binding = i;
 
                 ImGui::CloseCurrentPopup();
@@ -1183,9 +1185,8 @@ void MainMenuSnapshotsView::DrawSnapshotContextMenu(
 
         if (current_snapshot_binding >= 0) {
             if (ImGui::MenuItem("Unbind")) {
-                xemu_settings_set_string(
-                    g_snapshot_shortcut_index_key_map[current_snapshot_binding],
-                    "");
+                g_snapshot_mgr.SetSnapshotShortcut(current_snapshot_binding,
+                                                   std::nullopt);
                 current_snapshot_binding = -1;
             }
         }

--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -18,16 +18,16 @@
 //
 #include "ui/xemu-notifications.h"
 #include "ui/xui/snapshot-manager.hh"
-#include "menubar.hh"
-#include "actions.hh"
 #include "common.hh"
-#include "compat.hh"
-#include "debug.hh"
 #include "main-menu.hh"
+#include "menubar.hh"
 #include "misc.hh"
-#include "monitor.hh"
-#include "update.hh"
 #include "widgets.hh"
+#include "monitor.hh"
+#include "debug.hh"
+#include "actions.hh"
+#include "compat.hh"
+#include "update.hh"
 
 #include "../xemu-os-utils.h"
 

--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -28,7 +28,6 @@
 #include "actions.hh"
 #include "compat.hh"
 #include "update.hh"
-
 #include "../xemu-os-utils.h"
 
 extern float g_main_menu_height; // FIXME

--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -17,16 +17,18 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 #include "ui/xemu-notifications.h"
-#include "common.hh"
-#include "main-menu.hh"
+#include "ui/xui/snapshot-manager.hh"
 #include "menubar.hh"
-#include "misc.hh"
-#include "widgets.hh"
-#include "monitor.hh"
-#include "debug.hh"
 #include "actions.hh"
+#include "common.hh"
 #include "compat.hh"
+#include "debug.hh"
+#include "main-menu.hh"
+#include "misc.hh"
+#include "monitor.hh"
 #include "update.hh"
+#include "widgets.hh"
+
 #include "../xemu-os-utils.h"
 
 extern float g_main_menu_height; // FIXME
@@ -101,13 +103,13 @@ void ShowMainMenu()
                     char *load_name;
                     char *save_name;
 
-                    assert(g_snapshot_shortcut_index_key_map[i]);
-                    bool bound = *(g_snapshot_shortcut_index_key_map[i]) &&
-                            (**(g_snapshot_shortcut_index_key_map[i]) != 0);
+                    auto bound_snapshot = g_snapshot_mgr.GetSnapshotShortcut(i);
 
-                    if (bound) {
-                        load_name = g_strdup_printf("Load '%s'", *(g_snapshot_shortcut_index_key_map[i]));
-                        save_name = g_strdup_printf("Save '%s'", *(g_snapshot_shortcut_index_key_map[i]));
+                    if (bound_snapshot) {
+                        load_name =
+                            g_strdup_printf("Load '%s'", *bound_snapshot);
+                        save_name =
+                            g_strdup_printf("Save '%s'", *bound_snapshot);
                     } else {
                         load_name = g_strdup_printf("Load F%d (Unbound)", i + 5);
                         save_name = g_strdup_printf("Save F%d (Unbound)", i + 5);
@@ -115,11 +117,14 @@ void ShowMainMenu()
 
                     ImGui::Separator();
 
-                    if (ImGui::MenuItem(load_name, hotkey + sizeof("Shift+") - 1, false, bound)) {
+                    if (ImGui::MenuItem(load_name,
+                                        hotkey + sizeof("Shift+") - 1, false,
+                                        bound_snapshot.has_value())) {
                         ActionActivateBoundSnapshot(i, false);
                     }
 
-                    if (ImGui::MenuItem(save_name, hotkey, false, bound)) {
+                    if (ImGui::MenuItem(save_name, hotkey, false,
+                                        bound_snapshot.has_value())) {
                         ActionActivateBoundSnapshot(i, true);
                     }
 

--- a/ui/xui/snapshot-manager.cc
+++ b/ui/xui/snapshot-manager.cc
@@ -17,9 +17,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include "ui/xemu-settings.h"
+#include "snapshot-manager.hh"
 #include "common.hh"
 #include "notifications.hh"
-#include "snapshot-manager.hh"
 #include "xemu-hud.h"
 
 SnapshotManager g_snapshot_mgr;
@@ -104,6 +105,41 @@ void SnapshotManager::LoadSnapshot(const char *name)
         xemu_queue_error_message(error_get_pretty(err));
         error_free(err);
     }
+}
+
+static const char **snapshot_shortcut_index_key_map[] = {
+    &g_config.general.snapshots.shortcuts.f5,
+    &g_config.general.snapshots.shortcuts.f6,
+    &g_config.general.snapshots.shortcuts.f7,
+    &g_config.general.snapshots.shortcuts.f8,
+};
+
+static bool *snapshot_shortcut_index_present_map[] = {
+    &g_config.general.snapshots.shortcuts.f5_present,
+    &g_config.general.snapshots.shortcuts.f6_present,
+    &g_config.general.snapshots.shortcuts.f7_present,
+    &g_config.general.snapshots.shortcuts.f8_present,
+};
+
+std::optional<const char *> SnapshotManager::GetSnapshotShortcut(int index)
+{
+    assert(index >= 0 && index < 4);
+    bool bound = *snapshot_shortcut_index_present_map[index] ||
+                 **(snapshot_shortcut_index_key_map[index]) != 0;
+    if (!bound)
+        return std::nullopt;
+
+    return *(snapshot_shortcut_index_key_map[index]);
+}
+
+void SnapshotManager::SetSnapshotShortcut(
+    int index, std::optional<const char *> snapshot_name)
+{
+    assert(index >= 0 && index < 4);
+
+    *(snapshot_shortcut_index_present_map[index]) = snapshot_name.has_value();
+    xemu_settings_set_string(snapshot_shortcut_index_key_map[index],
+                             snapshot_name ? *snapshot_name : "");
 }
 
 void SnapshotManager::Draw()

--- a/ui/xui/snapshot-manager.cc
+++ b/ui/xui/snapshot-manager.cc
@@ -18,9 +18,9 @@
 //
 
 #include "ui/xemu-settings.h"
-#include "snapshot-manager.hh"
 #include "common.hh"
 #include "notifications.hh"
+#include "snapshot-manager.hh"
 #include "xemu-hud.h"
 
 SnapshotManager g_snapshot_mgr;

--- a/ui/xui/snapshot-manager.hh
+++ b/ui/xui/snapshot-manager.hh
@@ -18,8 +18,9 @@
 //
 
 #pragma once
-#include <string>
 #include "../xemu-snapshots.h"
+#include <optional>
+#include <string>
 
 class SnapshotManager
 {
@@ -39,6 +40,10 @@ public:
     void Refresh();
     void LoadSnapshot(const char *name);
     void LoadSnapshotChecked(const char *name);
+
+    std::optional<const char *> GetSnapshotShortcut(int index);
+    void SetSnapshotShortcut(int index,
+                             std::optional<const char *> snapshot_name);
 
     void Draw();
     void DrawSnapshotDiscLoadDialog();

--- a/ui/xui/snapshot-manager.hh
+++ b/ui/xui/snapshot-manager.hh
@@ -18,9 +18,9 @@
 //
 
 #pragma once
+#include <string>
 #include "../xemu-snapshots.h"
 #include <optional>
-#include <string>
 
 class SnapshotManager
 {


### PR DESCRIPTION
Snapshots without names are somewhat difficult to create (must use `savevm ""` in the monitor, QMP, or qemu-img) but should be handled correctly regardless.

This requires adding an additional present bool to the config. I preserved compatibility with existing shortcut bindings by checking the present field or that the shortcut snapshot name string is not empty.

Fixes #1543 