### PR TITLE
i386: Implement EBL_CR_POWERON MSR for Xbox CPU

### DIFF
--- a/target/i386/cpu.h
+++ b/target/i386/cpu.h
@@ -378,6 +378,7 @@ typedef enum X86Seg {
 #define MSR_IA32_APICBASE_ENABLE        (1<<11)
 #define MSR_IA32_APICBASE_EXTD          (1 << 10)
 #define MSR_IA32_APICBASE_BASE          (0xfffffU<<12)
+#define MSR_IA32_EBL_CR_POWERON         0x2a
 #define MSR_IA32_FEATURE_CONTROL        0x0000003a
 #define MSR_TSC_ADJUST                  0x0000003b
 #define MSR_IA32_SPEC_CTRL              0x48

--- a/target/i386/tcg/sysemu/misc_helper.c
+++ b/target/i386/tcg/sysemu/misc_helper.c
@@ -428,6 +428,11 @@ void helper_rdmsr(CPUX86State *env)
             val = 0;
         }
         break;
+#ifdef XBOX
+    case MSR_IA32_EBL_CR_POWERON:
+        val = 0xc5040000;
+        break;
+#endif
     case MSR_MCG_CAP:
         val = env->mcg_cap;
         break;


### PR DESCRIPTION
This implements reading of the `EBL_CR_POWERON` MSR, which is documented in chapter 2.22 of [Intel's Software Developer's Manual Volume 4](https://www.intel.com/content/dam/develop/external/us/en/documents/335592-sdm-vol-4.pdf). Technically some of its bits are supposed to be writable so this implementation is not entirely accurate, but to my knowledge neither the kernel nor the XDK ever access this MSR.
I intend to use this in nxdk in the future to calculate TSC frequency with perfect accuracy.

The value returned was taken from a stock Xbox CPU.

Testing is simple and can be done with a small nxdk app (might need a `#include <intrin.h>`):
```c
    uint64_t msr = __readmsr(0x2a);
    debugPrint("MSR 0x2a: 0x%llx\n", msr);
```

I only implemented it for the TCG backend, I hope that's ok.