### PR TITLE
build: Set march to IvyBridge for supported platforms

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -195,6 +195,9 @@ case "$platform" in # Adjust compilation options based on platform
         sys_cflags='-Wno-error=redundant-decls'
         opts="$opts --disable-werror"
         postbuild='package_linux'
+        if [ "$target_arch" == "x86_64" ]; then
+            sys_cflags="$sys_cflags -march=ivybridge"
+        fi
         ;;
     Darwin)
         echo "Compiling for MacOS for $target_arch..."
@@ -233,7 +236,7 @@ case "$platform" in # Adjust compilation options based on platform
         ;;
     CYGWIN*|MINGW*|MSYS*)
         echo 'Compiling for Windows...'
-        sys_cflags='-Wno-error'
+        sys_cflags='-Wno-error -march=ivybridge'
         opts="$opts --disable-fortify-source"
         postbuild='package_windows' # set the above function to be called after build
         target="qemu-system-i386w.exe"
@@ -241,7 +244,7 @@ case "$platform" in # Adjust compilation options based on platform
     win64-cross)
         echo 'Cross-compiling for Windows...'
         export AR=${AR:-$CROSSAR}
-        sys_cflags='-Wno-error'
+        sys_cflags='-Wno-error -march=ivybridge'
         opts="$opts --cross-prefix=$CROSSPREFIX --static --disable-fortify-source"
         postbuild='package_wincross' # set the above function to be called after build
         target="qemu-system-i386w.exe"

--- a/build.sh
+++ b/build.sh
@@ -196,7 +196,7 @@ case "$platform" in # Adjust compilation options based on platform
         opts="$opts --disable-werror"
         postbuild='package_linux'
         if [ "$target_arch" == "x86_64" ]; then
-            sys_cflags="$sys_cflags -march=ivybridge"
+            sys_cflags="$sys_cflags -msse4.2 -mavx"
         fi
         ;;
     Darwin)
@@ -236,7 +236,7 @@ case "$platform" in # Adjust compilation options based on platform
         ;;
     CYGWIN*|MINGW*|MSYS*)
         echo 'Compiling for Windows...'
-        sys_cflags='-Wno-error -march=ivybridge'
+        sys_cflags='-Wno-error -msse4.2 -mavx'
         opts="$opts --disable-fortify-source"
         postbuild='package_windows' # set the above function to be called after build
         target="qemu-system-i386w.exe"
@@ -244,7 +244,7 @@ case "$platform" in # Adjust compilation options based on platform
     win64-cross)
         echo 'Cross-compiling for Windows...'
         export AR=${AR:-$CROSSAR}
-        sys_cflags='-Wno-error -march=ivybridge'
+        sys_cflags='-Wno-error -msse4.2 -mavx'
         opts="$opts --cross-prefix=$CROSSPREFIX --static --disable-fortify-source"
         postbuild='package_wincross' # set the above function to be called after build
         target="qemu-system-i386w.exe"


### PR DESCRIPTION
It's safe to assume the vast majority of users are using a AVX1 capable CPU as the earliest supported Intel architecture is Sandy Bridge which is now at least 12 years old. Users on these older platforms can still run xemu although it's showing it's age quite severely. I run Ivy Bridge and have trouble with most things beyond, perhaps, MS Dash, and nxdk applications.

My reasons for not enabling `march=haswell` which would bring AVX2 support are obviously selfish (being I use an Ivy Bridge CPU), but a quiet poll in the Discord has found enough users that I believe it's still appropriate.

Now I can't say I've seen any real, or noticeable improvements, but looking quickly at the executable (23MB wow!) the compiler is vectorizing some things.