### PR TITLE
ui: Fix FilePicker clear button overlapping select button

### DIFF
--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -312,7 +312,8 @@ bool FilePicker(const char *str_id, const char **buf, const char *filters,
               GetWidgetTitleDescriptionHeight(str_id, desc));
     ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0, 0));
     ImGui::PushID(str_id);
-    bool status = ImGui::Button("###file_button", bb);
+    bool status =
+        ImGui::ButtonEx("###file_button", bb, ImGuiButtonFlags_AllowOverlap);
     ImGui::SetItemAllowOverlap();
     if (status) {
         int flags = NOC_FILE_DIALOG_OPEN;


### PR DESCRIPTION
Not sure why this worked before, but the button now highlights separately and works as intended:
![image](https://github.com/xemu-project/xemu/assets/25046221/2b453d9d-f005-4822-a0d9-28e7b8798cc5)
