### PR TITLE
build: Fix building on mingw

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -234,6 +234,7 @@ case "$platform" in # Adjust compilation options based on platform
     CYGWIN*|MINGW*|MSYS*)
         echo 'Compiling for Windows...'
         sys_cflags='-Wno-error'
+        CFLAGS="${CFLAGS} -lIphlpapi -lCrypt32" # workaround for linking libs on mingw
         opts="$opts --disable-fortify-source"
         postbuild='package_windows' # set the above function to be called after build
         target="qemu-system-i386w.exe"


### PR DESCRIPTION
Adds needed libs ( Iphlpapi and Crypt32 ) for compilation on mingw.
Fixes:
```
H:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: H:\msys64\tmp\ccyHZzNh.ltrans2.ltrans.o:<artificial>:(.text+0x2dd3): undefined reference to `ConvertInterfaceGuidToLuid'
H:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: H:\msys64\tmp\ccyHZzNh.ltrans2.ltrans.o:<artificial>:(.text+0x2df4): undefined reference to `ConvertInterfaceLuidToAlias'
H:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: H:\msys64\tmp\ccyHZzNh.ltrans5.ltrans.o:<artificial>:(.text+0x222a): undefined reference to `__imp_CertOpenSystemStoreW'
H:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: H:\msys64\tmp\ccyHZzNh.ltrans5.ltrans.o:<artificial>:(.text+0x223d): undefined reference to `__imp_CertEnumCertificatesInStore'
H:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: H:\msys64\tmp\ccyHZzNh.ltrans5.ltrans.o:<artificial>:(.text+0x22ab): undefined reference to `__imp_CertFreeCertificateContext'
H:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: H:\msys64\tmp\ccyHZzNh.ltrans5.ltrans.o:<artificial>:(.text+0x22b6): undefined reference to `__imp_CertCloseStore'
```
