### PR TITLE
Update metainfo.xml information

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,7 +219,7 @@ jobs:
         ar x dist/*.deb
         mkdir appimage
         tar -C appimage -xf data.tar*
-        install -DT src/xemu.appdata.xml appimage/usr/share/metainfo/xemu.appdata.xml
+        install -DT src/xemu.metainfo.xml appimage/usr/share/metainfo/xemu.metainfo.xml
 
         export VERSION=v$(cat src/XEMU_VERSION)
         if [[ "${{ matrix.configuration }}" == "Debug" ]]; then

--- a/xemu.metainfo.xml
+++ b/xemu.metainfo.xml
@@ -46,4 +46,7 @@
   <provides>
     <binary>xemu</binary>
   </provides>
+  <developer id="xemu.app">
+    <name>xemu project</name>
+  </developer>
 </component>


### PR DESCRIPTION
Some new information is needed by the appstream linter.

metainfo.xml extension is preferable over appdata.xml, see https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html#spec-appdata-introduction.

This fixes the Flatpak build.