### PR TITLE
Net: Search for npcap instead of winpcap based files

### DIFF
--- a/winpcap-loader/loader.c
+++ b/winpcap-loader/loader.c
@@ -21,7 +21,7 @@
 #include <pcap/pcap.h>
 #include <string.h>
 
-const char *lib_not_loaded_err = "winpcap library is not loaded";
+const char *lib_not_loaded_err = "pcap library is not loaded, is npcap installed?";
 
 static pcap_t *pcap_open_live_stub(const char *device, int snaplen, int promisc, int to_ms, char *errbuf)
 {
@@ -83,9 +83,10 @@ int pcap_load_library(void)
 		return 0;
 	}
 
-	HANDLE hwpcap = LoadLibrary("wpcap.dll");
+	HANDLE hwpcap = LoadLibrary("\\Npcap\\wpcap.dll");
+
 	if (hwpcap == NULL) {
-		HANDLE hwpcap = LoadLibrary("packet.dll");
+		hwpcap = LoadLibrary("packet.dll");
 		if ( hwpcap == NULL ) {
 			return 1;
 		}

--- a/winpcap-loader/loader.c
+++ b/winpcap-loader/loader.c
@@ -83,10 +83,10 @@ int pcap_load_library(void)
 		return 0;
 	}
 
-	HANDLE hwpcap = LoadLibrary("wpcap.dll");
+	HANDLE hwpcap = LoadLibrary("\\Npcap\\wpcap.dll");
 
 	if (hwpcap == NULL) {
-		hwpcap = LoadLibrary("packet.dll");
+		hwpcap = LoadLibrary("wpcap.dll");
 		if ( hwpcap == NULL ) {
 			return 1;
 		}

--- a/winpcap-loader/loader.c
+++ b/winpcap-loader/loader.c
@@ -83,7 +83,7 @@ int pcap_load_library(void)
 		return 0;
 	}
 
-	HANDLE hwpcap = LoadLibrary("\\Npcap\\wpcap.dll");
+	HANDLE hwpcap = LoadLibrary("wpcap.dll");
 
 	if (hwpcap == NULL) {
 		hwpcap = LoadLibrary("packet.dll");

--- a/winpcap-loader/loader.c
+++ b/winpcap-loader/loader.c
@@ -85,7 +85,10 @@ int pcap_load_library(void)
 
 	HANDLE hwpcap = LoadLibrary("wpcap.dll");
 	if (hwpcap == NULL) {
-		return 1;
+		HANDLE hwpcap = LoadLibrary("packet.dll");
+		if ( hwpcap == NULL ) {
+			return 1;
+		}
 	}
 
 	#define LOAD_FN(fname) do {\


### PR DESCRIPTION
If you install NPcap without checking the install in winpcap api-compliant mode, it will not use wpcap.dll and instead use its default packet.dll for the lib, and not populate wpcap.dll.

Edit: My apologies, the xemu cross-compiler docker container hogs about 12.5 gbs of ram on my laptop causing it to crawl, so I'm using the current runners to generate the working build!