### PR TITLE
nv2a: Fix vertex Z calculation using clip range

### DIFF
--- a/hw/xbox/nv2a/vsh.c
+++ b/hw/xbox/nv2a/vsh.c
@@ -849,8 +849,10 @@ void vsh_translate(uint16_t version,
         mstring_append(body, "  oPos.z = oPos.w;\n");
     }
     mstring_append(body,
-        "  if (clipRange.y != clipRange.x) {\n"
-        "    oPos.z = (oPos.z - clipRange.x)/(0.5*(clipRange.y - clipRange.x)) - 1;\n"
+        "  if (clipRange.y > clipRange.x) {\n"
+        "    oPos.z = (oPos.z - clipRange.x)/(0.5 * (clipRange.y - clipRange.x)) - 1;\n"
+        "  } else {\n"
+        "    oPos.z = (oPos.z - clipRange.y)/(0.5 * (clipRange.x - clipRange.y)) - 1;\n"
         "  }\n"
 
         /* Correct for the perspective divide */


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/xemu-project/xemu/issues/524#issuecomment-2019334483), this fix restores a number of missing UI elements in Halo 2 on Mac.

### System Information
2020 M1 Mac mini
macOS 14.1.1

### Fixed Behavior

Restored blue background on mainmenu:
![image](https://github.com/xemu-project/xemu/assets/52939755/a758b6ab-c947-40db-a63c-42ed7b1ed938)

Restored profile icons:
![image](https://github.com/xemu-project/xemu/assets/52939755/dbceb51b-a530-4926-9f35-5c222dfbbd54)

Restored UI elements:
![image](https://github.com/xemu-project/xemu/assets/52939755/3e76f89e-0bde-467b-9eac-e16d9e4470e1)
