### PR TITLE
Workflows: Update actions to silence Node 16 warnings

### DIFF
--- a/.github/workflows/build-xemu-win64-toolchain.yml
+++ b/.github/workflows/build-xemu-win64-toolchain.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone tree
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Extract image metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v4.3.0

--- a/.github/workflows/build-xemu-win64-toolchain.yml
+++ b/.github/workflows/build-xemu-win64-toolchain.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Extract image metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v4.3.0
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: |
@@ -35,16 +35,16 @@ jobs:
             type=ref,event=branch
             type=sha
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.2.1
+        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v5
         with:
           context: ubuntu-win64-cross
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
     - name: Download source package
-      uses: actions/download-artifact@v4@v4
+      uses: actions/download-artifact@v4
       with:
         name: src.tar.gz
     - name: Extract source package
@@ -318,12 +318,12 @@ jobs:
         configuration: ["debug", "release"]
     steps:
     - name: Download x86_64 build
-      uses: actions/download-artifact@v4@v4
+      uses: actions/download-artifact@v4
       with:
         name: xemu-macos-x86_64-${{ matrix.configuration }}
         path: xemu-macos-x86_64-${{ matrix.configuration }}
     - name: Download arm64 build
-      uses: actions/download-artifact@v4@v4
+      uses: actions/download-artifact@v4
       with:
         name: xemu-macos-arm64-${{ matrix.configuration }}
         path: xemu-macos-arm64-${{ matrix.configuration }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone tree
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     # On push to master, increment patch version and create a new tag on release
@@ -48,7 +48,7 @@ jobs:
         ./scripts/archive-source.sh src.tar
         gzip -1 src.tar
     - name: Upload source package artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: src.tar.gz
         path: src.tar.gz
@@ -71,14 +71,14 @@ jobs:
 
     steps:
     - name: Download source package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4@v4
       with:
         name: src.tar.gz
     - name: Extract source package
       run: tar xf src.tar.gz
     - name: Initialize compiler cache
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /tmp/xemu-ccache
         key: cache-wincross-${{ runner.os }}-${{ matrix.configuration }}-${{ github.sha }}
@@ -97,7 +97,7 @@ jobs:
           $DOCKER_IMAGE_NAME \
             bash -c "ccache -z; ./build.sh -p win64-cross ${{ matrix.build_param }} && ccache -s"
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.artifact_name }}
         path: dist
@@ -118,7 +118,7 @@ jobs:
           artifact_name: xemu-win-release
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ matrix.artifact_name }}
         path: ${{ matrix.artifact_name }}
@@ -132,7 +132,7 @@ jobs:
         7z a -tzip ../dist/${{ matrix.artifact_name }}.zip * "-xr!*.pdb"
         7z a -tzip ../dist/${{ matrix.artifact_name }}-pdb.zip "-ir!*.pdb"
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.artifact_name }}-pdb
         path: dist
@@ -155,13 +155,13 @@ jobs:
     steps:
     - name: Initialize compiler cache
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /tmp/xemu-ccache
         key: cache-${{ runner.os }}-${{ matrix.configuration }}-${{ github.sha }}
         restore-keys: cache-${{ runner.os }}-${{ matrix.configuration }}-
     - name: Download source package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: src.tar.gz
     - name: Extract source package
@@ -169,7 +169,7 @@ jobs:
         mkdir src
         tar -C src -xf src.tar.gz
     - name: Clone Debian packaging
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: deb
         path: debian-tmp
@@ -232,7 +232,7 @@ jobs:
       run: |
         tar -czvf ${{ matrix.artifact_filename }} --transform "s#^dist#xemu#" dist
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.artifact_name }}
         path: ${{ matrix.artifact_filename }}
@@ -266,7 +266,7 @@ jobs:
           artifact_filename: xemu-macos-arm64-release.zip
     steps:
     - name: Download source package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: src.tar.gz
     - name: Extract source package
@@ -284,7 +284,7 @@ jobs:
         python3 -m pip install pyyaml requests
     - name: Initialize compiler, library cache
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           xemu-ccache
@@ -304,7 +304,7 @@ jobs:
         zip -r ../${{ matrix.artifact_filename }} *
         popd
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.artifact_name }}
         path: ${{ matrix.artifact_filename }}
@@ -318,12 +318,12 @@ jobs:
         configuration: ["debug", "release"]
     steps:
     - name: Download x86_64 build
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4@v4
       with:
         name: xemu-macos-x86_64-${{ matrix.configuration }}
         path: xemu-macos-x86_64-${{ matrix.configuration }}
     - name: Download arm64 build
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4@v4
       with:
         name: xemu-macos-arm64-${{ matrix.configuration }}
         path: xemu-macos-arm64-${{ matrix.configuration }}
@@ -347,7 +347,7 @@ jobs:
         zip -r ../xemu-macos-universal-${{ matrix.configuration }}.zip *
         popd
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: xemu-macos-universal-${{ matrix.configuration }}
         path: xemu-macos-universal-${{ matrix.configuration }}.zip
@@ -358,7 +358,7 @@ jobs:
     needs: [Ubuntu, macOSUniversal, WindowsPdb]
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: dist
     - name: Extract source package
@@ -411,7 +411,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download source package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: src.tar.gz
     - name: Extract source package
@@ -419,7 +419,7 @@ jobs:
         mkdir src
         tar -C src -xf src.tar.gz
     - name: Clone Debian packaging
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: deb
         path: debian-tmp


### PR DESCRIPTION
Node 16 is deprecated on GitHub runners, causing a warning message, updating actions that use Node 16 to the versions that use Node 20, will silence the warnings.