### PR TITLE
apu.c: Kill audio subsystem if there are no playback devices

### DIFF
--- a/hw/xbox/mcpx/apu.c
+++ b/hw/xbox/mcpx/apu.c
@@ -2631,6 +2631,16 @@ void mcpx_apu_init(PCIBus *bus, int devfn, MemoryRegion *ram)
         exit(1);
     }
 
+    if (SDL_GetNumAudioDevices(0) == 0) {
+        SDL_QuitSubSystem(SDL_INIT_AUDIO);
+        
+        if (SDL_AudioInit("dummy") < 0) {
+            fprintf(stderr, "Failed to initalize 'dummy' audio device\n");
+            assert(!"SDL_AudioInit failed!");
+            exit(1);
+        }
+    }
+    
     SDL_AudioDeviceID sdl_audio_dev;
     sdl_audio_dev = SDL_OpenAudioDevice(NULL, 0, &sdl_audio_spec, NULL, 0);
     if (sdl_audio_dev == 0) {


### PR DESCRIPTION
fixes issue #354

@GXTX 's initial hypothesis was correct, simply killing the audio subsystem if there are no available audio devices does work...

in the event the dummy audio device does fail to load, assert and kill the program, however in my testing this *shouldn't* occur