### PR TITLE
UI: Add games directory and allow switching of games via controller in popup-menu

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -7,6 +7,7 @@ general:
       type: bool
       default: true
   screenshot_dir: string
+  games_dir: string
   skip_boot_anim: bool
   # throttle_io: bool
   last_viewed_menu_index: integer

--- a/ui/xui/actions.cc
+++ b/ui/xui/actions.cc
@@ -36,8 +36,6 @@ void ActionEjectDisc(void)
 
 void ActionLoadDisc(void)
 {
-    Error *err = NULL;
-
     const char *iso_file_filters = ".iso Files\0*.iso\0All Files\0*.*\0";
     const char *new_disc_path =
         PausedFileOpen(NOC_FILE_DIALOG_OPEN, iso_file_filters,
@@ -47,7 +45,14 @@ void ActionLoadDisc(void)
         return;
     }
 
-    xemu_load_disc(new_disc_path, &err);
+    ActionLoadDiscFile(new_disc_path);
+}
+
+void ActionLoadDiscFile(const char *file_path)
+{
+    Error *err = NULL;
+    xemu_load_disc(file_path, &err);
+
     if (err) {
         xemu_queue_error_message(error_get_pretty(err));
         error_free(err);

--- a/ui/xui/actions.hh
+++ b/ui/xui/actions.hh
@@ -20,6 +20,7 @@
 
 void ActionEjectDisc();
 void ActionLoadDisc();
+void ActionLoadDiscFile(const char *file_path);
 void ActionTogglePause();
 void ActionReset();
 void ActionShutdown();

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -71,6 +71,7 @@ void MainMenuGeneralView::Draw()
            "Skip the full Xbox boot animation sequence");
     FilePicker("Screenshot output directory", &g_config.general.screenshot_dir,
                NULL, true);
+    FilePicker("Games directory", &g_config.general.games_dir, NULL, true);
     // toggle("Throttle DVD/HDD speeds", &g_config.general.throttle_io,
     //        "Limit DVD/HDD throughput to approximate Xbox load times");
 }

--- a/ui/xui/popup-menu.hh
+++ b/ui/xui/popup-menu.hh
@@ -51,7 +51,7 @@ public:
     PopupMenu();
     void InitFocus();
     virtual ~PopupMenu();
-    void Show(const ImVec2 &direction);
+    virtual void Show(const ImVec2 &direction);
     void Hide(const ImVec2 &direction);
     bool IsAnimating();
     void Draw(PopupMenuItemDelegate &nav);


### PR DESCRIPTION
At the moment, switching between games in Xemu typically requires using a mouse/keyboard. When using a game controller, it's possible to open the popup menu, and select "Load Disc...", however that launches a native file browser which does not have controller input support, requiring use of a mouse/keyboard to select the target file. The goal of this PR is to make switching between games a bit more convenient and possible using a controller.

This PR introduces a new setting called "Games directory" within Settings > General > Miscellaneous. By default there is no value specified, and when clicked the user is presented with a file browser to select the desired directory containing .iso game files.

When the popup menu is activated (via right click, or start/back from an Xbox Controller S), there is now a "Games" submenu button that when selected, will present the user with a sorted list of games based on the configured directory. Selecting a game will result in Xemu loading the corresponding disc file. In the event no .iso files are detected in the directory, or if the directory is still undefined, there is an option "No games found" that when selected will open the main settings UI so that the user may adjust the games directory as needed.

![All Settings](https://github.com/xemu-project/xemu/assets/6829425/9108708e-5bfc-480c-a809-49c22128a0ad)

![Root Popup Menu](https://github.com/xemu-project/xemu/assets/6829425/e0c47a09-f7ac-43c7-988d-e8fdd160c788)

![Games Popup Menu - With .iso Files Found](https://github.com/xemu-project/xemu/assets/6829425/07b540f4-91e6-46dc-962f-deec71ab51d1)

![Games Popup Menu - No Files Found / Directory Not Set](https://github.com/xemu-project/xemu/assets/6829425/f6bea035-d683-45e9-9881-c8ccff123577)
