### PR TITLE
Halo 2 skybox fix (& realtime lighting shadow casting in other games)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 /GNUmakefile
 /build/
 /.cache/
+/ccache/
 /.vscode/
+/.vs/
 *.pyc
 .sdk
 .stgit-*

--- a/hw/xbox/nv2a/shaders.c
+++ b/hw/xbox/nv2a/shaders.c
@@ -977,7 +977,7 @@ GLSL_DEFINE(texMat3, GLSL_C_MAT4(NV_IGRAPH_XF_XFCTX_T3MAT))
                       "  gl_Position = oPos;\n"
                       "  gl_PointSize = oPts.x;\n"
                       "  gl_ClipDistance[0] = oPos.z - oPos.w*clipRange.z;\n" // Near
-                      "  gl_ClipDistance[1] = oPos.w*clipRange.w - oPos.z;\n" // Far
+                      "  gl_ClipDistance[1] = oPos.w*clipRange.w + oPos.z;\n" // Far
                       "\n"
                       "}\n",
                        shade_model_mult,

--- a/hw/xbox/nv2a/vsh.c
+++ b/hw/xbox/nv2a/vsh.c
@@ -842,8 +842,8 @@ void vsh_translate(uint16_t version,
          * opengl expects it in clip space.
          * TODO: the pixel-center co-ordinate differences should handled
          */
-        "  oPos.x = 2.0 * (oPos.x - surfaceSize.x * 0.5) / surfaceSize.x;\n"
-        "  oPos.y = -2.0 * (oPos.y - surfaceSize.y * 0.5) / surfaceSize.y;\n"
+        "  oPos.x = 2.0 * (oPos.x / surfaceSize.x) - 1;\n"
+        "  oPos.y = -2.0 * (oPos.y / surfaceSize.y) + 1;\n"
     );
     if (z_perspective) {
         mstring_append(body, "  oPos.z = oPos.w;\n");
@@ -861,6 +861,10 @@ void vsh_translate(uint16_t version,
         "  } else {\n"
             /* we don't want the OpenGL perspective divide to happen, but we
              * can't multiply by W because it could be meaningless here */
+            /* clamp z to 1 */
+        "    if (oPos.z > 1.0) {\n"
+        "      oPos.z = 1.0;\n"
+        "    }\n"
         "    oPos.w = 1.0;\n"
         "  }\n"
     );


### PR DESCRIPTION
Clamping depth value to 1 apparently fixes this. Skybox is also affected by the see through issue:

EDIT: In case you are caching shaders in disk, you will need to delete your shader cache file.

![Captura3](https://github.com/xemu-project/xemu/assets/30195994/1d239267-a15d-463c-a83c-21d654c34a29)
![Captura3mal](https://github.com/xemu-project/xemu/assets/30195994/8cb141b2-7a5b-47f0-bcb8-8fc355810751)
![Captura4](https://github.com/xemu-project/xemu/assets/30195994/b3537953-fe92-4335-b6f3-628dc21f0231)
![Captura4mal](https://github.com/xemu-project/xemu/assets/30195994/d1941ca8-36bb-4976-8d52-7ef5df09038f)
![Captura](https://github.com/xemu-project/xemu/assets/30195994/abc2d594-819f-46a7-841f-a31807becc84)
![Capturamal](https://github.com/xemu-project/xemu/assets/30195994/bce9c8bd-aaa3-4c31-b45e-f7daf25a4e62)
![Captura2](https://github.com/xemu-project/xemu/assets/30195994/407b4d2e-5639-411a-a26e-51191dc4dae6)
![Captura2mal](https://github.com/xemu-project/xemu/assets/30195994/7f44b53b-0d83-42de-ac3c-c7dca4f5ec2a)

