### PR TITLE
Implement XDVD security challenge responses

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -263,6 +263,7 @@ sys:
     eeprom_path: string
     hdd_path: string
     dvd_path: string
+    dvd_security_path: string
 
 perf:
   hard_fpu:

--- a/hw/ide/atapi.c
+++ b/hw/ide/atapi.c
@@ -1101,6 +1101,12 @@ static void cmd_read(IDEState *s, uint8_t* buf)
     }
 
     lba = ldl_be_p(buf + 2);
+
+#ifdef XBOX
+    lba = xdvd_get_lba_offset(&s->xdvd_security, total_sectors, lba);
+    total_sectors = xdvd_get_sector_cnt(&s->xdvd_security, total_sectors);
+#endif
+
     if (lba >= total_sectors || lba + nb_sectors - 1 >= total_sectors) {
         ide_atapi_cmd_error(s, ILLEGAL_REQUEST, ASC_LOGICAL_BLOCK_OOR);
         return;
@@ -1256,6 +1262,10 @@ static void cmd_read_toc_pma_atip(IDEState *s, uint8_t* buf)
 static void cmd_read_cdvd_capacity(IDEState *s, uint8_t* buf)
 {
     uint64_t total_sectors = s->nb_sectors >> 2;
+
+#ifdef XBOX
+    total_sectors = xdvd_get_sector_cnt(&s->xdvd_security, total_sectors);
+#endif
 
     /* NOTE: it is really the number of sectors minus 1 */
     stl_be_p(buf, total_sectors - 1);

--- a/hw/ide/atapi.c
+++ b/hw/ide/atapi.c
@@ -75,11 +75,27 @@ static inline int media_present(IDEState *s)
 /* XXX: DVDs that could fit on a CD will be reported as a CD */
 static inline int media_is_dvd(IDEState *s)
 {
+#ifdef XBOX
+    // We need to prevent small XISOs from being reported as CD-ROMs
+    // If the DVD security path is set, we can assume it is an XISO.
+    const char *dvd_security_path = g_config.sys.files.dvd_security_path;
+    if (strlen(dvd_security_path) > 0) {
+        return media_present(s);
+    }
+#endif
     return (media_present(s) && s->nb_sectors > CD_MAX_SECTORS);
 }
 
 static inline int media_is_cd(IDEState *s)
 {
+#ifdef XBOX
+    // We need to prevent small XISOs from being reported as CD-ROMs
+    // If the DVD security path is set, we can assume it is an XISO.
+    const char *dvd_security_path = g_config.sys.files.dvd_security_path;
+    if (strlen(dvd_security_path) > 0) {
+        return 0;
+    }
+#endif
     return (media_present(s) && s->nb_sectors <= CD_MAX_SECTORS);
 }
 

--- a/hw/ide/core.c
+++ b/hw/ide/core.c
@@ -1413,6 +1413,13 @@ static void ide_reset(IDEState *s)
     s->end_transfer_func = ide_dummy_transfer_stop;
     ide_dummy_transfer_stop(s);
     s->media_changed = 0;
+
+#ifdef XBOX
+    memset(s->xdvd_challenges_encrypted, 0, sizeof(s->xdvd_challenges_encrypted));
+    memset(s->xdvd_challenges_decrypted, 0, sizeof(s->xdvd_challenges_decrypted));
+    memset(&s->xdvd_security, 0, sizeof(s->xdvd_security));
+#endif
+
 }
 
 static bool cmd_nop(IDEState *s, uint8_t cmd)

--- a/hw/ide/core.c
+++ b/hw/ide/core.c
@@ -1217,6 +1217,13 @@ static void ide_cd_change_cb(void *opaque, bool load, Error **errp)
     s->cdrom_changed = 1;
     s->events.new_media = true;
     s->events.eject_request = false;
+
+#ifdef XBOX
+    memset(s->xdvd_challenges_encrypted, 0, sizeof(s->xdvd_challenges_encrypted));
+    memset(s->xdvd_challenges_decrypted, 0, sizeof(s->xdvd_challenges_decrypted));
+    memset(&s->xdvd_security, 0, sizeof(s->xdvd_security));
+#endif
+
     ide_bus_set_irq(s->bus);
 }
 

--- a/hw/xbox/meson.build
+++ b/hw/xbox/meson.build
@@ -19,3 +19,4 @@ specific_ss.add(files(
 	))
 subdir('nv2a')
 subdir('mcpx')
+subdir('xdvd')

--- a/hw/xbox/xdvd/meson.build
+++ b/hw/xbox/xdvd/meson.build
@@ -1,0 +1,6 @@
+xdvd_ss = ss.source_set()
+xdvd_ss.add(files(
+	'xdvd.c',
+	))
+
+specific_ss.add_all(xdvd_ss)

--- a/hw/xbox/xdvd/xdvd.c
+++ b/hw/xbox/xdvd/xdvd.c
@@ -1,0 +1,195 @@
+/*
+ * QEMU Xbox DVD Security Emulation
+ *
+ * Copyright (c) 2024 Ryan Wendland
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "qemu/osdep.h"
+#include "ui/xemu-settings.h"
+#include "util/rc4.h"
+#include "util/sha1.h"
+#include "xdvd.h"
+
+// Ref
+// https://web.archive.org/web/20240316195746/https://multimedia.cx/eggs/xbox-sphinx-protocol/
+// for these constants
+#define CR_TABLE_NUM_ENTRIES 773
+#define CR_ENTRIES_OFFSET 774
+#define CR_ENTRIES_LEN 253
+#define CR_KEY_BASIS_OFFSET 1187
+#define CR_KEY_BASIS_LEN 44
+
+#ifndef ATAPI_SECTOR_SIZE
+#define ATAPI_SECTOR_SIZE 2048
+#endif
+
+void xdvd_get_decrypted_responses(const uint8_t *xdvd_challenge_table_encrypted,
+                                  uint8_t *xdvd_challenge_table_decrypted)
+{
+    // Prepare the data for decryption
+    memcpy(xdvd_challenge_table_decrypted, xdvd_challenge_table_encrypted,
+           XDVD_STRUCTURE_LEN);
+
+    SHA1Context sha_ctx;
+    RC4Context rc4_ctx;
+    uint8_t sha_hash [20];
+
+    // The challenge/response table is encrypted with RC4. The key is derived
+    // from the CR_KEY_BASIS_OFFSET after a SHA1 hash is computed over it.
+    sha1_reset(&sha_ctx);
+    sha1_input(&sha_ctx, (uint8_t *)&xdvd_challenge_table_encrypted[CR_KEY_BASIS_OFFSET],
+                    CR_KEY_BASIS_LEN);
+    sha1_result(&sha_ctx, sha_hash);
+
+    // The first 7 bytes of the SHA1 hash are fed into the RC4 initialisation
+    // function as the key
+    rc4_init(&rc4_ctx, sha_hash, 7);
+
+    // Then, the RC4 decrypter does its work on the CR_ENTRIES_LEN bytes of the
+    // challenge/response table.
+    rc4_crypt(&rc4_ctx, &xdvd_challenge_table_decrypted[CR_ENTRIES_OFFSET],
+                   CR_ENTRIES_LEN);
+}
+
+// Given the already decrypted challenge table and the challenge ID sent by the
+// Xbox, return the required response dword
+uint32_t xdvd_get_challenge_response(const uint8_t *xdvd_challenge_table_decrypted,
+                            uint8_t challenge_id)
+{
+    int challengeEntryCount =
+        xdvd_challenge_table_decrypted[CR_TABLE_NUM_ENTRIES];
+    PXBOX_DVD_CHALLENGE challenges =
+        (PXBOX_DVD_CHALLENGE)(&xdvd_challenge_table_decrypted[CR_ENTRIES_OFFSET]);
+
+    for (int i = 0; i < challengeEntryCount; i++) {
+        if (challenges[i].type != 1)
+            continue;
+
+        if (challenges[i].id == challenge_id)
+            return challenges[i].response;
+    }
+
+    return 0;
+}
+
+// When the Xbox DVD in not authenticated it is on the video partition (=0) and
+// returns a small sector count Once the DVD is authenticated, the xbox will
+// activate the game partition (=1) which retuns the full sector count
+uint64_t xdvd_get_sector_cnt(XBOX_DVD_SECURITY *xdvd_security,
+                             uint64_t total_sectors)
+{
+    if (xdvd_is_redump(total_sectors) == false) {
+        return total_sectors;
+    }
+
+    // A 'redump' style iso returns XDVD_VIDEO_PARTITION_SECTOR_CNT initially
+    // before it is authenticated otherwise it returns the full sector count of
+    // the game data.
+    if (xdvd_security->page.Authenticated == 0 ||
+        xdvd_security->page.Partition == 0) {
+        total_sectors = XDVD_VIDEO_PARTITION_SECTOR_CNT;
+    } else {
+        assert((XGD1_LSEEK_OFFSET / ATAPI_SECTOR_SIZE) < total_sectors);
+        total_sectors -= (XGD1_LSEEK_OFFSET / ATAPI_SECTOR_SIZE);
+    }
+    return total_sectors;
+}
+
+// On the game partition, all reads to the ISO need to be offset to emulate it
+// being on the game partition
+uint32_t xdvd_get_lba_offset(XBOX_DVD_SECURITY *xdvd_security,
+                             uint64_t total_sectors, unsigned int lba)
+{
+    if (xdvd_is_redump(total_sectors)) {
+        if (xdvd_security->page.Authenticated == 1 &&
+            xdvd_security->page.Partition == 1) {
+            lba += XGD1_LSEEK_OFFSET / ATAPI_SECTOR_SIZE;
+        }
+    }
+    return lba;
+}
+
+bool xdvd_get_encrypted_challenge_table(uint8_t *xdvd_challenge_table_encrypted)
+{
+    bool status = true;
+
+    const char *dvd_security_path = g_config.sys.files.dvd_security_path;
+    memset(xdvd_challenge_table_encrypted, 0, XDVD_STRUCTURE_LEN);
+
+    FILE *f = qemu_fopen(dvd_security_path, "rb");
+    if (f == NULL) {
+        return false;
+    }
+
+    int file_size;
+    fseek(f, 0, SEEK_END);
+    file_size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    // If the security structure is read from the DVD drive it will be 1636 bytes long
+    // If it is read from the DVD disk (via Kreon etc) it will be 2048 bytes long
+    if (file_size == XDVD_STRUCTURE_LEN) {
+        fread(xdvd_challenge_table_encrypted, 1, file_size, f);
+    } else if (file_size == XDVD_SECURITY_SECTOR_LEN) {
+        // We have a redump style security sector. This is in a different layout to the expected
+        // challenge response but we can built it up from the data we have.
+
+        // First two bytes are length of structure
+        xdvd_challenge_table_encrypted[0] = (XDVD_STRUCTURE_LEN >> 8) & 0xFF;
+        xdvd_challenge_table_encrypted[1] = (XDVD_STRUCTURE_LEN >> 0) & 0xFF;
+
+        // Read header and place it in the correct place
+        fread(&xdvd_challenge_table_encrypted[4], 1, 0x10, f);
+
+        // Read challenge/response table onward to end of file
+        fseek(f, CR_ENTRIES_OFFSET - 6, SEEK_SET);
+        fread(&xdvd_challenge_table_encrypted[CR_ENTRIES_OFFSET - 2], 1,
+              XDVD_STRUCTURE_LEN - (CR_ENTRIES_OFFSET - 2), f);
+    } else {
+        status = false;
+    }
+
+    fclose(f);
+    return status;
+}
+
+// The Xbox will request this page before it begins sending challenges, so we
+// need to be able to reply with a default structure
+void xdvd_get_default_security_page(XBOX_DVD_SECURITY *xdvd_security)
+{
+    // Only needs a few crucial initial values to start the challenge/response
+    // session
+    static const XBOX_DVD_SECURITY s = {
+        .header.ModeDataLength[0] = 0,
+        .header.ModeDataLength[1] = sizeof(XBOX_DVD_SECURITY) - 2,
+        .page.PageCode = MODE_PAGE_XBOX_SECURITY,
+        .page.PageLength = sizeof(XBOX_DVD_SECURITY_PAGE) - 2,
+        .page.Unk1 = 1,
+        .page.BookTypeAndVersion = 0xD1,
+        .page.Unk2 = 2,
+    };
+    memcpy(xdvd_security, &s, sizeof(s));
+};
+
+bool xdvd_is_redump(uint64_t total_sectors)
+{
+    return total_sectors == XDVD_REDUMP_SECTOR_CNT;
+}

--- a/hw/xbox/xdvd/xdvd.h
+++ b/hw/xbox/xdvd/xdvd.h
@@ -1,0 +1,117 @@
+/*
+ * QEMU Xbox DVD Security Emulation
+ *
+ * Copyright (c) 2024 Ryan Wendland
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef HW_XDVD_H
+#define HW_XDVD_H
+
+#include <stdint.h>
+
+// Ref
+// https://web.archive.org/web/20230331163919/https://multimedia.cx/eggs/xbox-sphinx-protocol/
+// https://xboxdevwiki.net/Xbox_Game_Disc
+// https://xboxdevwiki.net/DVD_Drive
+// https://github.com/XboxDev/extract-xiso
+
+// This is the start of the Xbox game data
+#define XGD1_LSEEK_OFFSET 0x18300000UL
+
+// The sector count of the video parition of a Xbox DVD
+#define XDVD_VIDEO_PARTITION_SECTOR_CNT 6992
+
+// The sector count of 'redump' iso files
+#define XDVD_REDUMP_SECTOR_CNT 3820880
+
+// Page Code for Xbox Security Challenges (over SCSI)
+#define MODE_PAGE_XBOX_SECURITY 0x3E
+
+#define XDVD_STRUCTURE_LEN 0x664
+#define XDVD_SECURITY_PAGE_LEN 28
+#define XDVD_SECURITY_SECTOR_LEN 2048
+
+#define XDVD_STRUCTURE_LAYER 0xFE
+#define XDVD_STRUCTURE_BLOCK_NUMBER 0xFF02FDFF
+
+// Standard SCSI Mode Sense/Select header
+typedef struct _MODE_PARAMETER_HEADER10 {
+    uint8_t ModeDataLength[2];
+    uint8_t MediumType;
+    uint8_t DeviceSpecificParameter;
+    uint8_t Reserved[2];
+    uint8_t BlockDescriptorLength[2];
+} QEMU_PACKED MODE_PARAMETER_HEADER10, *PMODE_PARAMETER_HEADER10;
+QEMU_BUILD_BUG_MSG(sizeof(MODE_PARAMETER_HEADER10) != 8,
+               "sizeof(MODE_PARAMETER_HEADER10) != 8");
+
+// https://xboxdevwiki.net/DVD_Drive
+typedef struct _XBOX_DVD_SECURITY_PAGE {
+    uint8_t PageCode;
+    uint8_t PageLength;
+    uint8_t Partition; // 0 - video, 1 - xbox
+    uint8_t Unk1;
+    uint8_t Authenticated;
+    uint8_t BookTypeAndVersion;
+    uint8_t Unk2;
+    uint8_t ChallengeID;
+    uint32_t ChallengeValue;
+    uint32_t ResponseValue;
+    uint32_t Unk3;
+} QEMU_PACKED XBOX_DVD_SECURITY_PAGE, *PXBOX_DVD_SECURITY_PAGE;
+QEMU_BUILD_BUG_MSG(sizeof(XBOX_DVD_SECURITY_PAGE) != 20,
+               "sizeof(XBOX_DVD_SECURITY_PAGE) != 20");
+
+// DVD Mode Select/Mode Sense Security struct
+typedef struct _XBOX_DVD_SECURITY {
+    MODE_PARAMETER_HEADER10 header;
+    XBOX_DVD_SECURITY_PAGE page;
+} QEMU_PACKED XBOX_DVD_SECURITY;
+QEMU_BUILD_BUG_MSG(sizeof(XBOX_DVD_SECURITY) != 28,
+               "sizeof(XBOX_DVD_SECURITY) != 28");
+
+// https://web.archive.org/web/20240316195746/https://multimedia.cx/eggs/xbox-sphinx-protocol/
+typedef struct _XBOX_DVD_CHALLENGE {
+    uint8_t type;
+    uint8_t id;
+    uint32_t challenge;
+    uint8_t reserved;
+    uint32_t response;
+} QEMU_PACKED XBOX_DVD_CHALLENGE, *PXBOX_DVD_CHALLENGE;
+QEMU_BUILD_BUG_MSG(sizeof(XBOX_DVD_CHALLENGE) != 11,
+               "sizeof(XBOX_DVD_CHALLENGE) != 11");
+
+uint32_t
+xdvd_get_challenge_response(const uint8_t *xdvd_challenge_table_decrypted,
+                            uint8_t challenge_id);
+
+void xdvd_get_default_security_page(XBOX_DVD_SECURITY *xdvd_security);
+
+uint64_t xdvd_get_sector_cnt(XBOX_DVD_SECURITY *xdvd_security,
+                             uint64_t total_sectors);
+
+uint32_t xdvd_get_lba_offset(XBOX_DVD_SECURITY *xdvd_security,
+                             uint64_t total_sectors, unsigned int lba);
+
+bool xdvd_get_encrypted_challenge_table(
+    uint8_t *xdvd_challenge_table_encrypted);
+
+void xdvd_get_decrypted_responses(const uint8_t *xdvd_challenge_table_encrypted,
+                                  uint8_t *xdvd_challenge_table_decrypted);
+
+bool xdvd_is_redump(uint64_t total_sectors);
+
+#endif // HW_XDVD_H

--- a/hw/xbox/xdvd/xdvd.h
+++ b/hw/xbox/xdvd/xdvd.h
@@ -31,11 +31,12 @@
 // This is the start of the Xbox game data
 #define XGD1_LSEEK_OFFSET 0x18300000UL
 
-// The sector count of the video parition of a Xbox DVD
+// The sector count of the video partition of a Xbox DVD
 #define XDVD_VIDEO_PARTITION_SECTOR_CNT 6992
 
-// The sector count of 'redump' iso files
-#define XDVD_REDUMP_SECTOR_CNT 3820880
+// The sector count of full Xbox iso files. This includes the video partition and corresponds to 
+// equal to 7,825,162,240 bytes.
+#define XDVD_SECTOR_CNT 3820880
 
 // Page Code for Xbox Security Challenges (over SCSI)
 #define MODE_PAGE_XBOX_SECURITY 0x3E
@@ -46,6 +47,8 @@
 
 #define XDVD_STRUCTURE_LAYER 0xFE
 #define XDVD_STRUCTURE_BLOCK_NUMBER 0xFF02FDFF
+
+#define XDVD_CHALLENGE_VALID 0x01
 
 // Standard SCSI Mode Sense/Select header
 typedef struct _MODE_PARAMETER_HEADER10 {
@@ -112,6 +115,6 @@ bool xdvd_get_encrypted_challenge_table(
 void xdvd_get_decrypted_responses(const uint8_t *xdvd_challenge_table_encrypted,
                                   uint8_t *xdvd_challenge_table_decrypted);
 
-bool xdvd_is_redump(uint64_t total_sectors);
+bool xdvd_has_video_partition(uint64_t total_sectors);
 
 #endif // HW_XDVD_H

--- a/include/hw/ide/ide-dev.h
+++ b/include/hw/ide/ide-dev.h
@@ -50,6 +50,10 @@ enum ide_dma_cmd {
     IDE_DMA__COUNT
 };
 
+#ifdef XBOX
+#include "hw/xbox/xdvd/xdvd.h"
+#endif
+
 /* NOTE: IDEState represents in fact one drive */
 struct IDEState {
     IDEBus *bus;
@@ -140,6 +144,12 @@ struct IDEState {
     uint8_t *smart_selftest_data;
     /* AHCI */
     int ncq_queues;
+
+#ifdef XBOX
+    uint8_t xdvd_challenges_encrypted[XDVD_STRUCTURE_LEN];
+    uint8_t xdvd_challenges_decrypted[XDVD_STRUCTURE_LEN];
+    XBOX_DVD_SECURITY xdvd_security;
+#endif
 };
 
 struct IDEDeviceClass {

--- a/system/vl.c
+++ b/system/vl.c
@@ -2981,6 +2981,28 @@ void qemu_init(int argc, char **argv)
         }
     }
 
+    const char *dvd_security_path = g_config.sys.files.dvd_security_path;
+    for (int i = 1; i < argc; i++) {
+        if (argv[i] && strcmp(argv[i], "-dvd_security_path") == 0) {
+            argv[i] = NULL;
+            if (i < argc - 1 && argv[i+1]) {
+                dvd_security_path = argv[i+1];
+                argv[i+1] = NULL;
+                xemu_settings_set_string(&g_config.sys.files.dvd_security_path, dvd_security_path);
+            }
+            break;
+        }
+    }
+
+    if (strlen(dvd_security_path) > 0) {
+        if (xemu_check_file(dvd_security_path)) {
+            char *msg = g_strdup_printf("Failed to open DVD security file '%s'. Please check machine settings.", dvd_security_path);
+            xemu_queue_error_message(msg);
+            g_free(msg);
+            dvd_security_path = "";
+        }
+    }
+
     // Always populate DVD drive. If disc path is the empty string, drive is
     // connected but no media present.
     fake_argv[fake_argc++] = strdup("-drive");


### PR DESCRIPTION
This PR implements the DVD security challenge/response mechanism to the best of my knowledge used on a Xbox console between the DVD drive and the Xbox. 

This allows loading retail Xbox titles both in 'redump' format and xiso format with an unmodified retail BIOS.

For this to work, you need the security info from your original game disk. There is two methods:
1. `SS.bin` from a compatible 'Kreon' drive using the method on redump.org <http://wiki.redump.org/index.php?title=Microsoft_Xbox_and_Xbox_360_Dumping_Guide>, 
2. `dvd_layout.bin` from your Xbox and original disk using these homebrew apps <https://github.com/Ryzee119/OGX_CHALLENGE_TABLE/releases/tag/build-202310141001> or <https://gist.github.com/Ernegien/bef054a43213c52c2bef8d94bf9f51cb>  

These two dumps have the same info but in a slightly different format. As I understand `SS.bin` represents what is physically on the DVD, `dvd_layout.bin` is the packet that is formatted and sent by the DVD drive firmware. This PR detects either and converts accordingly.

To provide this file to xemu, there is currently no GUI element and is done by command line

`xemu.exe -dvd_security_path "SS.bin"`. The same arg is used for `"dvd_layout.bin"`.

**Notes from my testing:**
1. I had pretty good success using one common SS.bin/.dvd_layout.bin dump with many games. However later bioses seemed to only accept SS.bin dumps from that specific title. This could be improved security or an issue in my implementation?
2. The Xbox didn't seem to care if the DVD is 'redump' or XISO style aslong as the challenges are responded to correctly. Your mileage may vary.
3. Using a retail BIOS comes with the restrictions of the retail system such as region restrictions, and you wont be able to run homebrew (FTP etc)

**References**
1. https://gist.github.com/Ernegien/bef054a43213c52c2bef8d94bf9f51cb (Major shout out the xbox7887 for this!)
2. https://wayback-api.archive.org/web/20240316195746/https://multimedia.cx/eggs/xbox-sphinx-protocol/
4. https://xboxdevwiki.net/DVD_Drive
5. https://xboxdevwiki.net/Xbox_Game_Disc

This process just follows the text book challenge response process from the Xbox. There may be some unusual aspects that are missed and I only have a smallish selection of disks to test with. I pulled in some public domain RC4 and SHA1 libraries, not sure if they should live in the xdvd folder or not.

**Future work suggestions**
1. Generate SS.bin automatically?
2. Add to GUI and somehow link to specific titles

![image](https://github.com/xemu-project/xemu/assets/21236406/f4d80309-e5ad-4bc2-89d5-6aecaeb0b2de)


Fixes #1036
