### PR TITLE
Move SHA1 and RC4 functions from eeprom specific file to utils

### DIFF
--- a/hw/xbox/eeprom_generation.c
+++ b/hw/xbox/eeprom_generation.c
@@ -2,6 +2,7 @@
  * QEMU Xbox EEPROM Generation (MCPX Version 1.0)
  *
  * Copyright (c) 2020 Mike Davis
+ * Copyright (c) 2024 Ryan Wendland
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,6 +19,8 @@
  */
 
 #include "eeprom_generation.h"
+#include "util/sha1.h"
+#include "util/rc4.h"
 
 static uint32_t xbox_eeprom_crc(uint8_t *data, size_t len) {
 	uint32_t high = 0;
@@ -32,44 +35,6 @@ static uint32_t xbox_eeprom_crc(uint8_t *data, size_t len) {
 	return ~(high + low);
 }
 
-static void xbox_rc4_swap(RC4Context *ctx, int first, int second) {
-    uint8_t temp = ctx->s[first];
-    ctx->s[first] = ctx->s[second];
-    ctx->s[second] = temp;
-}
-
-static void xbox_rc4_init(RC4Context *ctx, uint8_t *data, size_t len) {
-    for (int i = 0; i < 256; i++) {
-        ctx->s[i] = i;
-    }
-    for (int i = 0, j = 0; i < 256; i++) {
-        j = (j + ctx->s[i] + data[i % len]) % 256;
-        xbox_rc4_swap(ctx, i, j);
-    }
-}
-
-static void xbox_rc4_crypt(RC4Context *ctx, uint8_t *data, size_t len) {
-    for (int i = 0, j = 0, k = 0; k < len; k++) {
-        i = (i + 1) % 256;
-        j = (j + ctx->s[i]) % 256;
-        xbox_rc4_swap(ctx, i, j);
-        data[k] ^= ctx->s[(ctx->s[i] + ctx->s[j]) % 256];
-    }
-}
-
-static uint32_t xbox_sha1_rotate(uint32_t bits, uint32_t val) {
-    return (val << bits) | (val >> (32 - bits));
-}
-
-static void xbox_sha1_fill(SHA1Context *ctx,
-    uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e) {
-    ctx->intermediate[0] = a;
-    ctx->intermediate[1] = b;
-    ctx->intermediate[2] = c;
-    ctx->intermediate[3] = d;
-    ctx->intermediate[4] = e;
-}
-
 static void xbox_sha1_reset(SHA1Context *ctx, XboxEEPROMVersion ver, bool first) {
     ctx->msg_blk_index = 0;
     ctx->computed = false;
@@ -79,127 +44,50 @@ static void xbox_sha1_reset(SHA1Context *ctx, XboxEEPROMVersion ver, bool first)
     switch (ver) {
     case XBOX_EEPROM_VERSION_D:
         if (first) {
-            xbox_sha1_fill(ctx, 0x85F9E51A, 0xE04613D2, 
+            sha1_fill(ctx, 0x85F9E51A, 0xE04613D2,
                 0x6D86A50C, 0x77C32E3C, 0x4BD717A4);
         } else {
-            xbox_sha1_fill(ctx, 0x5D7A9C6B, 0xE1922BEB,
+            sha1_fill(ctx, 0x5D7A9C6B, 0xE1922BEB,
                 0xB82CCDBC, 0x3137AB34, 0x486B52B3);
         }   
         break;
     case XBOX_EEPROM_VERSION_R2:
         if (first) {
-            xbox_sha1_fill(ctx, 0x39B06E79, 0xC9BD25E8, 
+            sha1_fill(ctx, 0x39B06E79, 0xC9BD25E8,
                 0xDBC6B498, 0x40B4389D, 0x86BBD7ED);
         } else {
-            xbox_sha1_fill(ctx, 0x9B49BED3, 0x84B430FC,
+            sha1_fill(ctx, 0x9B49BED3, 0x84B430FC,
                 0x6B8749CD, 0xEBFE5FE5, 0xD96E7393);
         }   
         break;
     case XBOX_EEPROM_VERSION_R3:
         if (first) {
-            xbox_sha1_fill(ctx, 0x8058763A, 0xF97D4E0E, 
+            sha1_fill(ctx, 0x8058763A, 0xF97D4E0E,
                 0x865A9762, 0x8A3D920D, 0x08995B2C);
         } else {
-            xbox_sha1_fill(ctx, 0x01075307, 0xA2f1E037,
+            sha1_fill(ctx, 0x01075307, 0xA2f1E037,
                 0x1186EEEA, 0x88DA9992, 0x168A5609);
         }   
         break;
     default: // default to 1.0 version
         if (first) {
-            xbox_sha1_fill(ctx, 0x72127625, 0x336472B9,
+            sha1_fill(ctx, 0x72127625, 0x336472B9,
                 0xBE609BEA, 0xF55E226B, 0x99958DAC);
         } else {
-            xbox_sha1_fill(ctx, 0x76441D41, 0x4DE82659,
+            sha1_fill(ctx, 0x76441D41, 0x4DE82659,
                 0x2E8EF85E, 0xB256FACA, 0xC4FE2DE8);
         }    
-    }
-}
-
-static void xbox_sha1_process(SHA1Context *ctx) {
-    const uint32_t k[] = { 0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6 };
-    uint32_t w[80];
-    uint32_t a = ctx->intermediate[0];
-    uint32_t b = ctx->intermediate[1];
-    uint32_t c = ctx->intermediate[2];
-    uint32_t d = ctx->intermediate[3];
-    uint32_t e = ctx->intermediate[4];
-
-    for (int i = 0; i < 16; i++) {
-        *(uint32_t*)&w[i] = cpu_to_be32(((uint32_t*)ctx->msg_blk)[i]);
-    }
-
-    for (int i = 16; i < 80; i++) {
-        w[i] = xbox_sha1_rotate(1, w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]);
-    }
-
-    for (int i = 0; i < 80; i++) {
-        uint32_t temp = xbox_sha1_rotate(5, a) + w[i] + e;
-        switch (i / 20) {
-        case 0: temp += k[0] + ((b & c) | ((~b) & d)); break;
-        case 1: temp += k[1] + (b ^ c ^ d); break;
-        case 2: temp += k[2] + ((b & c) | (b & d) | (c & d)); break;
-        case 3: temp += k[3] + (b ^ c ^ d); break;
-        }
-        e = d;
-        d = c;
-        c = xbox_sha1_rotate(30, b);
-        b = a;
-        a = temp;
-    }
-
-    ctx->intermediate[0] += a;
-    ctx->intermediate[1] += b;
-    ctx->intermediate[2] += c;
-    ctx->intermediate[3] += d;
-    ctx->intermediate[4] += e;
-    ctx->msg_blk_index = 0;
-}
-
-static void xbox_sha1_input(SHA1Context *ctx, uint8_t *data, size_t len) {
-    ctx->length += len << 3;
-    for (int i = 0; i < len; i++) {
-        ctx->msg_blk[ctx->msg_blk_index++] = data[i];
-        if (ctx->msg_blk_index == 64) {
-            xbox_sha1_process(ctx);
-        }
-    }
-}
-
-static void xbox_sha1_pad(SHA1Context *ctx) {
-    ctx->msg_blk[ctx->msg_blk_index++] = 0x80;
-    if (ctx->msg_blk_index > 56) {
-        while (ctx->msg_blk_index < 64) {
-            ctx->msg_blk[ctx->msg_blk_index++] = 0;
-        }
-        xbox_sha1_process(ctx);
-    }
-    while (ctx->msg_blk_index < 56) {
-        ctx->msg_blk[ctx->msg_blk_index++] = 0;
-    }
-    *(uint32_t*)&ctx->msg_blk[56] = 0;
-    *(uint32_t*)&ctx->msg_blk[60] = cpu_to_be32(ctx->length);
-    xbox_sha1_process(ctx);
-}
-
-static void xbox_sha1_result(SHA1Context *ctx, uint8_t *data) {
-    if (!ctx->computed) {
-        xbox_sha1_pad(ctx);
-        ctx->length = 0;
-        ctx->computed = true;
-    }
-    for (int i = 0; i < 20; ++i) {
-        data[i] = ctx->intermediate[i >> 2] >> 8 * (3 - (i & 3));
     }
 }
 
 static void xbox_sha1_compute(SHA1Context *ctx, XboxEEPROMVersion ver,
     uint8_t *data, size_t len, uint8_t *hash) {
     xbox_sha1_reset(ctx, ver, true);
-    xbox_sha1_input(ctx, data, len);
-    xbox_sha1_result(ctx, ctx->msg_blk);
+    sha1_input(ctx, data, len);
+    sha1_result(ctx, ctx->msg_blk);
     xbox_sha1_reset(ctx, ver, false);
-    xbox_sha1_input(ctx, ctx->msg_blk, 20);
-    xbox_sha1_result(ctx, hash);
+    sha1_input(ctx, ctx->msg_blk, 20);
+    sha1_result(ctx, hash);
 }
 
 bool xbox_eeprom_generate(const char *file, XboxEEPROMVersion ver) {
@@ -237,8 +125,8 @@ bool xbox_eeprom_generate(const char *file, XboxEEPROMVersion ver) {
     uint8_t seed[20];
     xbox_sha1_compute(&sctx, ver, e.confounder, 0x1C, e.hash);
     xbox_sha1_compute(&sctx, ver, e.hash, sizeof(e.hash), seed);
-    xbox_rc4_init(&rctx, seed, sizeof(seed));
-    xbox_rc4_crypt(&rctx, e.confounder, 0x1C);
+    rc4_init(&rctx, seed, sizeof(seed));
+    rc4_crypt(&rctx, e.confounder, 0x1C);
 
     // save to file
     FILE *fd = qemu_fopen(file, "wb");

--- a/hw/xbox/eeprom_generation.h
+++ b/hw/xbox/eeprom_generation.h
@@ -25,18 +25,6 @@
 #include "crypto/random.h"
 #include "include/qemu/bswap.h"
 
-typedef struct RC4Context {
-    uint8_t s[256];
-} RC4Context;
-
-typedef struct SHA1Context {
-    uint32_t intermediate[5];
-    uint8_t msg_blk[64];
-    uint32_t msg_blk_index;
-    uint32_t length;
-    bool computed;
-} SHA1Context;
-
 #pragma pack(push,1)
 typedef struct XboxEEPROM {
     uint8_t hash[20];

--- a/util/meson.build
+++ b/util/meson.build
@@ -106,3 +106,4 @@ if have_block
   endif
   util_ss.add(when: 'CONFIG_LINUX', if_true: files('vfio-helpers.c'))
 endif
+util_ss.add(files('sha1.c','rc4.c'))

--- a/util/rc4.c
+++ b/util/rc4.c
@@ -20,30 +20,30 @@
 
 #include "rc4.h"
 
-static void xbox_rc4_swap(RC4Context *ctx, int first, int second)
+static void rc4_swap(RC4Context *ctx, int first, int second)
 {
     uint8_t temp = ctx->s[first];
     ctx->s[first] = ctx->s[second];
     ctx->s[second] = temp;
 }
 
-void xbox_rc4_init(RC4Context *ctx, uint8_t *data, size_t len)
+void rc4_init(RC4Context *ctx, uint8_t *data, size_t len)
 {
     for (int i = 0; i < 256; i++) {
         ctx->s[i] = i;
     }
     for (int i = 0, j = 0; i < 256; i++) {
         j = (j + ctx->s[i] + data[i % len]) % 256;
-        xbox_rc4_swap(ctx, i, j);
+        rc4_swap(ctx, i, j);
     }
 }
 
-void xbox_rc4_crypt(RC4Context *ctx, uint8_t *data, size_t len)
+void rc4_crypt(RC4Context *ctx, uint8_t *data, size_t len)
 {
     for (int i = 0, j = 0, k = 0; k < len; k++) {
         i = (i + 1) % 256;
         j = (j + ctx->s[i]) % 256;
-        xbox_rc4_swap(ctx, i, j);
+        rc4_swap(ctx, i, j);
         data[k] ^= ctx->s[(ctx->s[i] + ctx->s[j]) % 256];
     }
 }

--- a/util/rc4.c
+++ b/util/rc4.c
@@ -1,0 +1,49 @@
+/*
+ * QEMU RC4 Implementation
+ *
+ * Copyright (c) 2020 Mike Davis
+ * Copyright (c) 2024 Ryan Wendland
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "rc4.h"
+
+static void xbox_rc4_swap(RC4Context *ctx, int first, int second)
+{
+    uint8_t temp = ctx->s[first];
+    ctx->s[first] = ctx->s[second];
+    ctx->s[second] = temp;
+}
+
+void xbox_rc4_init(RC4Context *ctx, uint8_t *data, size_t len)
+{
+    for (int i = 0; i < 256; i++) {
+        ctx->s[i] = i;
+    }
+    for (int i = 0, j = 0; i < 256; i++) {
+        j = (j + ctx->s[i] + data[i % len]) % 256;
+        xbox_rc4_swap(ctx, i, j);
+    }
+}
+
+void xbox_rc4_crypt(RC4Context *ctx, uint8_t *data, size_t len)
+{
+    for (int i = 0, j = 0, k = 0; k < len; k++) {
+        i = (i + 1) % 256;
+        j = (j + ctx->s[i]) % 256;
+        xbox_rc4_swap(ctx, i, j);
+        data[k] ^= ctx->s[(ctx->s[i] + ctx->s[j]) % 256];
+    }
+}

--- a/util/rc4.h
+++ b/util/rc4.h
@@ -25,5 +25,5 @@ typedef struct RC4Context {
     uint8_t s[256];
 } RC4Context;
 
-void xbox_rc4_init(RC4Context *ctx, uint8_t *data, size_t len);
-void xbox_rc4_crypt(RC4Context *ctx, uint8_t *data, size_t len);
+void rc4_init(RC4Context *ctx, uint8_t *data, size_t len);
+void rc4_crypt(RC4Context *ctx, uint8_t *data, size_t len);

--- a/util/rc4.h
+++ b/util/rc4.h
@@ -1,0 +1,29 @@
+/*
+ * QEMU RC4 Implementation
+ *
+ * Copyright (c) 2020 Mike Davis
+ * Copyright (c) 2024 Ryan Wendland
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct RC4Context {
+    uint8_t s[256];
+} RC4Context;
+
+void xbox_rc4_init(RC4Context *ctx, uint8_t *data, size_t len);
+void xbox_rc4_crypt(RC4Context *ctx, uint8_t *data, size_t len);

--- a/util/sha1.c
+++ b/util/sha1.c
@@ -19,18 +19,17 @@
  */
 
 #include "qemu/osdep.h"
-#include "crypto/random.h"
 #include "qapi/error.h"
 #include "qemu/bswap.h"
 #include "sha1.h"
 
-static uint32_t xbox_sha1_rotate(uint32_t bits, uint32_t val)
+static uint32_t sha1_rotate(uint32_t bits, uint32_t val)
 {
     return (val << bits) | (val >> (32 - bits));
 }
 
-void xbox_sha1_fill(SHA1Context *ctx, uint32_t a, uint32_t b, uint32_t c,
-                    uint32_t d, uint32_t e)
+void sha1_fill(SHA1Context *ctx, uint32_t a, uint32_t b, uint32_t c,
+               uint32_t d, uint32_t e)
 {
     ctx->intermediate[0] = a;
     ctx->intermediate[1] = b;
@@ -39,7 +38,7 @@ void xbox_sha1_fill(SHA1Context *ctx, uint32_t a, uint32_t b, uint32_t c,
     ctx->intermediate[4] = e;
 }
 
-static void xbox_sha1_process(SHA1Context *ctx)
+static void sha1_process(SHA1Context *ctx)
 {
     const uint32_t k[] = { 0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6 };
     uint32_t w[80];
@@ -54,11 +53,11 @@ static void xbox_sha1_process(SHA1Context *ctx)
     }
 
     for (int i = 16; i < 80; i++) {
-        w[i] = xbox_sha1_rotate(1, w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]);
+        w[i] = sha1_rotate(1, w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]);
     }
 
     for (int i = 0; i < 80; i++) {
-        uint32_t temp = xbox_sha1_rotate(5, a) + w[i] + e;
+        uint32_t temp = sha1_rotate(5, a) + w[i] + e;
         switch (i / 20) {
         case 0:
             temp += k[0] + ((b & c) | ((~b) & d));
@@ -75,7 +74,7 @@ static void xbox_sha1_process(SHA1Context *ctx)
         }
         e = d;
         d = c;
-        c = xbox_sha1_rotate(30, b);
+        c = sha1_rotate(30, b);
         b = a;
         a = temp;
     }
@@ -88,38 +87,38 @@ static void xbox_sha1_process(SHA1Context *ctx)
     ctx->msg_blk_index = 0;
 }
 
-static void xbox_sha1_pad(SHA1Context *ctx)
+static void sha1_pad(SHA1Context *ctx)
 {
     ctx->msg_blk[ctx->msg_blk_index++] = 0x80;
     if (ctx->msg_blk_index > 56) {
         while (ctx->msg_blk_index < 64) {
             ctx->msg_blk[ctx->msg_blk_index++] = 0;
         }
-        xbox_sha1_process(ctx);
+        sha1_process(ctx);
     }
     while (ctx->msg_blk_index < 56) {
         ctx->msg_blk[ctx->msg_blk_index++] = 0;
     }
     *(uint32_t *)&ctx->msg_blk[56] = 0;
     *(uint32_t *)&ctx->msg_blk[60] = cpu_to_be32(ctx->length);
-    xbox_sha1_process(ctx);
+    sha1_process(ctx);
 }
 
-void xbox_sha1_input(SHA1Context *ctx, uint8_t *data, size_t len)
+void sha1_input(SHA1Context *ctx, uint8_t *data, size_t len)
 {
     ctx->length += len << 3;
     for (int i = 0; i < len; i++) {
         ctx->msg_blk[ctx->msg_blk_index++] = data[i];
         if (ctx->msg_blk_index == 64) {
-            xbox_sha1_process(ctx);
+            sha1_process(ctx);
         }
     }
 }
 
-void xbox_sha1_result(SHA1Context *ctx, uint8_t *data)
+void sha1_result(SHA1Context *ctx, uint8_t *data)
 {
     if (!ctx->computed) {
-        xbox_sha1_pad(ctx);
+        sha1_pad(ctx);
         ctx->length = 0;
         ctx->computed = true;
     }
@@ -128,48 +127,11 @@ void xbox_sha1_result(SHA1Context *ctx, uint8_t *data)
     }
 }
 
-void xbox_sha1_reset(SHA1Context *ctx, XboxEEPROMVersion ver, bool first)
+void sha1_reset(SHA1Context *ctx)
 {
+    sha1_fill(ctx, 0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0);
+
     ctx->msg_blk_index = 0;
     ctx->computed = false;
-    ctx->length = 512;
-
-    // https://web.archive.org/web/20040618164907/http://www.xbox-linux.org/down/The%20Middle%20Message-1a.pdf
-    switch (ver) {
-    case XBOX_EEPROM_VERSION_D:
-        if (first) {
-            xbox_sha1_fill(ctx, 0x85F9E51A, 0xE04613D2, 0x6D86A50C, 0x77C32E3C,
-                           0x4BD717A4);
-        } else {
-            xbox_sha1_fill(ctx, 0x5D7A9C6B, 0xE1922BEB, 0xB82CCDBC, 0x3137AB34,
-                           0x486B52B3);
-        }
-        break;
-    case XBOX_EEPROM_VERSION_R2:
-        if (first) {
-            xbox_sha1_fill(ctx, 0x39B06E79, 0xC9BD25E8, 0xDBC6B498, 0x40B4389D,
-                           0x86BBD7ED);
-        } else {
-            xbox_sha1_fill(ctx, 0x9B49BED3, 0x84B430FC, 0x6B8749CD, 0xEBFE5FE5,
-                           0xD96E7393);
-        }
-        break;
-    case XBOX_EEPROM_VERSION_R3:
-        if (first) {
-            xbox_sha1_fill(ctx, 0x8058763A, 0xF97D4E0E, 0x865A9762, 0x8A3D920D,
-                           0x08995B2C);
-        } else {
-            xbox_sha1_fill(ctx, 0x01075307, 0xA2f1E037, 0x1186EEEA, 0x88DA9992,
-                           0x168A5609);
-        }
-        break;
-    default: // default to 1.0 version
-        if (first) {
-            xbox_sha1_fill(ctx, 0x72127625, 0x336472B9, 0xBE609BEA, 0xF55E226B,
-                           0x99958DAC);
-        } else {
-            xbox_sha1_fill(ctx, 0x76441D41, 0x4DE82659, 0x2E8EF85E, 0xB256FACA,
-                           0xC4FE2DE8);
-        }
-    }
+    ctx->length = 0;
 }

--- a/util/sha1.c
+++ b/util/sha1.c
@@ -1,0 +1,175 @@
+/*
+ * QEMU SHA1 Implementation
+ *
+ * Copyright (c) 2020 Mike Davis
+ * Copyright (c) 2024 Ryan Wendland
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "qemu/osdep.h"
+#include "crypto/random.h"
+#include "qapi/error.h"
+#include "qemu/bswap.h"
+#include "sha1.h"
+
+static uint32_t xbox_sha1_rotate(uint32_t bits, uint32_t val)
+{
+    return (val << bits) | (val >> (32 - bits));
+}
+
+void xbox_sha1_fill(SHA1Context *ctx, uint32_t a, uint32_t b, uint32_t c,
+                    uint32_t d, uint32_t e)
+{
+    ctx->intermediate[0] = a;
+    ctx->intermediate[1] = b;
+    ctx->intermediate[2] = c;
+    ctx->intermediate[3] = d;
+    ctx->intermediate[4] = e;
+}
+
+static void xbox_sha1_process(SHA1Context *ctx)
+{
+    const uint32_t k[] = { 0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6 };
+    uint32_t w[80];
+    uint32_t a = ctx->intermediate[0];
+    uint32_t b = ctx->intermediate[1];
+    uint32_t c = ctx->intermediate[2];
+    uint32_t d = ctx->intermediate[3];
+    uint32_t e = ctx->intermediate[4];
+
+    for (int i = 0; i < 16; i++) {
+        *(uint32_t *)&w[i] = cpu_to_be32(((uint32_t *)ctx->msg_blk)[i]);
+    }
+
+    for (int i = 16; i < 80; i++) {
+        w[i] = xbox_sha1_rotate(1, w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]);
+    }
+
+    for (int i = 0; i < 80; i++) {
+        uint32_t temp = xbox_sha1_rotate(5, a) + w[i] + e;
+        switch (i / 20) {
+        case 0:
+            temp += k[0] + ((b & c) | ((~b) & d));
+            break;
+        case 1:
+            temp += k[1] + (b ^ c ^ d);
+            break;
+        case 2:
+            temp += k[2] + ((b & c) | (b & d) | (c & d));
+            break;
+        case 3:
+            temp += k[3] + (b ^ c ^ d);
+            break;
+        }
+        e = d;
+        d = c;
+        c = xbox_sha1_rotate(30, b);
+        b = a;
+        a = temp;
+    }
+
+    ctx->intermediate[0] += a;
+    ctx->intermediate[1] += b;
+    ctx->intermediate[2] += c;
+    ctx->intermediate[3] += d;
+    ctx->intermediate[4] += e;
+    ctx->msg_blk_index = 0;
+}
+
+static void xbox_sha1_pad(SHA1Context *ctx)
+{
+    ctx->msg_blk[ctx->msg_blk_index++] = 0x80;
+    if (ctx->msg_blk_index > 56) {
+        while (ctx->msg_blk_index < 64) {
+            ctx->msg_blk[ctx->msg_blk_index++] = 0;
+        }
+        xbox_sha1_process(ctx);
+    }
+    while (ctx->msg_blk_index < 56) {
+        ctx->msg_blk[ctx->msg_blk_index++] = 0;
+    }
+    *(uint32_t *)&ctx->msg_blk[56] = 0;
+    *(uint32_t *)&ctx->msg_blk[60] = cpu_to_be32(ctx->length);
+    xbox_sha1_process(ctx);
+}
+
+void xbox_sha1_input(SHA1Context *ctx, uint8_t *data, size_t len)
+{
+    ctx->length += len << 3;
+    for (int i = 0; i < len; i++) {
+        ctx->msg_blk[ctx->msg_blk_index++] = data[i];
+        if (ctx->msg_blk_index == 64) {
+            xbox_sha1_process(ctx);
+        }
+    }
+}
+
+void xbox_sha1_result(SHA1Context *ctx, uint8_t *data)
+{
+    if (!ctx->computed) {
+        xbox_sha1_pad(ctx);
+        ctx->length = 0;
+        ctx->computed = true;
+    }
+    for (int i = 0; i < 20; ++i) {
+        data[i] = ctx->intermediate[i >> 2] >> 8 * (3 - (i & 3));
+    }
+}
+
+void xbox_sha1_reset(SHA1Context *ctx, XboxEEPROMVersion ver, bool first)
+{
+    ctx->msg_blk_index = 0;
+    ctx->computed = false;
+    ctx->length = 512;
+
+    // https://web.archive.org/web/20040618164907/http://www.xbox-linux.org/down/The%20Middle%20Message-1a.pdf
+    switch (ver) {
+    case XBOX_EEPROM_VERSION_D:
+        if (first) {
+            xbox_sha1_fill(ctx, 0x85F9E51A, 0xE04613D2, 0x6D86A50C, 0x77C32E3C,
+                           0x4BD717A4);
+        } else {
+            xbox_sha1_fill(ctx, 0x5D7A9C6B, 0xE1922BEB, 0xB82CCDBC, 0x3137AB34,
+                           0x486B52B3);
+        }
+        break;
+    case XBOX_EEPROM_VERSION_R2:
+        if (first) {
+            xbox_sha1_fill(ctx, 0x39B06E79, 0xC9BD25E8, 0xDBC6B498, 0x40B4389D,
+                           0x86BBD7ED);
+        } else {
+            xbox_sha1_fill(ctx, 0x9B49BED3, 0x84B430FC, 0x6B8749CD, 0xEBFE5FE5,
+                           0xD96E7393);
+        }
+        break;
+    case XBOX_EEPROM_VERSION_R3:
+        if (first) {
+            xbox_sha1_fill(ctx, 0x8058763A, 0xF97D4E0E, 0x865A9762, 0x8A3D920D,
+                           0x08995B2C);
+        } else {
+            xbox_sha1_fill(ctx, 0x01075307, 0xA2f1E037, 0x1186EEEA, 0x88DA9992,
+                           0x168A5609);
+        }
+        break;
+    default: // default to 1.0 version
+        if (first) {
+            xbox_sha1_fill(ctx, 0x72127625, 0x336472B9, 0xBE609BEA, 0xF55E226B,
+                           0x99958DAC);
+        } else {
+            xbox_sha1_fill(ctx, 0x76441D41, 0x4DE82659, 0x2E8EF85E, 0xB256FACA,
+                           0xC4FE2DE8);
+        }
+    }
+}

--- a/util/sha1.h
+++ b/util/sha1.h
@@ -1,0 +1,35 @@
+/*
+ * QEMU SHA1 Implementation
+ *
+ * Copyright (c) 2020 Mike Davis
+ * Copyright (c) 2024 Ryan Wendland
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct SHA1Context {
+    uint32_t intermediate[5];
+    uint8_t msg_blk[64];
+    uint32_t msg_blk_index;
+    uint32_t length;
+    bool computed;
+} SHA1Context;
+
+void xbox_sha1_fill(SHA1Context *ctx, uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e);
+void xbox_sha1_input(SHA1Context *ctx, uint8_t *data, size_t len);
+void xbox_sha1_result(SHA1Context *ctx, uint8_t *data);
+void xbox_sha1_reset(SHA1Context *ctx, XboxEEPROMVersion ver, bool first);

--- a/util/sha1.h
+++ b/util/sha1.h
@@ -29,7 +29,7 @@ typedef struct SHA1Context {
     bool computed;
 } SHA1Context;
 
-void xbox_sha1_fill(SHA1Context *ctx, uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e);
-void xbox_sha1_input(SHA1Context *ctx, uint8_t *data, size_t len);
-void xbox_sha1_result(SHA1Context *ctx, uint8_t *data);
-void xbox_sha1_reset(SHA1Context *ctx, XboxEEPROMVersion ver, bool first);
+void sha1_fill(SHA1Context *ctx, uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e);
+void sha1_input(SHA1Context *ctx, uint8_t *data, size_t len);
+void sha1_result(SHA1Context *ctx, uint8_t *data);
+void sha1_reset(SHA1Context *ctx);


### PR DESCRIPTION
As suggested in https://github.com/xemu-project/xemu/pull/1659, instead of pulling in another RC4/SHA1 implementation use the one already provided in the EEPROM generation code.

To do this it needs to be moved to a more accessible location.

To ensure I didnt break anything I generated an eeprom with xemu and loaded it up with https://github.com/Ernegien/XboxEepromEditor and made sure the hashes matched up