### PR TITLE
nv2a: Drop unused ShaderState field material_alpha

### DIFF
--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -4471,7 +4471,6 @@ static void pgraph_bind_shaders(PGRAPHState *pg)
         state.ambient_src = (enum MaterialColorSource)GET_MASK(pg->regs[NV_PGRAPH_CSV0_C], NV_PGRAPH_CSV0_C_AMBIENT);
         state.diffuse_src = (enum MaterialColorSource)GET_MASK(pg->regs[NV_PGRAPH_CSV0_C], NV_PGRAPH_CSV0_C_DIFFUSE);
         state.specular_src = (enum MaterialColorSource)GET_MASK(pg->regs[NV_PGRAPH_CSV0_C], NV_PGRAPH_CSV0_C_SPECULAR);
-        state.material_alpha = pg->material_alpha;
     }
 
     /* vertex program stuff */

--- a/hw/xbox/nv2a/shaders.h
+++ b/hw/xbox/nv2a/shaders.h
@@ -78,8 +78,6 @@ typedef struct ShaderState {
     enum MaterialColorSource diffuse_src;
     enum MaterialColorSource specular_src;
 
-    float material_alpha;
-
     bool lighting;
     enum VshLight light[NV2A_MAX_LIGHTS];
 


### PR DESCRIPTION
Fix an issue with shader over-generation. Cherry-picked from feat/vulkan
