### PR TITLE
nv2a: Clip range and see through fix

### DIFF
--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -417,6 +417,7 @@ typedef struct PGRAPHState {
 
     unsigned int surface_scale_factor;
     uint8_t *scale_buf;
+    float fragment_depth_offset;
 } PGRAPHState;
 
 typedef struct NV2AState {

--- a/hw/xbox/nv2a/pgraph.c
+++ b/hw/xbox/nv2a/pgraph.c
@@ -2845,6 +2845,8 @@ DEF_METHOD(NV097, SET_BEGIN_END)
     bool stencil_test =
         pg->regs[NV_PGRAPH_CONTROL_1] & NV_PGRAPH_CONTROL_1_STENCIL_TEST_ENABLE;
     bool is_nop_draw = !(color_write || depth_test || stencil_test);
+    bool z_perspective = control_0 & NV_PGRAPH_CONTROL_0_Z_PERSPECTIVE_ENABLE;
+    bool clip_planes_enabled = z_perspective;
 
     if (parameter == NV097_SET_BEGIN_END_OP_END) {
         if (pg->primitive_mode == PRIM_TYPE_INVALID) {
@@ -2945,10 +2947,6 @@ DEF_METHOD(NV097, SET_BEGIN_END)
             glDisable(GL_CULL_FACE);
         }
 
-        /* Clipping */
-        glEnable(GL_CLIP_DISTANCE0);
-        glEnable(GL_CLIP_DISTANCE1);
-
         /* Front-face select */
         glFrontFace(pg->regs[NV_PGRAPH_SETUPRASTER]
                         & NV_PGRAPH_SETUPRASTER_FRONTFACE
@@ -2981,6 +2979,10 @@ DEF_METHOD(NV097, SET_BEGIN_END)
             GLfloat zfactor = *(float*)&pg->regs[NV_PGRAPH_ZOFFSETFACTOR];
             GLfloat zbias = *(float*)&pg->regs[NV_PGRAPH_ZOFFSETBIAS];
             glPolygonOffset(zfactor, zbias);
+            // TODO: emulate zfactor when z_perspective true, i.e. w-buffering
+            pg->fragment_depth_offset = zbias;
+        } else {
+            pg->fragment_depth_offset = 0.0f;
         }
 
         /* Depth testing */
@@ -2993,14 +2995,29 @@ DEF_METHOD(NV097, SET_BEGIN_END)
             glDepthFunc(pgraph_depth_func_map[depth_func]);
         } else {
             glDisable(GL_DEPTH_TEST);
+            clip_planes_enabled = false;
         }
 
         if (GET_MASK(pg->regs[NV_PGRAPH_ZCOMPRESSOCCLUDE],
                      NV_PGRAPH_ZCOMPRESSOCCLUDE_ZCLAMP_EN) ==
             NV_PGRAPH_ZCOMPRESSOCCLUDE_ZCLAMP_EN_CLAMP) {
             glEnable(GL_DEPTH_CLAMP);
+            clip_planes_enabled = false;
         } else {
-            glDisable(GL_DEPTH_CLAMP);
+            if (z_perspective) {
+                glEnable(GL_DEPTH_CLAMP);
+            } else {
+                glDisable(GL_DEPTH_CLAMP);
+            }
+        }
+
+        /* Clipping */
+        if (z_perspective && clip_planes_enabled) {
+            glEnable(GL_CLIP_DISTANCE0);
+            glEnable(GL_CLIP_DISTANCE1);
+        } else {
+            glDisable(GL_CLIP_DISTANCE0);
+            glDisable(GL_CLIP_DISTANCE1);
         }
 
         if (GET_MASK(pg->regs[NV_PGRAPH_CONTROL_3],
@@ -4292,9 +4309,13 @@ static void pgraph_shader_update_constants(PGRAPHState *pg,
     }
 
     if (binding->clip_range_loc != -1) {
-        float zclip_min = *(float*)&pg->regs[NV_PGRAPH_ZCLIPMIN] / zmax * 2.0 - 1.0;
-        float zclip_max = *(float*)&pg->regs[NV_PGRAPH_ZCLIPMAX] / zmax * 2.0 - 1.0;
+        float zclip_min = *(float*)&pg->regs[NV_PGRAPH_ZCLIPMIN]; // zmax * 2.0 - 1.0;
+        float zclip_max = *(float*)&pg->regs[NV_PGRAPH_ZCLIPMAX]; // zmax * 2.0 - 1.0;
         glUniform4f(binding->clip_range_loc, 0, zmax, zclip_min, zclip_max);
+    }
+
+    if (binding->depth_offset_loc != -1) {
+        glUniform1f(binding->depth_offset_loc, pg->fragment_depth_offset);
     }
 
     /* Clipping regions */

--- a/hw/xbox/nv2a/psh.h
+++ b/hw/xbox/nv2a/psh.h
@@ -82,6 +82,6 @@ typedef struct PshState {
     bool smooth_shading;
 } PshState;
 
-MString *psh_translate(const PshState state);
+MString *psh_translate(const PshState state, bool z_perspective);
 
 #endif

--- a/hw/xbox/nv2a/shaders.h
+++ b/hw/xbox/nv2a/shaders.h
@@ -117,6 +117,7 @@ typedef struct ShaderBinding {
 
     GLint surface_size_loc;
     GLint clip_range_loc;
+    GLint depth_offset_loc;
 
     GLint vsh_constant_loc[NV2A_VERTEXSHADER_CONSTANTS];
     uint32_t vsh_constants[NV2A_VERTEXSHADER_CONSTANTS][4];

--- a/hw/xbox/nv2a/shaders_common.h
+++ b/hw/xbox/nv2a/shaders_common.h
@@ -23,28 +23,33 @@
 
 #include "debug.h"
 
-#define DEF_VERTEX_DATA(qualifier, in_out, prefix, suffix) \
+#define DEF_VERTEX_DATA(qualifier, qualifier_z, in_out, prefix, suffix) \
     "noperspective " in_out " float " prefix "vtx_inv_w" suffix ";\n" \
     "flat " in_out " float " prefix "vtx_inv_w_flat" suffix ";\n" \
     qualifier " " in_out " vec4 " prefix "vtxD0" suffix ";\n" \
     qualifier " " in_out " vec4 " prefix "vtxD1" suffix ";\n" \
     qualifier " " in_out " vec4 " prefix "vtxB0" suffix ";\n" \
     qualifier " " in_out " vec4 " prefix "vtxB1" suffix ";\n" \
-    "noperspective " in_out " float " prefix "vtxFog" suffix ";\n" \
-    "noperspective " in_out " vec4 " prefix "vtxT0" suffix ";\n" \
-    "noperspective " in_out " vec4 " prefix "vtxT1" suffix ";\n" \
-    "noperspective " in_out " vec4 " prefix "vtxT2" suffix ";\n" \
-    "noperspective " in_out " vec4 " prefix "vtxT3" suffix ";\n"
+    qualifier_z " " in_out " float " prefix "vtxFog" suffix ";\n" \
+    qualifier_z " " in_out " vec4 " prefix "vtxT0" suffix ";\n" \
+    qualifier_z " " in_out " vec4 " prefix "vtxT1" suffix ";\n" \
+    qualifier_z " " in_out " vec4 " prefix "vtxT2" suffix ";\n" \
+    qualifier_z " " in_out " vec4 " prefix "vtxT3" suffix ";\n"
 
-#define STRUCT_VERTEX_DATA_OUT_SMOOTH DEF_VERTEX_DATA("noperspective", "out", "", "")
-#define STRUCT_VERTEX_DATA_IN_SMOOTH  DEF_VERTEX_DATA("noperspective", "in", "", "")
-#define STRUCT_V_VERTEX_DATA_OUT_SMOOTH DEF_VERTEX_DATA("noperspective", "out", "v_", "")
-#define STRUCT_V_VERTEX_DATA_IN_ARRAY_SMOOTH DEF_VERTEX_DATA("noperspective", "in", "v_", "[]")
+#define STRUCT_VERTEX_DATA_OUT_SMOOTH DEF_VERTEX_DATA("noperspective", "noperspective", "out", "", "")
+#define STRUCT_VERTEX_DATA_IN_SMOOTH  DEF_VERTEX_DATA("noperspective", "noperspective",  "in", "", "")
+#define STRUCT_V_VERTEX_DATA_OUT_SMOOTH DEF_VERTEX_DATA("noperspective", "noperspective",  "out", "v_", "")
+#define STRUCT_V_VERTEX_DATA_IN_ARRAY_SMOOTH DEF_VERTEX_DATA("noperspective", "noperspective",  "in", "v_", "[]")
 
-#define STRUCT_VERTEX_DATA_OUT_FLAT DEF_VERTEX_DATA("flat", "out", "", "")
-#define STRUCT_VERTEX_DATA_IN_FLAT  DEF_VERTEX_DATA("flat", "in", "", "")
-#define STRUCT_V_VERTEX_DATA_OUT_FLAT DEF_VERTEX_DATA("flat", "out", "v_", "")
-#define STRUCT_V_VERTEX_DATA_IN_ARRAY_FLAT DEF_VERTEX_DATA("flat", "in", "v_", "[]")
+#define STRUCT_VERTEX_DATA_OUT_FLAT DEF_VERTEX_DATA("flat", "noperspective",  "out", "", "")
+#define STRUCT_VERTEX_DATA_IN_FLAT  DEF_VERTEX_DATA("flat", "noperspective",  "in", "", "")
+#define STRUCT_V_VERTEX_DATA_OUT_FLAT DEF_VERTEX_DATA("flat", "noperspective",  "out", "v_", "")
+#define STRUCT_V_VERTEX_DATA_IN_ARRAY_FLAT DEF_VERTEX_DATA("flat", "noperspective",  "in", "v_", "[]")
+
+#define STRUCT_VERTEX_DATA_OUT_SMOOTH_ZPERSP DEF_VERTEX_DATA("", "", "out", "", "")
+#define STRUCT_VERTEX_DATA_IN_SMOOTH_ZPERSP  DEF_VERTEX_DATA("", "", "in", "", "")
+#define STRUCT_V_VERTEX_DATA_OUT_SMOOTH_ZPERSP DEF_VERTEX_DATA("", "", "out", "v_", "")
+#define STRUCT_V_VERTEX_DATA_IN_ARRAY_SMOOTH_ZPERSP DEF_VERTEX_DATA("", "", "in", "v_", "[]")
 
 typedef struct {
    int ref;


### PR DESCRIPTION
Thanks to @coldhex for your work! I used part of the code you mention in https://github.com/xemu-project/xemu/issues/55#issuecomment-2241693861 , though I didn't implement any of the other fixes. As per the related commit:

> z_perspective is true seems to imply w-buffering and then the w-coordinate stored in the depth buffer should also be interpolated in a perspective-correct way. We do this by calculating w and setting gl_FragDepth in the fragment shader.
> 
> Since enabling polygon offset and setting values using glPolygonOffset won't have any effect when manually setting gl_FragDepth, we introduce the depthOffset variable to obtain similar behaviour (but the glPolygonOffset factor-argument is currently not emulated.)

I fixed the regressions by leaving the shader code for no z_perspective unaltered. Also used NV_PGRAPH_ZCLIPMIN and NV_PGRPAH_ZCLIPMAX as clip planes, thus fixing things such as shadows.