### PR TITLE
.clang-format: Set SortIncludes to Never

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -82,7 +82,7 @@ MaxEmptyLinesToKeep: 2
 #PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 ReflowComments:  true
-SortIncludes:    true
+SortIncludes:    Never
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements


### PR DESCRIPTION
Sets `SortIncludes` to never as per https://clang.llvm.org/docs/ClangFormatStyleOptions.html#sortincludes
This should preserve header ordering during code formatting and allow clang-format to be run without changing header orders in the event they are not otherwise touched.