### PR TITLE
ci: Actually strip release Windows binaries, create temporary arch tag free Windows binary for updater

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -393,6 +393,10 @@ jobs:
         pushd dist/xemu-ubuntu-debug
         tar xvf xemu-ubuntu-debug.tgz
         popd
+    # Architecture tags were recently added to the Windows release path. Provide an alias with the former name for a while.
+    - name: Add transitionary package alias
+      run: |
+        cp dist/xemu-win-x86_64-release-pdb/xemu-win-x86_64-release.zip dist/xemu-win-x86_64-release-pdb/xemu-win-release.zip
     - name: Publish release
       uses: softprops/action-gh-release@v1
       with:
@@ -405,6 +409,7 @@ jobs:
           dist/xemu-win-x86_64-debug-pdb/xemu-win-x86_64-debug.zip
           dist/xemu-win-x86_64-debug-pdb/xemu-win-x86_64-debug-pdb.zip
           dist/xemu-win-x86_64-release-pdb/xemu-win-x86_64-release.zip
+          dist/xemu-win-x86_64-release-pdb/xemu-win-release.zip
           dist/xemu-win-x86_64-release-pdb/xemu-win-x86_64-release-pdb.zip
           dist/xemu-macos-universal-release/xemu-macos-universal-release.zip
           dist/xemu-macos-universal-debug/xemu-macos-universal-debug.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,9 +145,12 @@ jobs:
     - name: Generate PDB
       run: |
         Invoke-WebRequest -Uri "https://github.com/rainers/cv2pdb/releases/download/v0.52/cv2pdb-0.52.zip" -OutFile "cv2pdb.zip"
+        Invoke-WebRequest -Uri "https://github.com/mstorsjo/llvm-mingw/releases/download/20241217/llvm-mingw-20241217-ucrt-x86_64.zip" -OutFile "llvm-mingw.zip"
         7z x -ocv2pdb -y cv2pdb.zip
+        7z x -y llvm-mingw.zip
         cd ${{ matrix.artifact_name }}
         ../cv2pdb/cv2pdb64.exe xemu.exe
+        ../llvm-mingw-20241217-ucrt-x86_64/bin/${{ matrix.arch }}-w64-mingw32-strip.exe xemu.exe
         mkdir ../dist
         7z a -tzip ../dist/${{ matrix.artifact_name }}.zip * "-xr!*.pdb"
         7z a -tzip ../dist/${{ matrix.artifact_name }}-pdb.zip "-ir!*.pdb"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,12 +126,16 @@ jobs:
         include:
         - configuration: Debug
           artifact_name: xemu-win-x86_64-debug
+          arch: x86_64
         - configuration: Release
           artifact_name: xemu-win-x86_64-release
+          arch: x86_64
         - configuration: Debug
           artifact_name: xemu-win-aarch64-debug
+          arch: aarch64
         - configuration: Release
           artifact_name: xemu-win-aarch64-release
+          arch: aarch64
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v4


### PR DESCRIPTION
Shaves a cool 50M off...
