### PR TITLE
build: Allow CFLAGS to be passed through on macos.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -213,12 +213,14 @@ case "$platform" in # Adjust compilation options based on platform
 
         python3 ./scripts/download-macos-libs.py ${target_arch}
         lib_prefix=${PWD}/macos-libs/${target_arch}/opt/local
-        export CFLAGS="-arch ${target_arch} \
+        export CFLAGS="${CFLAGS} \
+                       -arch ${target_arch} \
                        -target ${target_arch}-apple-macos${macos_min_ver} \
                        -isysroot ${sdk} \
                        -I${lib_prefix}/include \
                        -mmacosx-version-min=$macos_min_ver"
-        export LDFLAGS="-arch ${target_arch} \
+        export LDFLAGS="${LDFLAGS} \
+                        -arch ${target_arch} \
                         -isysroot ${sdk}"
         if [ "$target_arch" == "x86_64" ]; then
             sys_cflags='-march=ivybridge'


### PR DESCRIPTION
Makes it slightly more convenient to set things like `DEBUG_NV2A_GL`