### PR TITLE
Get some things ready for #1188

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -32,5 +32,7 @@
   <true/>
   <key>com.apple.security.cs.allow-jit</key>
   <true/>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Microphone used for peripheral emulation, e.g. Xbox Live Communicator.</string>
 </dict>
 </plist>

--- a/meson.build
+++ b/meson.build
@@ -2406,8 +2406,7 @@ if have_system
 
   # Default to native drivers first, OSS second, SDL third
   audio_drivers_priority = \
-    [ 'pa', 'coreaudio', 'dsound', 'sndio', 'oss' ] + \
-    (host_os == 'linux' ? [] : [ 'sdl' ])
+    [ 'pa', 'coreaudio', 'dsound', 'sndio', 'oss', 'sdl' ]
   audio_drivers_default = []
   foreach k: audio_drivers_priority
     if audio_drivers_available[k]


### PR DESCRIPTION
* Disable ac97 pi/mc reads for now, to avoid Bluetooth headsets auto-switching to low-quality mode due to startup microphone initialization (though it is unused)
* Allow auto fallback to SDL audio driver on Linux
* Fix microphone access on macOS by adding required NSMicrophoneUsageDescription key