### PR TITLE
build.yml: Fix PPA Deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -450,6 +450,9 @@ jobs:
 
         # Ensure subprojects are uploaded
         rm src/subprojects/.gitignore
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade build
     - name: Integrate Debian packaging
       run: |
         pushd src


### PR DESCRIPTION
Due to some really long multi-year issue/regression you must either manually patch python on Ubuntu 22.04 or force pip to grab the deps to setup the venv, 99% sure this will fix it.