### PR TITLE
Add 720x480 resolution to display settings

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -151,7 +151,7 @@ display:
     fullscreen_exclusive: bool
     startup_size:
       type: enum
-      values: [last_used, 640x480, 1280x720, 1280x800, 1280x960, 1920x1080, 2560x1440, 2560x1600, 2560x1920, 3840x2160]
+      values: [last_used, 640x480, 720x480, 1280x720, 1280x800, 1280x960, 1920x1080, 2560x1440, 2560x1600, 2560x1920, 3840x2160]
       default: 1280x960
     last_width:
       type: integer

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -731,6 +731,7 @@ static void sdl2_display_very_early_init(DisplayOptions *o)
 
     const int res_table[][2] = {
         {640,  480},
+        {720,  480},
         {1280, 720},
         {1280, 800},
         {1280, 960},

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -525,6 +525,7 @@ void MainMenuDisplayView::Draw()
     if (ChevronCombo("Window size", &g_config.display.window.startup_size,
                      "Last Used\0"
                      "640x480\0"
+                     "720x480\0"
                      "1280x720\0"
                      "1280x800\0"
                      "1280x960\0"


### PR DESCRIPTION
This small change adds the 720x480 resolution to the display settings. This isn't a huge deal for games but it is supported display mode for the original Xbox, which is currently missing from the emulator. This also fixes an annoying mismatch between Xbox Linux running at 720x480 and Xemu only having 640x480, which causes both the aspect ratio to be wrong and the mouse to be unaligned. I have to admit that the Xbox Linux thing is the whole reason I did this in the first place to be honest.
Screenshot of the added option in the settings:
![image](https://github.com/user-attachments/assets/7f20ff95-df7a-4baa-9ffc-9609aee7ca44)
Screenshot of the now properly aligned mouse cursor:
![image](https://github.com/user-attachments/assets/9e7bba16-694d-4e60-ad28-024bad88f27a)
Screenshot of the misaligned cursor at 640x480:
![image](https://github.com/user-attachments/assets/4f42367a-d54a-4ca6-b5f0-ece5729f5916)
