### PR TITLE
DotSTRCube_HiLoHemi texture cubemap pgraph test fix

### DIFF
--- a/hw/xbox/nv2a/pgraph/glsl/psh.c
+++ b/hw/xbox/nv2a/pgraph/glsl/psh.c
@@ -770,8 +770,8 @@ static MString* psh_convert(struct PixelShader *ps)
         "dotmap_minus1_to_1_gl",
         "dotmap_minus1_to_1",
         "dotmap_hilo_1",
-        "dotmap_hilo_hemisphere_d3d",
-        "dotmap_hilo_hemisphere_gl",
+        "dotmap_hilo_hemisphere", //D3D
+        "dotmap_hilo_hemisphere", //GL
         "dotmap_hilo_hemisphere",
     };
 
@@ -820,12 +820,6 @@ static MString* psh_convert(struct PixelShader *ps)
         "    vec2 hilo = vec2(_col.a << 8 | _col.r, _col.g << 8 | _col.b);\n"
         "    hilo = (hilo - 65536.0f*step(32767.5f, hilo)) / 32767.0f;\n"
         "    return vec3(hilo, sqrt(max(1.0f - dot(hilo, hilo), 0.0f)));\n"
-        "}\n"
-        "vec3 dotmap_hilo_hemisphere_gl(vec4 col) {\n"
-        "    return dotmap_hilo_hemisphere(col);\n"
-        "}\n"
-        "vec3 dotmap_hilo_hemisphere_d3d(vec4 col) {\n"
-        "    return dotmap_hilo_hemisphere(col);\n"
         "}\n"
         "const float[9] gaussian3x3 = float[9](\n"
         "    1.0/16.0, 2.0/16.0, 1.0/16.0,\n"

--- a/hw/xbox/nv2a/pgraph/glsl/psh.c
+++ b/hw/xbox/nv2a/pgraph/glsl/psh.c
@@ -815,14 +815,17 @@ static MString* psh_convert(struct PixelShader *ps)
         "    float lo_f = float(lo_i) / float(0xffff);\n"
         "    return vec3(hi_f, lo_f, 1.0);\n"
         "}\n"
-        "vec3 dotmap_hilo_hemisphere_d3d(vec4 col) {\n"
-        "    return col.rgb;\n" // FIXME
+        "vec3 dotmap_hilo_hemisphere(vec4 col) {\n"
+        "    uvec4 _col = uvec4(col * 255);\n"
+        "    vec2 hilo = vec2(_col.a << 8 | _col.r, _col.g << 8 | _col.b);\n"
+        "    hilo = (hilo - 65536.0f*step(32767.5f, hilo)) / 32767.0f;\n"
+        "    return vec3(hilo, sqrt(max(1.0f - dot(hilo, hilo), 0.0f)));\n"
         "}\n"
         "vec3 dotmap_hilo_hemisphere_gl(vec4 col) {\n"
-        "    return col.rgb;\n" // FIXME
+        "    return dotmap_hilo_hemisphere(col);\n"
         "}\n"
-        "vec3 dotmap_hilo_hemisphere(vec4 col) {\n"
-        "    return col.rgb;\n" // FIXME
+        "vec3 dotmap_hilo_hemisphere_d3d(vec4 col) {\n"
+        "    return dotmap_hilo_hemisphere(col);\n"
         "}\n"
         "const float[9] gaussian3x3 = float[9](\n"
         "    1.0/16.0, 2.0/16.0, 1.0/16.0,\n"


### PR DESCRIPTION
I don't know if there is any game that suffers an issue related to this.

https://github.com/abaire/nxdk_pgraph_tests_golden_results/blob/main/Texture_cubemap/DotSTRCube_HiLoHemi.png
PR
![xemu-2025-02-04-13-53-32](https://github.com/user-attachments/assets/21ba03ab-ed6c-4532-b344-4d9c6e018fd4)
v0.8.15
![xemu-2025-02-04-16-11-30](https://github.com/user-attachments/assets/78f9b8a8-cb15-4a90-8b0f-83ec54df13ed)
