### PR TITLE
nv2a: Use rounded values for alpha testing

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/shaders.c
+++ b/hw/xbox/nv2a/pgraph/gl/shaders.c
@@ -712,9 +712,9 @@ static void shader_update_constants(PGRAPHState *pg, ShaderBinding *binding,
         }
     }
     if (binding->alpha_ref_loc != -1) {
-        float alpha_ref = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_CONTROL_0),
-                                   NV_PGRAPH_CONTROL_0_ALPHAREF) / 255.0;
-        glUniform1f(binding->alpha_ref_loc, alpha_ref);
+        int alpha_ref = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_CONTROL_0),
+                                   NV_PGRAPH_CONTROL_0_ALPHAREF);
+        glUniform1i(binding->alpha_ref_loc, alpha_ref);
     }
 
 

--- a/hw/xbox/nv2a/pgraph/glsl/psh.c
+++ b/hw/xbox/nv2a/pgraph/glsl/psh.c
@@ -743,7 +743,7 @@ static MString* psh_convert(struct PixelShader *ps)
                            "layout(location = 0) out vec4 fragColor;\n");
     }
 
-    mstring_append_fmt(preflight, "%sfloat alphaRef;\n"
+    mstring_append_fmt(preflight, "%sint alphaRef;\n"
                                   "%svec4  fogColor;\n"
                                   "%sivec4 clipRegion[8];\n",
                                   u, u, u);
@@ -1190,7 +1190,9 @@ static MString* psh_convert(struct PixelShader *ps)
                 assert(false);
                 break;
             }
-            mstring_append_fmt(ps->code, "if (!(fragColor.a %s alphaRef)) discard;\n",
+            mstring_append_fmt(ps->code,
+                               "int fragAlpha = int(round(fragColor.a * 255.0));\n"
+                               "if (!(fragAlpha %s alphaRef)) discard;\n",
                                alpha_op);
         }
     }

--- a/hw/xbox/nv2a/pgraph/vk/shaders.c
+++ b/hw/xbox/nv2a/pgraph/vk/shaders.c
@@ -477,10 +477,9 @@ static void shader_update_constants(PGRAPHState *pg, ShaderBinding *binding,
         }
     }
     if (binding->alpha_ref_loc != -1) {
-        float alpha_ref = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_CONTROL_0),
-                                   NV_PGRAPH_CONTROL_0_ALPHAREF) /
-                          255.0;
-        uniform1f(&binding->fragment->uniforms, binding->alpha_ref_loc,
+        int alpha_ref = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_CONTROL_0),
+                                   NV_PGRAPH_CONTROL_0_ALPHAREF);
+        uniform1i(&binding->fragment->uniforms, binding->alpha_ref_loc,
                          alpha_ref);
     }
 


### PR DESCRIPTION
Fixes #1912

[Tests](https://github.com/abaire/nxdk_pgraph_tests/blob/fd47469ad52548a5b24aebd1630532b0d436e07b/src/tests/alpha_func_tests.cpp#L1)

[HW results](https://abaire.github.io/nxdk_pgraph_tests_golden_results/results/Alpha_func/index.html)
[Pre-CL results](https://abaire.github.io/xemu-nxdk_pgraph_tests_results/compare/xemu-0.8.20-master-3bdb9e7fd4d6c9f5adec0543f1679d2943a0d092/Linux_x86_64/gl_NVIDIA_Corporation_NVIDIA_GeForce_GTX_1070-PCIe-SSE2%3Agslv_4.00_NVIDIA_via_Cg_compiler/Alpha_func.html)

CL results can be found [here](https://github.com/abaire/xemu-dev_pgraph_test_results/tree/fix/1912_alpha_test_should_use_rounded_values/results/xemu-0.8.20-1-g60c8e4e513-fix_1912_alpha_test_should_use_rounded_values-60c8e4e5139511672c682a4d54c7ab76ace87452/Darwin_arm64/gl_Apple_Apple_M3_Max/gslv_4.10/Alpha_func)