### PR TITLE
Fix Ubuntu build times

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,7 +213,7 @@ jobs:
       run: |
         pushd src
         echo -e "\
-        xemu (1:$(cat XEMU_VERSION)-0) unstable; urgency=medium\n\
+        xemu (1:0.0.0-0) unstable; urgency=medium\n\
           Built from $(cat XEMU_VERSION)\n\
          -- Matt Borgerson <contact@mborgerson.com>  $(date -R)" > debian/changelog
         popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
           build_param:
           artifact_name: xemu-ubuntu-x86_64-release
           artifact_filename: xemu-ubuntu-x86_64-release.tgz
-          runs-on: ubuntu-22.04
+          runs-on: ubuntu-24.04
         - arch: aarch64
           configuration: Debug
           build_param: --debug


### PR DESCRIPTION
Apparently dpkg on Ubuntu 24.04 is adding version-specific file mapping prefix cflags (e.g. `-fdebug-prefix-map=/home/runner/work/xemu/xemu/src=/usr/src/xemu-1:0.8.20-2-gef0ace1a1a-0`) and in the process killing object caching. For now just zero out the version so flags are consistent across builds. Final AppImage product will have the correct version added. There's probably a nicer approach--we'll fix it if we start releasing debs on GH.