### PR TITLE
meson: Trim unreferenced functions, data

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -353,6 +353,10 @@ qemu_common_flags = [
 qemu_cflags = []
 qemu_ldflags = []
 
+# Trim unreferenced functions, data
+qemu_common_flags += ['-ffunction-sections', '-fdata-sections']
+qemu_ldflags += '-Wl,--gc-sections'
+
 if host_os == 'darwin'
   # Disable attempts to use ObjectiveC features in os/object.h since they
   # won't work when we're compiling with gcc as a C compiler.


### PR DESCRIPTION
Trim ~4MiB

- [ ] Trim more
- [ ] Fix build
   - [ ] macOS *pass the -dead_strip option to ld. You should also pass the -gfull option to GCC* [ref](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/CodeFootprint/Articles/CompilerOptions.html)
- [ ] Compare to LTO