### PR TITLE
nv2a: Handle texture dimensions not divisible by 4 in S3TC decoder

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/texture.c
+++ b/hw/xbox/nv2a/pgraph/gl/texture.c
@@ -467,12 +467,9 @@ static void upload_gl_texture(GLenum gl_target,
                         8 : 16;
                 unsigned int physical_width = (width + 3) & ~3,
                              physical_height = (height + 3) & ~3;
-                if (physical_width != width) {
-                    glPixelStorei(GL_UNPACK_ROW_LENGTH, physical_width);
-                }
                 uint8_t *converted = s3tc_decompress_2d(
                     gl_internal_format_to_s3tc_enum(f.gl_internal_format),
-                    texture_data, physical_width, physical_height);
+                    texture_data, width, height);
                 unsigned int tex_width = width;
                 unsigned int tex_height = height;
 
@@ -492,9 +489,6 @@ static void upload_gl_texture(GLenum gl_target,
                 glTexImage2D(gl_target, level, GL_RGBA, tex_width, tex_height, 0,
                              GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, converted);
                 g_free(converted);
-                if (physical_width != width) {
-                    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-                }
                 if (s.cubemap && adjusted_width != s.width) {
                     glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
                     glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);

--- a/hw/xbox/nv2a/pgraph/gl/texture.c
+++ b/hw/xbox/nv2a/pgraph/gl/texture.c
@@ -551,10 +551,10 @@ static void upload_gl_texture(GLenum gl_target,
         int level;
         for (level = 0; level < s.levels; level++) {
             if (f.gl_format == 0) { /* compressed */
-                assert(width % 4 == 0 && height % 4 == 0 &&
-                       "Compressed 3D texture virtual size");
-                width = MAX(width, 4);
-                height = MAX(height, 4);
+                width = MAX(width, 1);
+                height = MAX(height, 1);
+                unsigned int physical_width = (width + 3) & ~3,
+                             physical_height = (height + 3) & ~3;
                 depth = MAX(depth, 1);
 
                 unsigned int block_size;
@@ -564,7 +564,7 @@ static void upload_gl_texture(GLenum gl_target,
                     block_size = 16;
                 }
 
-                size_t texture_size = width/4 * height/4 * depth * block_size;
+                size_t texture_size = physical_width/4 * physical_height/4 * depth * block_size;
 
                 uint8_t *converted = s3tc_decompress_3d(
                     gl_internal_format_to_s3tc_enum(f.gl_internal_format),

--- a/hw/xbox/nv2a/pgraph/s3tc.c
+++ b/hw/xbox/nv2a/pgraph/s3tc.c
@@ -63,9 +63,10 @@ static void decode_bc1_colors(uint16_t c0, uint16_t c1, uint8_t r[4],
 }
 
 static void write_block_to_texture(uint8_t *converted_data, uint32_t indices,
-                                   int i, int j, int width, int z_pos_factor,
-                                   uint8_t r[4], uint8_t g[4], uint8_t b[4],
-                                   uint8_t a[16], bool separate_alpha)
+                                   int i, int j, int width, int height,
+                                   int z_pos_factor, uint8_t r[4],
+                                   uint8_t g[4], uint8_t b[4], uint8_t a[16],
+                                   bool separate_alpha)
 {
     int x0 = i * 4,
         y0 = j * 4;
@@ -73,10 +74,10 @@ static void write_block_to_texture(uint8_t *converted_data, uint32_t indices,
     int x1 = x0 + 4,
         y1 = y0 + 4;
 
-    for (int y = y0; y < y1; y++) {
+    for (int y = y0; y < y1 && y < height; y++) {
         int y_index = 4 * (y - y0);
         int z_plus_y_pos_factor = z_pos_factor + y * width;
-        for (int x = x0; x < x1; x++) {
+        for (int x = x0; x < x1 && x < width; x++) {
             int xy_index = y_index + x - x0;
             uint8_t index = (indices >> 2 * xy_index) & 0x03;
             uint8_t alpha_index = separate_alpha ? xy_index : index;
@@ -91,7 +92,7 @@ static void write_block_to_texture(uint8_t *converted_data, uint32_t indices,
 
 static void decompress_dxt1_block(const uint8_t block_data[8],
                                   uint8_t *converted_data, int i, int j,
-                                  int width, int z_pos_factor)
+                                  int width, int height, int z_pos_factor)
 {
     uint16_t c0 = ((uint16_t*)block_data)[0],
              c1 = ((uint16_t*)block_data)[1];
@@ -100,13 +101,13 @@ static void decompress_dxt1_block(const uint8_t block_data[8],
 
     uint32_t indices = ((uint32_t*)block_data)[1];
     write_block_to_texture(converted_data, indices,
-                           i, j, width, z_pos_factor,
+                           i, j, width, height, z_pos_factor,
                            r, g, b, a, false);
 }
 
 static void decompress_dxt3_block(const uint8_t block_data[16],
                                   uint8_t *converted_data, int i, int j,
-                                  int width, int z_pos_factor)
+                                  int width, int height, int z_pos_factor)
 {
     uint16_t c0 = ((uint16_t*)block_data)[4],
              c1 = ((uint16_t*)block_data)[5];
@@ -120,13 +121,13 @@ static void decompress_dxt3_block(const uint8_t block_data[16],
 
     uint32_t indices = ((uint32_t*)block_data)[3];
     write_block_to_texture(converted_data, indices,
-                           i, j, width, z_pos_factor,
+                           i, j, width, height, z_pos_factor,
                            r, g, b, a, true);
 }
 
 static void decompress_dxt5_block(const uint8_t block_data[16],
                                   uint8_t *converted_data, int i, int j,
-                                  int width, int z_pos_factor)
+                                  int width, int height, int z_pos_factor)
 {
     uint16_t c0 = ((uint16_t*)block_data)[4],
              c1 = ((uint16_t*)block_data)[5];
@@ -160,7 +161,7 @@ static void decompress_dxt5_block(const uint8_t block_data[16],
 
     uint32_t indices = ((uint32_t*)block_data)[3];
     write_block_to_texture(converted_data, indices,
-                           i, j, width, z_pos_factor,
+                           i, j, width, height, z_pos_factor,
                            r, g, b, a, true);
 }
 
@@ -187,13 +188,13 @@ uint8_t *s3tc_decompress_3d(enum S3TC_DECOMPRESS_FORMAT color_format,
 
                     if (color_format == S3TC_DECOMPRESS_FORMAT_DXT1) {
                         decompress_dxt1_block(data + 8 * sub_block_index, converted_data,
-                                              i, j, width, z_pos_factor);
+                                              i, j, width, height, z_pos_factor);
                     } else if (color_format == S3TC_DECOMPRESS_FORMAT_DXT3) {
                         decompress_dxt3_block(data + 16 * sub_block_index, converted_data,
-                                              i, j, width, z_pos_factor);
+                                              i, j, width, height, z_pos_factor);
                     } else if (color_format == S3TC_DECOMPRESS_FORMAT_DXT5) {
                         decompress_dxt5_block(data + 16 * sub_block_index, converted_data,
-                                              i, j, width, z_pos_factor);
+                                              i, j, width, height, z_pos_factor);
                     } else {
                         assert(false);
                     }
@@ -209,22 +210,24 @@ uint8_t *s3tc_decompress_2d(enum S3TC_DECOMPRESS_FORMAT color_format,
                             const uint8_t *data, unsigned int width,
                             unsigned int height)
 {
-    assert((width > 0) && (width % 4 == 0));
-    assert((height > 0) && (height % 4 == 0));
-    int num_blocks_x = width / 4, num_blocks_y = height / 4;
+    assert(width > 0);
+    assert(height > 0);
+    unsigned int physical_width = (width + 3) & ~3,
+                 physical_height = (height + 3) & ~3;
+    int num_blocks_x = physical_width / 4, num_blocks_y = physical_height / 4;
     uint8_t *converted_data = (uint8_t *)g_malloc(width * height * 4);
     for (int j = 0; j < num_blocks_y; j++) {
         for (int i = 0; i < num_blocks_x; i++) {
             int block_index = j * num_blocks_x + i;
             if (color_format == S3TC_DECOMPRESS_FORMAT_DXT1) {
                 decompress_dxt1_block(data + 8 * block_index,
-                                      converted_data, i, j, width, 0);
+                                      converted_data, i, j, width, height, 0);
             } else if (color_format == S3TC_DECOMPRESS_FORMAT_DXT3) {
                 decompress_dxt3_block(data + 16 * block_index,
-                                      converted_data, i, j, width, 0);
+                                      converted_data, i, j, width, height, 0);
             } else if (color_format == S3TC_DECOMPRESS_FORMAT_DXT5) {
                 decompress_dxt5_block(data + 16 * block_index,
-                                      converted_data, i, j, width, 0);
+                                      converted_data, i, j, width, height, 0);
             } else {
                 assert(false);
             }

--- a/hw/xbox/nv2a/pgraph/vk/texture.c
+++ b/hw/xbox/nv2a/pgraph/vk/texture.c
@@ -246,14 +246,11 @@ static TextureLayout *get_texture_layout(PGRAPHState *pg, int texture_idx)
                     unsigned int tex_width = width, tex_height = height;
                     unsigned int physical_width = (width + 3) & ~3,
                                  physical_height = (height + 3) & ~3;
-                    // if (physical_width != width) {
-                    //     glPixelStorei(GL_UNPACK_ROW_LENGTH, physical_width);
-                    // }
 
                     size_t converted_size = width * height * 4;
                     uint8_t *converted = s3tc_decompress_2d(
                         kelvin_format_to_s3tc_format(s.color_format),
-                        texture_data_ptr, physical_width, physical_height);
+                        texture_data_ptr, width, height);
                     assert(converted);
 
                     if (s.cubemap && adjusted_width != s.width) {

--- a/hw/xbox/nv2a/pgraph/vk/texture.c
+++ b/hw/xbox/nv2a/pgraph/vk/texture.c
@@ -332,11 +332,10 @@ static TextureLayout *get_texture_layout(PGRAPHState *pg, int texture_idx)
 
         for (int level = 0; level < s.levels; level++) {
             if (is_compressed) {
-                assert(width % 4 == 0 && height % 4 == 0 &&
-                       "Compressed 3D texture virtual size");
-
-                width = MAX(width, 4);
-                height = MAX(height, 4);
+                width = MAX(width, 1);
+                height = MAX(height, 1);
+                unsigned int physical_width = (width + 3) & ~3,
+                             physical_height = (height + 3) & ~3;
                 depth = MAX(depth, 1);
 
                 size_t converted_size = width * height * depth * 4;
@@ -353,7 +352,7 @@ static TextureLayout *get_texture_layout(PGRAPHState *pg, int texture_idx)
                     .decoded_data = converted,
                 };
 
-                texture_data_ptr += width / 4 * height / 4 * depth * block_size;
+                texture_data_ptr += physical_width / 4 * physical_height / 4 * depth * block_size;
             } else {
                 width = MAX(width, 1);
                 height = MAX(height, 1);


### PR DESCRIPTION
Fixes #1830 by keeping the actual texture size when decompressing 2D textures (e.g. 1x32 instead of 4x32), thus eliminating the need for the call to glPixelStorei (which has no equivalent on Vulkan, hence the bug)

Thanks @coldhex for the heads up

Before (on Vulkan):
![xemu-2025-03-11-20-14-58](https://github.com/user-attachments/assets/9aacb385-e24a-4c61-92eb-28c5e555b1a2)

After:
![xemu-2025-03-11-20-15-52](https://github.com/user-attachments/assets/708ddfa1-4dca-440d-91e9-fdccde0645cf)

