### PR TITLE
scripts/xemu-version.sh: Use 0.0.0 if version cannot be detected

### DIFF
--- a/scripts/xemu-version.sh
+++ b/scripts/xemu-version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -25,6 +25,10 @@ XEMU_VERSION=$( \
   elif test -e XEMU_VERSION; then \
     cat XEMU_VERSION; \
   fi)
+
+if [[ "${XEMU_VERSION}" == "" ]]; then
+  XEMU_VERSION="0.0.0"
+fi
 
 get_version_field() {
   echo ${XEMU_VERSION}-0 | cut -d- -f$1


### PR DESCRIPTION
It could be argued that the build should just fail with a better error message if a proper version number cannot be found... But instead of forcing developers to fix their environment at the moment, we'll just use a dummy version number for now.

Fix #1978 