### PR TITLE
nv2a: Drop surface compat clip constraint

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/draw.c
+++ b/hw/xbox/nv2a/pgraph/gl/draw.c
@@ -334,11 +334,10 @@ void pgraph_gl_draw_begin(NV2AState *d)
     /* FIXME: Consider moving to PSH w/ window clip */
     unsigned int xmin = pg->surface_shape.clip_x,
                  ymin = pg->surface_shape.clip_y;
-    unsigned int xmax = xmin + pg->surface_shape.clip_width - 1,
-                 ymax = ymin + pg->surface_shape.clip_height - 1;
 
-    unsigned int scissor_width = xmax - xmin + 1,
-                 scissor_height = ymax - ymin + 1;
+    unsigned int scissor_width = pg->surface_shape.clip_width,
+                 scissor_height = pg->surface_shape.clip_height;
+
     pgraph_apply_anti_aliasing_factor(pg, &xmin, &ymin);
     pgraph_apply_anti_aliasing_factor(pg, &scissor_width, &scissor_height);
     ymin = pg->surface_binding_dim.height - (ymin + scissor_height);

--- a/hw/xbox/nv2a/pgraph/gl/surface.c
+++ b/hw/xbox/nv2a/pgraph/gl/surface.c
@@ -582,9 +582,7 @@ static bool check_surface_compatibility(SurfaceBinding *s1, SurfaceBinding *s2,
         (s1->color == s2->color) &&
         (s1->fmt.gl_attachment == s2->fmt.gl_attachment) &&
         (s1->fmt.gl_internal_format == s2->fmt.gl_internal_format) &&
-        (s1->pitch == s2->pitch) &&
-        (s1->shape.clip_x <= s2->shape.clip_x) &&
-        (s1->shape.clip_y <= s2->shape.clip_y);
+        (s1->pitch == s2->pitch);
     if (!format_compatible) {
         return false;
     }

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1475,11 +1475,8 @@ static void begin_draw(PGRAPHState *pg)
         unsigned int xmin = pg->surface_shape.clip_x,
                      ymin = pg->surface_shape.clip_y;
 
-        unsigned int xmax = xmin + pg->surface_shape.clip_width - 1,
-                     ymax = ymin + pg->surface_shape.clip_height - 1;
-
-        unsigned int scissor_width = xmax - xmin + 1,
-                     scissor_height = ymax - ymin + 1;
+        unsigned int scissor_width = pg->surface_shape.clip_width,
+                     scissor_height = pg->surface_shape.clip_height;
 
         pgraph_apply_anti_aliasing_factor(pg, &xmin, &ymin);
         pgraph_apply_anti_aliasing_factor(pg, &scissor_width, &scissor_height);

--- a/hw/xbox/nv2a/pgraph/vk/surface.c
+++ b/hw/xbox/nv2a/pgraph/vk/surface.c
@@ -890,9 +890,7 @@ static bool check_surface_compatibility(SurfaceBinding const *s1,
     bool format_compatible =
         (s1->color == s2->color) &&
         (s1->host_fmt.vk_format == s2->host_fmt.vk_format) &&
-        (s1->pitch == s2->pitch) &&
-        (s1->shape.clip_x <= s2->shape.clip_x) &&
-        (s1->shape.clip_y <= s2->shape.clip_y);
+        (s1->pitch == s2->pitch);
     if (!format_compatible) {
         return false;
     }


### PR DESCRIPTION
After we fix clipping issues in #1986, relax surface compatibility constraints to resolve unnecessary surface synchronization (and avoid some precision loss issues).

* Fix #1237