### PR TITLE
build.yml: Omit scripts path on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - '.github/**'
       - '!.github/workflows/build.yml'
       - 'README.md'
+      - 'scripts/**'
       - 'ubuntu-win64-cross/**'
   pull_request:
     paths-ignore:


### PR DESCRIPTION
As far as I'm aware we shouldn't be generating a new rel on any push in regards to modifying a script. 