### PR TITLE
nv2a: Fix cubemap fourth texture coordinate component handling

### DIFF
--- a/hw/xbox/nv2a/pgraph/glsl/psh.c
+++ b/hw/xbox/nv2a/pgraph/glsl/psh.c
@@ -984,8 +984,8 @@ static MString* psh_convert(struct PixelShader *ps)
             }
             break;
         case PS_TEXTUREMODES_CUBEMAP:
-            mstring_append_fmt(vars, "vec4 t%d = texture(texSamp%d, pT%d.xyz / pT%d.w);\n",
-                               i, i, i, i);
+            mstring_append_fmt(vars, "vec4 t%d = texture(texSamp%d, pT%d.xyz);\n",
+                               i, i, i);
             break;
         case PS_TEXTUREMODES_PASSTHRU:
             assert(ps->state.border_logical_size[i][0] == 0.0f && "Unexpected border texture on passthru");


### PR DESCRIPTION
Xbox hardware ignores fourth texture coordinate component for cubemaps.

I added more test cases varying the fourth component (q) in nxdk_pgraph_tests cubemap tests:

Xbox HW (all are the same regardless of q):
![xboxhw-cubemap](https://github.com/user-attachments/assets/ceae9b35-5fe6-4fb4-96d6-0598eacbd7d2)


Xemu 0.8.34 (only q=1.0 matches hardware):
![xemu0834-cubemap](https://github.com/user-attachments/assets/8425cb0c-b3b1-4b70-aa60-f409b8c97c09)


PR matches hardware, but I won't repeat the same image here again. More interesting is that PR improves Chronicles of Riddick, which sets fourth coordinate of cubemaps to zero (q=0.0):

Xemu 0.8.34:


https://github.com/user-attachments/assets/c89546d8-70a0-4080-a9b3-ff5fb58a9578



PR:

https://github.com/user-attachments/assets/0ec3d4f6-ade4-4e46-92ee-73c210377ef8


Xbox HW: https://www.youtube.com/watch?v=Xu5BH4j0K1A&t=105s