### PR TITLE
nv2a: Adjust NaN handling for fog coordinate and colors to be similar to HW

### DIFF
--- a/hw/xbox/nv2a/pgraph/glsl/vsh-prog.c
+++ b/hw/xbox/nv2a/pgraph/glsl/vsh-prog.c
@@ -639,7 +639,7 @@ static const char* vsh_header =
     // Unfortunately mix() falls victim to the same handling of exceptional
     // (inf/NaN) handling as a multiply, so per-component comparisons are used
     // to guarantee HW behavior (anything * 0 must == 0).
-    "  vec4 zero_components = sign(src0) * sign(src1);\n"
+    "  vec4 zero_components = sign(NaNToOne(src0)) * sign(NaNToOne(src1));\n"
     "  vec4 ret = src0 * src1;\n"
     "  if (zero_components.x == 0.0) { ret.x = 0.0; }\n"
     "  if (zero_components.y == 0.0) { ret.y = 0.0; }\n"


### PR DESCRIPTION
Resurrecting #913 and incorporating some of the comments from #1780 in the hopes that:

1) This approach will work across different GPU manufacturers (testing needed, it works for M3 mac and my old NVIDIA 1070)
2) That the handful of fog nan mishandles that have been identified are the only places where NaN handling is important in practice so the perf hit of patching up NaNs can be limited to once per vertex instead of having to run on all attribs.

I suspect that the MUL zero handling fix that was added in #1045 may already be preventing/masking some issues.

[HW exceptional fog tests](https://abaire.github.io/nxdk_pgraph_tests_golden_results/results/Fog_exceptional_value/index.html)
[PR test results](https://abaire.github.io/xemu-dev_pgraph_test_results/fix_nan_fog/index.html)

This PR does not fix all issues with the exceptional fog tests, but it does fix the ones that seem to matter for Otogi. I have not fully reversed how fog params are utilized so I think the pgraph tests may be generating cases that would never be triggered by D3D.


(Probably) Fixes https://github.com/xemu-project/xemu/issues/365 by forcing treatment of NaN fog values generated in the vertex shader to follow the same pattern as HW.
Reportedly fixes #1026 as well
