### PR TITLE
nv2a: Fix assert when setting fog gen mode to fog_x

### DIFF
--- a/hw/xbox/nv2a/pgraph/glsl/vsh-ff.c
+++ b/hw/xbox/nv2a/pgraph/glsl/vsh-ff.c
@@ -414,7 +414,7 @@ GLSL_DEFINE(materialEmissionColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_CM_COL) ".xyz
             mstring_append(body, "  float fogDistance = fogCoord;\n");
             break;
         default:
-            assert(false);
+            assert(!"Invalid foggen mode");
             break;
         }
 

--- a/hw/xbox/nv2a/pgraph/vsh.h
+++ b/hw/xbox/nv2a/pgraph/vsh.h
@@ -55,8 +55,6 @@ enum VshFoggen {
     FOGGEN_RADIAL,
     FOGGEN_PLANAR,
     FOGGEN_ABS_PLANAR,
-    FOGGEN_ERROR4,
-    FOGGEN_ERROR5,
     FOGGEN_FOG_X
 };
 


### PR DESCRIPTION
There is a mismatch between the values set into `CSV0_D` and the PGRAPH parameters leading to an assertion failure in the fixed function shader when selecting `NV097_SET_FOG_GEN_MODE_V_FOG_X` generation mode.

I verified that the `CSV0_D` value actually is 4 using abaire/nxdk_nv2a_register_finder, so the issue here is that the `VshFoggen` enumeration was incorrectly based on the `NV097_SET_FOG_GEN_MODE` parameters rather than the register vals.


Not sure if any games use `NV097_SET_FOG_GEN_MODE_V_FOG_X`, I was expanding the fog tests in the pgraph tester and ran into this.