### PR TITLE
build.sh: Add xemu_version fallback to macOS builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,8 +66,14 @@ package_macos() {
 
     cp Info.plist dist/xemu.app/Contents/
 
-    plutil -replace CFBundleShortVersionString -string $(cat ${project_source_dir}/XEMU_VERSION | cut -f1 -d-) dist/xemu.app/Contents/Info.plist
-    plutil -replace CFBundleVersion            -string $(cat ${project_source_dir}/XEMU_VERSION | cut -f1 -d-) dist/xemu.app/Contents/Info.plist
+    if [[ -e "${project_source_dir}/XEMU_VERSION" ]]; then
+      xemu_version="$(cat ${project_source_dir}/XEMU_VERSION | cut -f1 -d-)"
+    else
+      xemu_version="0.0.0"
+    fi
+
+    plutil -replace CFBundleShortVersionString -string "${xemu_version}" dist/xemu.app/Contents/Info.plist
+    plutil -replace CFBundleVersion            -string "${xemu_version}" dist/xemu.app/Contents/Info.plist
 
     codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign - "${exe_path}"
     python3 ./scripts/gen-license.py --version-file=macos-libs/$target_arch/INSTALLED > dist/LICENSE.txt


### PR DESCRIPTION
Fixes the macOS build action on forked repos (at least on mine)