### PR TITLE
nv2a: Increase MAX_BATCH_LENGTH beyond highest known retail use

### DIFF
--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -1467,7 +1467,18 @@
 #define NV2A_NUM_SUBCHANNELS 8
 #define NV2A_CACHE1_SIZE 128
 
-#define NV2A_MAX_BATCH_LENGTH 0x1FFFF
+/* This is a multi-use limit. Testing on an Xbox 1.0, it is possible to send
+ * arrays of at least 0x0FFFFF elements without issue, however sending
+ * NV097_DRAW_ARRAYS with a start value > 0xFFFF raises an exception implying
+ * that there may be a vertex limit. Since xemu uses batch length for vertex
+ * elements in NV097_INLINE_ARRAY the size should ideally be high enough to
+ * accommodate 0xFFFF vertices with maximum attributes specified.
+ *
+ * Retail games are known to send at least 0x410FA elements in a single draw, so
+ * a somewhat larger value is selected to balance memory use with real-world
+ * limits.
+ */
+#define NV2A_MAX_BATCH_LENGTH 0x07FFFF
 #define NV2A_VERTEXSHADER_ATTRIBUTES 16
 #define NV2A_MAX_TEXTURES 4
 

--- a/hw/xbox/nv2a/pgraph/pgraph.c
+++ b/hw/xbox/nv2a/pgraph/pgraph.c
@@ -2692,7 +2692,11 @@ DEF_METHOD(NV097, DRAW_ARRAYS)
     int32_t count = GET_MASK(parameter, NV097_DRAW_ARRAYS_COUNT) + 1;
 
     if (pg->inline_elements_length) {
-        /* FIXME: Determine HW behavior for overflow case. */
+        /* FIXME: HW throws an exception if the start index is > 0xFFFF. This
+         * would prevent this assert from firing for any reasonable choice of
+         * NV2A_MAX_BATCH_LENGTH (which must be larger to accommodate
+         * NV097_INLINE_ARRAY anyway)
+         */
         assert((pg->inline_elements_length + count) < NV2A_MAX_BATCH_LENGTH);
         assert(!pg->draw_arrays_prevent_connect);
 


### PR DESCRIPTION
It seems that the 0x1FFFF is arbitrary, I was able to successfully compose draw calls with 0x0FFFFF elements in all draw mechanisms, except for DRAW_ARRAYS which throws a HW exception when given a start offset > 0xFFFF.

I chose 0x7FFFF as a value higher than the known max use in a retail game of 0x410FA (King of Fighters 2003)

Test (not sure I'm going to merge it yet as it's a "crash or pass") https://github.com/abaire/nxdk_pgraph_tests/pull/221

Fixes #2104 