### PR TITLE
nv2a: Fix migration for new NV2A_MAX_BATCH_LENGTH

### DIFF
--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -423,7 +423,7 @@ const VMStateDescription vmstate_nv2a_pgraph_vertex_attributes = {
 
 static const VMStateDescription vmstate_nv2a = {
     .name = "nv2a",
-    .version_id = 2,
+    .version_id = 3,
     .minimum_version_id = 1,
     .post_save = nv2a_post_save,
     .post_load = nv2a_post_load,
@@ -507,9 +507,11 @@ static const VMStateDescription vmstate_nv2a = {
         VMSTATE_BOOL_ARRAY(pgraph.ltc1_dirty, NV2AState, NV2A_LTC1_COUNT),
         VMSTATE_STRUCT_ARRAY(pgraph.vertex_attributes, NV2AState, NV2A_VERTEXSHADER_ATTRIBUTES, 1, vmstate_nv2a_pgraph_vertex_attributes, VertexAttribute),
         VMSTATE_UINT32(pgraph.inline_array_length, NV2AState),
-        VMSTATE_UINT32_ARRAY(pgraph.inline_array, NV2AState, NV2A_MAX_BATCH_LENGTH),
+        VMSTATE_UINT32_SUB_ARRAY(pgraph.inline_array, NV2AState, 0, NV2A_MAX_BATCH_LENGTH_V2),
+        VMSTATE_UINT32_SUB_ARRAY_V(pgraph.inline_array, NV2AState, NV2A_MAX_BATCH_LENGTH_V2, NV2A_MAX_BATCH_LENGTH - NV2A_MAX_BATCH_LENGTH_V2, 3),
         VMSTATE_UINT32(pgraph.inline_elements_length, NV2AState), // fixme
-        VMSTATE_UINT32_ARRAY(pgraph.inline_elements, NV2AState, NV2A_MAX_BATCH_LENGTH),
+        VMSTATE_UINT32_SUB_ARRAY(pgraph.inline_elements, NV2AState, 0, NV2A_MAX_BATCH_LENGTH_V2),
+        VMSTATE_UINT32_SUB_ARRAY_V(pgraph.inline_elements, NV2AState, NV2A_MAX_BATCH_LENGTH_V2, NV2A_MAX_BATCH_LENGTH - NV2A_MAX_BATCH_LENGTH_V2, 3),
         VMSTATE_UINT32(pgraph.inline_buffer_length, NV2AState), // fixme
         VMSTATE_UINT32(pgraph.draw_arrays_length, NV2AState),
         VMSTATE_UINT32(pgraph.draw_arrays_max_count, NV2AState),

--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -1477,8 +1477,12 @@
  * Retail games are known to send at least 0x410FA elements in a single draw, so
  * a somewhat larger value is selected to balance memory use with real-world
  * limits.
+ *
+ * NV2A_MAX_BATCH_LENGTH_V2 is the previous limit, for migration.
+ * FIXME: Remove NV2A_MAX_BATCH_LENGTH_V2 at some point in the future.
  */
 #define NV2A_MAX_BATCH_LENGTH 0x07FFFF
+#define NV2A_MAX_BATCH_LENGTH_V2 0x1FFFF
 #define NV2A_VERTEXSHADER_ATTRIBUTES 16
 #define NV2A_MAX_TEXTURES 4
 

--- a/include/migration/vmstate.h
+++ b/include/migration/vmstate.h
@@ -1085,6 +1085,9 @@ extern const VMStateInfo vmstate_info_qlist;
 #define VMSTATE_UINT32_SUB_ARRAY(_f, _s, _start, _num)                \
     VMSTATE_SUB_ARRAY(_f, _s, _start, _num, 0, vmstate_info_uint32, uint32_t)
 
+#define VMSTATE_UINT32_SUB_ARRAY_V(_f, _s, _start, _num, _v)          \
+    VMSTATE_SUB_ARRAY(_f, _s, _start, _num, _v, vmstate_info_uint32, uint32_t)
+
 #define VMSTATE_UINT32_2DARRAY(_f, _s, _n1, _n2)                      \
     VMSTATE_UINT32_2DARRAY_V(_f, _s, _n1, _n2, 0)
 


### PR DESCRIPTION
Support older snapshots after batch length bump