### PR TITLE
nv2a/psh: Fix default alpha for unbound texture samplers

### DIFF
--- a/hw/xbox/nv2a/pgraph/glsl/psh.c
+++ b/hw/xbox/nv2a/pgraph/glsl/psh.c
@@ -949,7 +949,7 @@ static MString* psh_convert(struct PixelShader *ps)
 
         switch (ps->tex_modes[i]) {
         case PS_TEXTUREMODES_NONE:
-            mstring_append_fmt(vars, "vec4 t%d = vec4(0.0); /* PS_TEXTUREMODES_NONE */\n",
+            mstring_append_fmt(vars, "vec4 t%d = vec4(0.0, 0.0, 0.0, 1.0); /* PS_TEXTUREMODES_NONE */\n",
                                i);
             break;
         case PS_TEXTUREMODES_PROJECT2D: {


### PR DESCRIPTION
[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/bc52fcf598a98228d8a0457e51c7e6610da014a2/src/tests/combiner_tests.cpp#L387)
[HW results](https://abaire.github.io/nxdk_pgraph_tests_golden_results/results/Combiner/index.html#UnboundTexSampler)
[Diff results](https://abaire.github.io/xemu-dev_pgraph_test_results/fix_unbound_texture_alpha/index.html)

Fixes #1920 