### PR TITLE
nv2a: Move point params to uniforms

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/renderer.h
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.h
@@ -126,6 +126,7 @@ typedef struct ShaderBinding {
 
     GLint clip_region_loc[8];
 
+    GLint point_params_loc[8];
     GLint material_alpha_loc;
 } ShaderBinding;
 

--- a/hw/xbox/nv2a/pgraph/gl/shaders.c
+++ b/hw/xbox/nv2a/pgraph/gl/shaders.c
@@ -190,6 +190,11 @@ static void update_shader_constant_locations(ShaderBinding *binding)
         binding->clip_region_loc[i] = glGetUniformLocation(binding->gl_program, tmp);
     }
 
+    for (int i = 0; i < 8; ++i) {
+        snprintf(tmp, sizeof(tmp), "pointParams[%d]", i);
+        binding->point_params_loc[i] = glGetUniformLocation(binding->gl_program, tmp);
+    }
+
     if (binding->state.fixed_function) {
         binding->material_alpha_loc =
             glGetUniformLocation(binding->gl_program, "material_alpha");
@@ -948,6 +953,13 @@ static void shader_update_constants(PGRAPHState *pg, ShaderBinding *binding,
 
         glUniform4i(r->shader_binding->clip_region_loc[i],
                     x_min, y_min_xlat, x_max, y_max_xlat);
+    }
+
+    for (i = 0; i < 8; ++i) {
+        GLint loc = binding->point_params_loc[i];
+        if (loc != -1) {
+            glUniform1f(loc, pg->point_params[i]);
+        }
     }
 
     if (binding->material_alpha_loc != -1) {

--- a/hw/xbox/nv2a/pgraph/glsl/vsh-ff.c
+++ b/hw/xbox/nv2a/pgraph/glsl/vsh-ff.c
@@ -482,14 +482,12 @@ GLSL_DEFINE(materialEmissionColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_CM_COL) ".xyz
 
     /* FIXME: Testing */
     if (state->point_params_enable) {
-        mstring_append_fmt(
+        mstring_append_fmt(uniforms, "%sfloat pointParams[8];\n", u);
+        mstring_append(
             body,
             "  float d_e = length(position * modelViewMat0);\n"
-            "  oPts.x = 1/sqrt(%f + %f*d_e + %f*d_e*d_e) + %f;\n",
-            state->point_params[0], state->point_params[1], state->point_params[2],
-            state->point_params[6]);
-        mstring_append_fmt(body, "  oPts.x = min(oPts.x*%f + %f, 64.0) * %d;\n",
-                           state->point_params[3], state->point_params[7],
+            "  oPts.x = 1/sqrt(pointParams[0] + pointParams[1] * d_e + pointParams[2] * d_e * d_e) + pointParams[6];\n");
+        mstring_append_fmt(body, "  oPts.x = min(oPts.x * pointParams[3] + pointParams[7], 64.0) * %d;\n",
                            state->surface_scale_factor);
     } else {
         mstring_append_fmt(body, "  oPts.x = %f * %d;\n", state->point_size,

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -194,6 +194,7 @@ typedef struct ShaderBinding {
 
     int clip_region_loc;
 
+    int point_params_loc[8];
     int material_alpha_loc;
 
     int uniform_attrs_loc;

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -191,10 +191,9 @@ typedef struct ShaderBinding {
     int light_local_position_loc[NV2A_MAX_LIGHTS];
     int light_local_attenuation_loc[NV2A_MAX_LIGHTS];
     int specular_power_loc;
+    int point_params_loc;
 
     int clip_region_loc;
-
-    int point_params_loc[8];
     int material_alpha_loc;
 
     int uniform_attrs_loc;

--- a/hw/xbox/nv2a/pgraph/vk/shaders.c
+++ b/hw/xbox/nv2a/pgraph/vk/shaders.c
@@ -308,11 +308,8 @@ static void update_shader_constant_locations(ShaderBinding *binding)
     binding->clip_region_loc =
         uniform_index(&binding->fragment->uniforms, "clipRegion");
 
-    for (int i = 0; i < 8; ++i) {
-        snprintf(tmp, sizeof(tmp), "pointParams[%d]", i);
-        binding->point_params_loc[i] =
-            uniform_index(&binding->vertex->uniforms, tmp);
-    }
+    binding->point_params_loc =
+        uniform_index(&binding->vertex->uniforms, "pointParams");
 
     binding->material_alpha_loc =
         uniform_index(&binding->vertex->uniforms, "material_alpha");
@@ -726,11 +723,9 @@ static void shader_update_constants(PGRAPHState *pg, ShaderBinding *binding,
     uniform1iv(&binding->fragment->uniforms, binding->clip_region_loc,
                      8 * 4, (void *)clip_regions);
 
-    for (int i = 0; i < 8; ++i) {
-        int loc = binding->point_params_loc[i];
-        if (loc != -1) {
-            uniform1f(&binding->vertex->uniforms, loc, pg->point_params[i]);
-        }
+    if (binding->point_params_loc != -1) {
+        uniform1iv(&binding->vertex->uniforms, binding->point_params_loc,
+                   ARRAY_SIZE(pg->point_params), (void *)pg->point_params);
     }
 
     if (binding->material_alpha_loc != -1) {

--- a/hw/xbox/nv2a/pgraph/vk/shaders.c
+++ b/hw/xbox/nv2a/pgraph/vk/shaders.c
@@ -308,6 +308,12 @@ static void update_shader_constant_locations(ShaderBinding *binding)
     binding->clip_region_loc =
         uniform_index(&binding->fragment->uniforms, "clipRegion");
 
+    for (int i = 0; i < 8; ++i) {
+        snprintf(tmp, sizeof(tmp), "pointParams[%d]", i);
+        binding->point_params_loc[i] =
+            uniform_index(&binding->vertex->uniforms, tmp);
+    }
+
     binding->material_alpha_loc =
         uniform_index(&binding->vertex->uniforms, "material_alpha");
 
@@ -719,6 +725,13 @@ static void shader_update_constants(PGRAPHState *pg, ShaderBinding *binding,
     }
     uniform1iv(&binding->fragment->uniforms, binding->clip_region_loc,
                      8 * 4, (void *)clip_regions);
+
+    for (int i = 0; i < 8; ++i) {
+        int loc = binding->point_params_loc[i];
+        if (loc != -1) {
+            uniform1f(&binding->vertex->uniforms, loc, pg->point_params[i]);
+        }
+    }
 
     if (binding->material_alpha_loc != -1) {
         uniform1f(&binding->vertex->uniforms, binding->material_alpha_loc,


### PR DESCRIPTION
Fixes #1190 though it may or may not result in correct rendering (it changes but does not fix the point size pgraph tests)

[Test results](https://abaire.github.io/xemu-dev_pgraph_test_results/fix_1190_point_params_as_uniforms/index.html)