### PR TITLE
nv2a/psh: Fix 2D texture addressing in DOT_STR_3D mode

### DIFF
--- a/hw/xbox/nv2a/pgraph/glsl/psh.c
+++ b/hw/xbox/nv2a/pgraph/glsl/psh.c
@@ -1123,8 +1123,8 @@ static MString* psh_convert(struct PixelShader *ps)
                 i, i-2, i-1, i);
 
             apply_border_adjustment(ps, vars, i, "dotSTR%d");
-            mstring_append_fmt(vars, "vec4 t%d = texture(texSamp%d, dotSTR%d);\n",
-                i, i, i);
+            mstring_append_fmt(vars, "vec4 t%d = texture(texSamp%d, %s(dotSTR%d%s));\n",
+                i, i, tex_remap, i, ps->state.dim_tex[i] == 2 ? ".xy" : "");
             break;
         case PS_TEXTUREMODES_DOT_STR_CUBE:
             assert(i == 3);


### PR DESCRIPTION
Fixes #2151 

![xemu-2025-04-29-23-26-51](https://github.com/user-attachments/assets/dc71dc7f-280c-487f-893b-b856e4457ae2)
