### PR TITLE
nv2a: Fix handling of color/zeta offset with RAM addresses

### DIFF
--- a/hw/xbox/nv2a/pgraph/pgraph.c
+++ b/hw/xbox/nv2a/pgraph/pgraph.c
@@ -1025,15 +1025,17 @@ DEF_METHOD(NV097, SET_SURFACE_PITCH)
 DEF_METHOD(NV097, SET_SURFACE_COLOR_OFFSET)
 {
     d->pgraph.renderer->ops.surface_update(d, false, true, true);
-    pg->surface_color.buffer_dirty |= (pg->surface_color.offset != parameter);
-    pg->surface_color.offset = parameter;
+    hwaddr offset = parameter & 0x0FFFFFFF;
+    pg->surface_color.buffer_dirty |= (pg->surface_color.offset != offset);
+    pg->surface_color.offset = offset;
 }
 
 DEF_METHOD(NV097, SET_SURFACE_ZETA_OFFSET)
 {
     d->pgraph.renderer->ops.surface_update(d, false, true, true);
-    pg->surface_zeta.buffer_dirty |= (pg->surface_zeta.offset != parameter);
-    pg->surface_zeta.offset = parameter;
+    hwaddr offset = parameter & 0x0FFFFFFF;
+    pg->surface_zeta.buffer_dirty |= (pg->surface_zeta.offset != offset);
+    pg->surface_zeta.offset = offset;
 }
 
 DEF_METHOD_INC(NV097, SET_COMBINER_ALPHA_ICW)


### PR DESCRIPTION
Fixes #326 

ESPN NFL Football sets the color surface offset using a RAM address (`0x83ba0000`) rather than the equivalent VRAM range (`0x03ba0000`). The game modifies the 0x880 register to disable the associated limit exception similar to what was seen previously in Spongebob.

While we could implement the limit exceptions and handle the 0x880 flag to emulate hardware, it is simpler to allow RAM addresses by masking off the high nibble.