### PR TITLE
nv2a: Allow multiframe RenderDoc captures with nv2a traces

### DIFF
--- a/hw/xbox/nv2a/debug.h
+++ b/hw/xbox/nv2a/debug.h
@@ -155,8 +155,9 @@ static inline void nv2a_profile_inc_counter(enum NV2A_PROF_COUNTERS_ENUM cnt)
 void nv2a_dbg_renderdoc_init(void);
 void *nv2a_dbg_renderdoc_get_api(void);
 bool nv2a_dbg_renderdoc_available(void);
-void nv2a_dbg_renderdoc_capture_frames(int num_frames);
+void nv2a_dbg_renderdoc_capture_frames(int num_frames, bool trace);
 extern int renderdoc_capture_frames;
+extern bool renderdoc_trace_frames;
 #endif
 
 #ifdef __cplusplus

--- a/hw/xbox/nv2a/pgraph/debug_renderdoc.c
+++ b/hw/xbox/nv2a/pgraph/debug_renderdoc.c
@@ -36,6 +36,7 @@
 static RENDERDOC_API_1_6_0 *rdoc_api = NULL;
 
 int renderdoc_capture_frames = 0;
+bool renderdoc_trace_frames = false;
 
 void nv2a_dbg_renderdoc_init(void)
 {
@@ -89,7 +90,8 @@ bool nv2a_dbg_renderdoc_available(void)
     return rdoc_api != NULL;
 }
 
-void nv2a_dbg_renderdoc_capture_frames(int num_frames)
+void nv2a_dbg_renderdoc_capture_frames(int num_frames, bool trace)
 {
     renderdoc_capture_frames += num_frames;
+    renderdoc_trace_frames = trace;
 }

--- a/ui/xui/main.cc
+++ b/ui/xui/main.cc
@@ -218,7 +218,7 @@ void xemu_hud_render(void)
 
 #if defined(CONFIG_RENDERDOC)
     if (g_capture_renderdoc_frame) {
-        nv2a_dbg_renderdoc_capture_frames(1);
+        nv2a_dbg_renderdoc_capture_frames(1, false);
         g_capture_renderdoc_frame = false;
     }
 #endif
@@ -291,7 +291,7 @@ void xemu_hud_render(void)
                     !ImGui::IsAnyItemFocused() && !ImGui::IsAnyItemHovered())) {
             g_scene_mgr.PushScene(g_popup_menu);
         }
-        
+
         bool mod_key_down = ImGui::IsKeyDown(ImGuiKey_ModShift);
         for (int f_key = 0; f_key < 4; ++f_key) {
             if (ImGui::IsKeyPressed((enum ImGuiKey)(ImGuiKey_F5 + f_key))) {

--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -73,7 +73,9 @@ void ProcessKeyboardShortcuts(void)
 
 #ifdef CONFIG_RENDERDOC
     if (ImGui::IsKeyPressed(ImGuiKey_F10) && nv2a_dbg_renderdoc_available()) {
-        nv2a_dbg_renderdoc_capture_frames(1);
+        ImGuiIO& io = ImGui::GetIO();
+        int num_frames = io.KeyShift ? 5 : 1;
+        nv2a_dbg_renderdoc_capture_frames(num_frames, io.KeyCtrl);
     }
 #endif
 }


### PR DESCRIPTION
- Allows multiple frames to be captured at once by holding shift while pressing F10.
- Temporarily toggles nv2a trace messages if control is held while pressing F10.