### PR TITLE
nv2a: Implement screen coordinate rounding to 4-bit fractional precision

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/display.c
+++ b/hw/xbox/nv2a/pgraph/gl/display.c
@@ -68,7 +68,7 @@ void pgraph_gl_init_display(NV2AState *d)
         "{\n"
         "    vec2 texCoord = gl_FragCoord.xy/display_size;\n"
         "    float rel = display_size.y/textureSize(tex, 0).y/line_offset;\n"
-        "    texCoord.y = 1 + rel*(texCoord.y - 1);"
+        "    texCoord.y = rel*(1.0f - texCoord.y);"
         "    out_Color.rgba = texture(tex, texCoord);\n"
         "    if (pvideo_enable) {\n"
         "        vec2 screenCoord = gl_FragCoord.xy - 0.5;\n"

--- a/hw/xbox/nv2a/pgraph/gl/draw.c
+++ b/hw/xbox/nv2a/pgraph/gl/draw.c
@@ -92,7 +92,6 @@ void pgraph_gl_clear_surface(NV2AState *d, uint32_t parameter)
                  scissor_height = ymax - ymin + 1;
     pgraph_apply_anti_aliasing_factor(pg, &xmin, &ymin);
     pgraph_apply_anti_aliasing_factor(pg, &scissor_width, &scissor_height);
-    ymin = pg->surface_binding_dim.height - (ymin + scissor_height);
 
     NV2A_DPRINTF("Translated clear rect to %d,%d - %d,%d\n", xmin, ymin,
                  xmin + scissor_width - 1, ymin + scissor_height - 1);
@@ -204,9 +203,10 @@ void pgraph_gl_draw_begin(NV2AState *d)
     }
 
     /* Front-face select */
+    /* Winding is reverse here because clip-space y-coordinates are inverted */
     glFrontFace(pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER)
                     & NV_PGRAPH_SETUPRASTER_FRONTFACE
-                        ? GL_CCW : GL_CW);
+                        ? GL_CW : GL_CCW);
 
     /* Polygon offset */
     /* FIXME: GL implementation-specific, maybe do this in VS? */
@@ -340,7 +340,6 @@ void pgraph_gl_draw_begin(NV2AState *d)
 
     pgraph_apply_anti_aliasing_factor(pg, &xmin, &ymin);
     pgraph_apply_anti_aliasing_factor(pg, &scissor_width, &scissor_height);
-    ymin = pg->surface_binding_dim.height - (ymin + scissor_height);
     pgraph_apply_scaling_factor(pg, &xmin, &ymin);
     pgraph_apply_scaling_factor(pg, &scissor_width, &scissor_height);
 

--- a/hw/xbox/nv2a/pgraph/gl/renderer.h
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.h
@@ -111,7 +111,6 @@ typedef struct ShaderBinding {
     GLint vsh_constant_loc[NV2A_VERTEXSHADER_CONSTANTS];
     uint32_t vsh_constants[NV2A_VERTEXSHADER_CONSTANTS][4];
 
-    GLint inv_viewport_loc;
     GLint ltctxa_loc[NV2A_LTCTXA_COUNT];
     GLint ltctxb_loc[NV2A_LTCTXB_COUNT];
     GLint ltc1_loc[NV2A_LTC1_COUNT];

--- a/hw/xbox/nv2a/pgraph/gl/shaders.c
+++ b/hw/xbox/nv2a/pgraph/gl/shaders.c
@@ -924,12 +924,8 @@ static void shader_update_constants(PGRAPHState *pg, ShaderBinding *binding,
         pgraph_apply_scaling_factor(pg, &x_min, &y_min);
         pgraph_apply_scaling_factor(pg, &x_max, &y_max);
 
-        /* Translate for the GL viewport origin */
-        int y_min_xlat = MAX((int)max_gl_height - (int)y_max, 0);
-        int y_max_xlat = MIN((int)max_gl_height - (int)y_min, max_gl_height);
-
         glUniform4i(r->shader_binding->clip_region_loc[i],
-                    x_min, y_min_xlat, x_max, y_max_xlat);
+                    x_min, y_min, x_max, y_max);
     }
 
     for (i = 0; i < 8; ++i) {

--- a/hw/xbox/nv2a/pgraph/gl/shaders.c
+++ b/hw/xbox/nv2a/pgraph/gl/shaders.c
@@ -158,7 +158,6 @@ static void update_shader_constant_locations(ShaderBinding *binding)
     binding->fog_color_loc = glGetUniformLocation(binding->gl_program, "fogColor");
     binding->fog_param_loc = glGetUniformLocation(binding->gl_program, "fogParam");
 
-    binding->inv_viewport_loc = glGetUniformLocation(binding->gl_program, "invViewport");
     for (int i = 0; i < NV2A_LTCTXA_COUNT; i++) {
         snprintf(tmp, sizeof(tmp), "ltctxa[%d]", i);
         binding->ltctxa_loc[i] = glGetUniformLocation(binding->gl_program, tmp);
@@ -847,28 +846,6 @@ static void shader_update_constants(PGRAPHState *pg, ShaderBinding *binding,
         if (binding->specular_power_loc != -1) {
     	    glUniform1f(binding->specular_power_loc, pg->specular_power);
 	    }
-
-        /* estimate the viewport by assuming it matches the surface ... */
-        unsigned int aa_width = 1, aa_height = 1;
-        pgraph_apply_anti_aliasing_factor(pg, &aa_width, &aa_height);
-
-        float m11 = 0.5 * (pg->surface_binding_dim.width/aa_width);
-        float m22 = -0.5 * (pg->surface_binding_dim.height/aa_height);
-        float m33 = zmax;
-        float m41 = *(float*)&pg->vsh_constants[NV_IGRAPH_XF_XFCTX_VPOFF][0];
-        float m42 = *(float*)&pg->vsh_constants[NV_IGRAPH_XF_XFCTX_VPOFF][1];
-
-        float invViewport[16] = {
-            1.0/m11, 0, 0, 0,
-            0, 1.0/m22, 0, 0,
-            0, 0, 1.0/m33, 0,
-            -1.0+m41/m11, 1.0+m42/m22, 0, 1.0
-        };
-
-        if (binding->inv_viewport_loc != -1) {
-            glUniformMatrix4fv(binding->inv_viewport_loc,
-                               1, GL_FALSE, &invViewport[0]);
-        }
     }
 
     /* update vertex program constants */

--- a/hw/xbox/nv2a/pgraph/gl/surface.c
+++ b/hw/xbox/nv2a/pgraph/gl/surface.c
@@ -137,11 +137,7 @@ static void init_render_to_texture(PGRAPHState *pg)
         "layout(location = 0) out vec4 out_Color;\n"
         "void main()\n"
         "{\n"
-        "    vec2 texCoord;\n"
-        "    texCoord.x = gl_FragCoord.x;\n"
-        "    texCoord.y = (surface_size.y - gl_FragCoord.y)\n"
-        "                 + (textureSize(tex,0).y - surface_size.y);\n"
-        "    texCoord /= textureSize(tex,0).xy;\n"
+        "    vec2 texCoord = gl_FragCoord.xy / textureSize(tex, 0).xy;\n"
         "    out_Color.rgba = texture(tex, texCoord);\n"
         "}\n";
 
@@ -298,7 +294,7 @@ static void render_surface_to_texture_slow(NV2AState *d,
     size_t bufsize = width * height * surface->fmt.bytes_per_pixel;
 
     uint8_t *buf = g_malloc(bufsize);
-    surface_download_to_buffer(d, surface, false, true, false, buf);
+    surface_download_to_buffer(d, surface, false, false, false, buf);
 
     width = texture_shape->width;
     height = texture_shape->height;
@@ -738,7 +734,7 @@ static void surface_download(NV2AState *d, SurfaceBinding *surface, bool force)
 
     nv2a_profile_inc_counter(NV2A_PROF_SURF_DOWNLOAD);
 
-    surface_download_to_buffer(d, surface, true, true, true,
+    surface_download_to_buffer(d, surface, true, false, true,
                                d->vram_ptr + surface->vram_addr);
 
     memory_region_set_client_dirty(d->vram, surface->vram_addr,
@@ -875,20 +871,26 @@ void pgraph_gl_upload_surface_data(NV2AState *d, SurfaceBinding *surface,
                        surface->fmt.bytes_per_pixel);
     }
 
-    /* FIXME: Replace this flip/scaling */
+    /* FIXME: Replace this scaling */
 
     // This is VRAM so we can't do this inplace!
-    uint8_t *flipped_buf = (uint8_t *)g_malloc(
-        surface->height * surface->width * surface->fmt.bytes_per_pixel);
-    unsigned int irow;
-    for (irow = 0; irow < surface->height; irow++) {
-        memcpy(&flipped_buf[surface->width * (surface->height - irow - 1)
-                                 * surface->fmt.bytes_per_pixel],
-               &buf[surface->pitch * irow],
-               surface->width * surface->fmt.bytes_per_pixel);
+    uint8_t *optimal_buf = buf;
+    unsigned int optimal_pitch = surface->width * surface->fmt.bytes_per_pixel;
+
+    if (surface->pitch != optimal_pitch) {
+        optimal_buf = (uint8_t *)g_malloc(surface->height * optimal_pitch);
+
+        uint8_t *src = buf;
+        uint8_t *dst = optimal_buf;
+        unsigned int irow;
+        for (irow = 0; irow < surface->height; irow++) {
+            memcpy(dst, src, optimal_pitch);
+            src += surface->pitch;
+            dst += optimal_pitch;
+        }
     }
 
-    uint8_t *gl_read_buf = flipped_buf;
+    uint8_t *gl_read_buf = optimal_buf;
     unsigned int width = surface->width, height = surface->height;
 
     if (pg->surface_scale_factor > 1) {
@@ -896,7 +898,7 @@ void pgraph_gl_upload_surface_data(NV2AState *d, SurfaceBinding *surface,
         pg->scale_buf = (uint8_t *)g_realloc(
             pg->scale_buf, width * height * surface->fmt.bytes_per_pixel);
         gl_read_buf = pg->scale_buf;
-        uint8_t *out = gl_read_buf, *in = flipped_buf;
+        uint8_t *out = gl_read_buf, *in = optimal_buf;
         surface_copy_expand(out, in, surface->width, surface->height,
                             surface->fmt.bytes_per_pixel,
                             d->pgraph.surface_scale_factor);
@@ -915,7 +917,9 @@ void pgraph_gl_upload_surface_data(NV2AState *d, SurfaceBinding *surface,
                  height, 0, surface->fmt.gl_format, surface->fmt.gl_type,
                  gl_read_buf);
     glPixelStorei(GL_UNPACK_ALIGNMENT, prev_unpack_alignment);
-    g_free(flipped_buf);
+    if (optimal_buf != buf) {
+        g_free(optimal_buf);
+    }
     if (surface->swizzle) {
         g_free(buf);
     }

--- a/hw/xbox/nv2a/pgraph/glsl/vsh-ff.c
+++ b/hw/xbox/nv2a/pgraph/glsl/vsh-ff.c
@@ -115,8 +115,6 @@ GLSL_DEFINE(sceneAmbientColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_FR_AMB) ".xyz")
 GLSL_DEFINE(materialEmissionColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_CM_COL) ".xyz")
 "\n"
 );
-    mstring_append_fmt(uniforms,
-"%smat4 invViewport;\n", u);
 
     /* Skinning */
     unsigned int count;
@@ -471,13 +469,18 @@ GLSL_DEFINE(materialEmissionColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_CM_COL) ".xyz
     }
 
     mstring_append(body,
-    "   oPos = tPosition * compositeMat;\n"
-    "   oPos.w = clampAwayZeroInf(oPos.w);\n"
-    "   oPos = invViewport * oPos;\n"
+    "  oPos = tPosition * compositeMat;\n"
+    "  oPos.z = oPos.z / clipRange.y;\n"
+    "  oPos.w = clampAwayZeroInf(oPos.w);\n"
+    "  oPos.xy /= oPos.w;\n"
+    "  oPos.xy += c[" stringify(NV_IGRAPH_XF_XFCTX_VPOFF) "].xy;\n"
+    "  oPos.xy = floor(oPos.xy * 16.0f) / 16.0f;\n"
+    "  oPos.xy = (2.0f * oPos.xy - surfaceSize) / surfaceSize;\n"
+    "  oPos.xy *= oPos.w;\n"
     );
 
-    if (state->vulkan) {
-        mstring_append(body, "   oPos.y *= -1;\n");
+    if (!state->vulkan) {
+        mstring_append(body, "  oPos.y = -oPos.y;\n");
     }
 
     /* FIXME: Testing */

--- a/hw/xbox/nv2a/pgraph/glsl/vsh-ff.c
+++ b/hw/xbox/nv2a/pgraph/glsl/vsh-ff.c
@@ -479,10 +479,6 @@ GLSL_DEFINE(materialEmissionColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_CM_COL) ".xyz
     "  oPos.xy *= oPos.w;\n"
     );
 
-    if (!state->vulkan) {
-        mstring_append(body, "  oPos.y = -oPos.y;\n");
-    }
-
     /* FIXME: Testing */
     if (state->point_params_enable) {
         mstring_append_fmt(uniforms, "%sfloat pointParams[8];\n", u);

--- a/hw/xbox/nv2a/pgraph/glsl/vsh-ff.c
+++ b/hw/xbox/nv2a/pgraph/glsl/vsh-ff.c
@@ -474,7 +474,7 @@ GLSL_DEFINE(materialEmissionColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_CM_COL) ".xyz
     "  oPos.w = clampAwayZeroInf(oPos.w);\n"
     "  oPos.xy /= oPos.w;\n"
     "  oPos.xy += c[" stringify(NV_IGRAPH_XF_XFCTX_VPOFF) "].xy;\n"
-    "  oPos.xy = floor(oPos.xy * 16.0f) / 16.0f;\n"
+    "  oPos.xy = roundScreenCoords(oPos.xy);\n"
     "  oPos.xy = (2.0f * oPos.xy - surfaceSize) / surfaceSize;\n"
     "  oPos.xy *= oPos.w;\n"
     );

--- a/hw/xbox/nv2a/pgraph/glsl/vsh-prog.c
+++ b/hw/xbox/nv2a/pgraph/glsl/vsh-prog.c
@@ -839,8 +839,4 @@ void pgraph_gen_vsh_prog_glsl(uint16_t version,
          */
         "  oPos.xyz *= oPos.w;\n"
     );
-
-    if (!vulkan) {
-        mstring_append(body, "  oPos.y = -oPos.y;\n");
-    }
 }

--- a/hw/xbox/nv2a/pgraph/glsl/vsh-prog.c
+++ b/hw/xbox/nv2a/pgraph/glsl/vsh-prog.c
@@ -822,11 +822,9 @@ void pgraph_gen_vsh_prog_glsl(uint16_t version,
 
     mstring_append(body,
         /* The shaders leave the result in screen space, while OpenGL expects it
-         * in clip space. Xbox NV2A rasterizer appears to have 4 bit precision
-         * fixed point fractional part and to convert floating point coordinates
-         * by flooring.
+         * in clip space.
          */
-        "  oPos.xy = floor(oPos.xy * 16.0f) / 16.0f;\n"
+        "  oPos.xy = roundScreenCoords(oPos.xy);\n"
         "  oPos.xy = (2.0f * oPos.xy - surfaceSize) / surfaceSize;\n"
 
         "  oPos.z = oPos.z / clipRange.y;\n"

--- a/hw/xbox/nv2a/pgraph/glsl/vsh.c
+++ b/hw/xbox/nv2a/pgraph/glsl/vsh.c
@@ -85,6 +85,13 @@ MString *pgraph_gen_vsh_glsl(const ShaderState *state, bool prefix_outputs)
         "\n"
         "vec4 NaNToOne(vec4 src) {\n"
         "  return mix(src, vec4(1.0), isnan(src));\n"
+        "}\n"
+        "\n"
+        // Xbox NV2A rasterizer appears to have 4 bit precision fixed-point
+        // fractional part and to convert floating-point coordinates by
+        // by truncating (not flooring).
+        "vec2 roundScreenCoords(vec2 pos) {\n"
+        "  return trunc(pos * 16.0f) / 16.0f;\n"
         "}\n");
 
     pgraph_get_glsl_vtx_header(header, state->vulkan, state->smooth_shading,

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -179,7 +179,6 @@ typedef struct ShaderBinding {
     int vsh_constant_loc;
     uint32_t vsh_constants[NV2A_VERTEXSHADER_CONSTANTS][4];
 
-    int inv_viewport_loc;
     int ltctxa_loc;
     int ltctxb_loc;
     int ltc1_loc;

--- a/hw/xbox/nv2a/pgraph/vk/shaders.c
+++ b/hw/xbox/nv2a/pgraph/vk/shaders.c
@@ -283,8 +283,6 @@ static void update_shader_constant_locations(ShaderBinding *binding)
     binding->fog_param_loc =
         uniform_index(&binding->vertex->uniforms, "fogParam");
 
-    binding->inv_viewport_loc =
-        uniform_index(&binding->vertex->uniforms, "invViewport");
     binding->ltctxa_loc = uniform_index(&binding->vertex->uniforms, "ltctxa");
     binding->ltctxb_loc = uniform_index(&binding->vertex->uniforms, "ltctxb");
     binding->ltc1_loc = uniform_index(&binding->vertex->uniforms, "ltc1");
@@ -616,27 +614,6 @@ static void shader_update_constants(PGRAPHState *pg, ShaderBinding *binding,
         if (binding->specular_power_loc != -1) {
             uniform1f(&binding->vertex->uniforms, binding->specular_power_loc,
                       pg->specular_power);
-        }
-
-        /* estimate the viewport by assuming it matches the surface ... */
-        unsigned int aa_width = 1, aa_height = 1;
-        pgraph_apply_anti_aliasing_factor(pg, &aa_width, &aa_height);
-
-        float m11 = 0.5 * (pg->surface_binding_dim.width / aa_width);
-        float m22 = -0.5 * (pg->surface_binding_dim.height / aa_height);
-        float m33 = zmax;
-        float m41 = *(float *)&pg->vsh_constants[NV_IGRAPH_XF_XFCTX_VPOFF][0];
-        float m42 = *(float *)&pg->vsh_constants[NV_IGRAPH_XF_XFCTX_VPOFF][1];
-
-        float invViewport[16] = {
-            1.0 / m11, 0,  0, 0,         0, 1.0 / m22,        0,
-            0,         0,  0, 1.0 / m33, 0, -1.0 + m41 / m11, 1.0 + m42 / m22,
-            0,         1.0
-        };
-
-        if (binding->inv_viewport_loc != -1) {
-            uniformMatrix4fv(&binding->vertex->uniforms,
-                                    binding->inv_viewport_loc, &invViewport[0]);
         }
     }
 


### PR DESCRIPTION
This PR implements rounding of floating point screen coordinates x and y to 4-bit fractional precision. Rounding is towards zero (i.e. truncating). This is based on tests https://github.com/coldhex/nxdk_pgraph_tests/commit/96017220b1fb0be796176574df1e0c905f304494

(I suspect that NV2A rasterization has 4-bit sub-pixel precision and converts floating-point screen coordinates to a fixed-point representation.)

Previous work on this includes these PRs:
- https://github.com/xemu-project/xemu/pull/1732
- https://github.com/xemu-project/xemu/pull/1362
- https://github.com/xemu-project/xemu/pull/735

However, #1732 (at 1x) and #1362 don't match hardware (see TopLeftRaster results below). I didn't test #735, but quite likely would not match either.

To test and interpret vertex rounding results the triangle rasterization rule matters. NV2A rasterizes using the top-left triangle rasterization rule of Direct3D (which is a tie-breaking rule when pixel center falls precisely on a triangle edge.) On the other hand, both OpenGL and Vulkan leave the details of
such tie-breaking up to implementation, but GPUs generally just follow the same Direct3D top-left rule (but I haven't tested Apple silicon GPUs).

Considering OpenGL, while the top-left rule is what implementations follow when rendering to a framebuffer, things change when rendering to a framebuffer object (FBO). I have a gist demostrating this: https://gist.github.com/coldhex/114f251c536d8a362ef2cd2cf8ee0964 . When rendering to FBO the rule effectively changes to the bottom-left rule. I suspect this has something to do with bottom-left coordinate convention of OpenGL, forcing implementations to flip y-coordinates and render scenes upside-down to FBOs. This PR also contains an OpenGL-backend commit that flips y-coordinates thereby restoring the top-left rule. Vulkan-backend doesn't need a corresponding modification since Vulkan doesn't have the top-left/bottom-left discrepancy in the first place.

At 1x scale, this PR should fix many problems in games related to the 0.5 pixel offset problem caused by Direct3D (before version 10) coordinate convention. However, I'll list explicitly what this PR doesn't do:

1. Does not fix such problems for GPUs that don't follow the top-left rasterization rule (if there even are modern such GPUs.) It would be possible to add hacks to fix the situation in some cases. For example, if hardware truly followed e.g. the bottom-left rule in Vulkan, then subtracting a small implementation-dependent value from y-coordinates can change render result to look like top-left rule was followed. However, such a hack would also mean that interpolated values such as texture coordinates would be sampled slightly off pixel center and therefore would be slightly off how
NV2A samples. For OpenGL FBO rendering, instead of applying such a hack, I prefer the commit in this PR.

2. Does not fix such problems for scales higher than 1x. At 1x scale Xemu can emulate what the hardware does and the 0.5 pixel offset problem disappears as a result. However, at higher scales the correct rendering result depends on intentions of game developers. Direct3D adds 0.5 offset usually, but this depends on what game devs decided and e.g. Halo 2 doesn't apply the 0.5 offset always. For example, suppose 2x scaling was used and a game wants to render a rectangle with top-left and bottom-right coordinates (0.5, 0.5) and (256.5, 256.5). For 2x scale, consider these two choices: either (1.0, 1.0) and (513.0, 513.0) (which is what Xemu currently does), or (0.5, 0.5) and (512.5, 512.5). The first would be correct if the game did not apply the 0.5 offset and the rectangle was actually in motion and moving towards (0.0, 0.0) and we just happened to catch one frame of it in its path. The second would be correct if the game did apply the 0.5 offset and if the rectangle is supposed to be flush top-left of screen. So fixing the 0.5 offset problem generally requires some guess work. It's difficult to know if the game applied the 0.5 offset or not (because NV2A has programmable vertex shaders.) One possibility would be to add a UI toggle to enable subtracting an offset and let users experiment what looks right per-game (but a game may also be mixed in its use of the 0.5 offset.)

3. Does not fix NV2A floating-point arithmetic emulation. For example, floating-point multiplication result in NV2A vertex shader seems to round towards zero, while modern GPUs follow the IEEE-754 round-to-even rule. Also, NV2A floating point addition rounding is peculiar because the result of e.g. 16777000.0+(-1.0/32.0) rounds to 16776999.0, but adding anything even slightly larger than -1.0/32.0 rounds to 16777000.0. The reason I mention this is that the ProjAdjacentGeometry tests in nxdk_pgraph_tests are sensitive to floating-point rounding, especially ProjAdjacentGeometry_0.5625, the result of which even changed on Xbox hardware due to a math library change in nxdk_pgraph_tests commit [66b32a0b1feba32a0db7a95d6358e84f7a6246ad](https://github.com/abaire/nxdk_pgraph_tests/commit/66b32a0b1feba32a0db7a95d6358e84f7a6246ad). Differing results in ProjAdjacentGeometry tests are caused by inaccurate floating-point arithmetic emulation, not because of the 4-bit vertex rounding (which is what this PR implements.)

4. Does not fix multisampling anti-aliasing (MSAA) sampling points. The vertex rounding in this PR should be correct for MSAA too, but Xemu rasterization for MSAA uses supersampling (SSAA) and if similar test-cases as the TopLeftRaster for this PR was made for MSAA, the results wouldn't match NV2A. For MSAA 2x, NV2A seems to use pixel sample points (0.0, 0.0) and (0.5, 0.5), while Xemu effectively uses (0.25, 0.5) and (0.75, 0.5). For MSAA 4x, NV2A uses (0.0, 0.0), (0.5, 0.0), (0.0, 0.5)
and (0.5, 0.5), while Xemu effectively uses (0.25, 0.25), (0.75, 0.25), (0.25, 0.75) and (0.75, 0.75).

Here are the TopLeftRaster results (https://github.com/coldhex/nxdk_pgraph_tests/commit/96017220b1fb0be796176574df1e0c905f304494)
Tests were run with AMD Radeon RX 6600 Vulkan (but PR with OpenGL gives exactly the same result.)
![top-left-raster](https://github.com/user-attachments/assets/8879fa42-1692-48b8-aefd-e91851e48210)

The match between HW and PR is almost pixel-perfect. The colors for grey (around 0x808080 have some 1-off RGB interpolation errors.

Truncation (instead of flooring) is somewhat difficult to see and needs to be inspected using an image editor. The top-most pixel row (line 0) contains three thin quads with slightly differing colors. In TopLeftRaster this is the code for these quads:

https://github.com/coldhex/nxdk_pgraph_tests/blob/96017220b1fb0be796176574df1e0c905f304494/src/tests/vertex_shader_rounding_tests.cpp#L1200-L1228

(Both Xbox and PR have interpolation inaccuracies that I did not expect for such a quad. Ideally the quad would have a constant color, but since quads are rendered using two triangles e.g. the right-most segment consists of both RGB 0x808080 and 0x7F7F7F.)

Here is Xemu 0.8.62 with OpenGL. Note how the bottom two horizontal lines swapped in thickness (due to FBO bottom-left rule) compared to the 0.8.62 with Vulkan above:
![TopLeftRaster](https://github.com/user-attachments/assets/ce122948-df66-4ebe-868b-92cd9fc24744)

Here is the previous #1732 (at 1x, OpenGL):
![TopLeftRaster](https://github.com/user-attachments/assets/d6a851d3-d019-4a81-8eb7-51a4a37806fa)
