### PR TITLE
nv2a: Prevent NaN in specular power factor calculation

### DIFF
--- a/hw/xbox/nv2a/pgraph/glsl/vsh-ff.c
+++ b/hw/xbox/nv2a/pgraph/glsl/vsh-ff.c
@@ -360,7 +360,7 @@ GLSL_DEFINE(materialEmissionColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_CM_COL) ".xyz
 
             mstring_append_fmt(body,
                 "    float pf;\n"
-                "    if (nDotVP == 0.0) {\n"
+                "    if (nDotVP == 0.0 || nDotHV == 0.0) {\n"
                 "      pf = 0.0;\n"
                 "    } else {\n"
                 "      pf = pow(nDotHV, specularPower);\n"


### PR DESCRIPTION
Fixes #2187

Probably fixes #2177 and #2181 as well