### PR TITLE
cli: Allow overriding skip startup animation

### DIFF
--- a/system/vl.c
+++ b/system/vl.c
@@ -2902,9 +2902,19 @@ void qemu_init(int argc, char **argv)
         "none",
     }[g_config.sys.avpack];
 
+    // Allow overriding the skip startup animation setting from command line
+    bool short_animation = g_config.general.skip_boot_anim;
+    for (int i = 1; i < argc; i++) {
+        if (argv[i] && strcmp(argv[i], "-short-animation") == 0) {
+            argv[i] = NULL;
+            short_animation = true;
+            break;
+        }
+    }
+
     fake_argv[fake_argc++] = g_strdup_printf("xbox%s%s%s,avpack=%s",
         (bootrom_arg != NULL) ? bootrom_arg : "",
-        g_config.general.skip_boot_anim ? ",short-animation=on" : "",
+        short_animation ? ",short-animation=on" : "",
         ",kernel-irqchip=off",
         avpack_str
         );

--- a/system/vl.c
+++ b/system/vl.c
@@ -2912,12 +2912,10 @@ void qemu_init(int argc, char **argv)
         }
     }
 
-    fake_argv[fake_argc++] = g_strdup_printf("xbox%s%s%s,avpack=%s",
-        (bootrom_arg != NULL) ? bootrom_arg : "",
-        short_animation ? ",short-animation=on" : "",
-        ",kernel-irqchip=off",
-        avpack_str
-        );
+    fake_argv[fake_argc++] = g_strdup_printf(
+        "xbox%s%s%s,avpack=%s", (bootrom_arg != NULL) ? bootrom_arg : "",
+        short_animation ? ",short-animation=on" : "", ",kernel-irqchip=off",
+        avpack_str);
 
     if (bootrom_arg != NULL) {
         g_free(bootrom_arg);

--- a/system/vl.c
+++ b/system/vl.c
@@ -2905,7 +2905,7 @@ void qemu_init(int argc, char **argv)
     // Allow overriding the skip startup animation setting from command line
     bool short_animation = g_config.general.skip_boot_anim;
     for (int i = 1; i < argc; i++) {
-        if (argv[i] && strcmp(argv[i], "-short-animation") == 0) {
+        if (argv[i] && strcmp(argv[i], "-skip_boot_anim") == 0) {
             argv[i] = NULL;
             short_animation = true;
             break;


### PR DESCRIPTION
Allows skipping the startup animation with `-short-animation` which is very neat for me when developing games but don't want to override my current setting for when I play games.

I was unsure what to name the arg but as the internals seems to call it "short-animation", I figured it would make the most sense.