### PR TITLE
nv2a: Ignore unsupported depth funcs to match HW

### DIFF
--- a/hw/xbox/nv2a/pgraph/pgraph.c
+++ b/hw/xbox/nv2a/pgraph/pgraph.c
@@ -1411,8 +1411,10 @@ DEF_METHOD(NV097, SET_BLEND_EQUATION)
 
 DEF_METHOD(NV097, SET_DEPTH_FUNC)
 {
-    PG_SET_MASK(NV_PGRAPH_CONTROL_0, NV_PGRAPH_CONTROL_0_ZFUNC,
-             parameter & 0xF);
+    if (parameter >= 0x200 && parameter <= 0x207) {
+        PG_SET_MASK(NV_PGRAPH_CONTROL_0, NV_PGRAPH_CONTROL_0_ZFUNC,
+                    parameter & 0xF);
+    }
 }
 
 DEF_METHOD(NV097, SET_COLOR_MASK)


### PR DESCRIPTION
Fixes #584 

[Test](https://github.com/abaire/nxdk_pgraph_tests/blob/1a4533186d47e1eba61164e65c24c2d2f869029e/src/tests/depth_function_tests.cpp#L21)
[HW Results](https://abaire.github.io/nxdk_pgraph_tests_golden_results/results/Depth_function/index.html)

PR Results (the test asserts on xemu master due to intentional use of invalid depth funcs that are ignored on HW)
![PR Results](https://raw.githubusercontent.com/abaire/xemu-dev_pgraph_test_results/refs/heads/fix_584_ignore_unsupported_depth_func/results/xemu-0.8.67-1-g8fcfea617c-fix_584_ignore_unsupported_depth_func-8fcfea617c890adff0990d7a0b89a26314adf162/Darwin_arm64/gl_Apple_Apple_M3_Max/gslv_4.10/Depth_function/DepthFunc.png)