### PR TITLE
PPA fix attempt

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Build-Depends: debhelper (>= 11),
  libslirp-dev,
  libvulkan-dev,
  libcurl4-gnutls-dev,
+ libxxhash-dev,
 Standards-Version: 3.9.8
 Homepage: https://xemu.app
 XS-Debian-Vcs-Browser: https://github.com/mborgerson/xemu

--- a/meson.build
+++ b/meson.build
@@ -3554,7 +3554,7 @@ endif
 
 tomlplusplus = dependency('tomlplusplus', fallback: ['tomlplusplus', 'tomlplusplus_dep'], default_options: ['default_library=static'])
 
-xxhash = dependency('libxxhash', fallback: ['xxhash', 'xxhash_dep'], default_options: ['default_library=static'])
+xxhash = dependency('libxxhash', static: true, fallback: ['xxhash', 'xxhash_dep'], default_options: ['default_library=static'])
 
 #####################
 # Generated sources #


### PR DESCRIPTION
I didn't set up my own PPA to test, so I can't guarantee this fully fixes the PPA, but the issue seems to be with the meson wrapper for xxhash which we can bypass by installing the system's version first.
I also added the `static` parameter to avoid a new runtime dependency on the libxxhash package.