### PR TITLE
apu/vp: Make number of voice workers dynamic

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -214,6 +214,10 @@ display:
         default: false
 
 audio:
+  vp:
+    num_workers:
+      type: integer
+      default: 0  # 0 = auto
   use_dsp: bool
   hrtf:
     type: bool

--- a/hw/xbox/mcpx/apu/apu_debug.h
+++ b/hw/xbox/mcpx/apu/apu_debug.h
@@ -23,6 +23,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#define MAX_VOICE_WORKERS 16
+
 typedef enum McpxApuDebugMonitorPoint {
     MCPX_APU_DEBUG_MON_AC97,
     MCPX_APU_DEBUG_MON_VP,
@@ -55,10 +57,11 @@ struct McpxApuDebugVoice
 struct McpxApuDebugVp
 {
     struct McpxApuDebugVoice v[256];
+    int num_workers;
     struct {
         int num_voices;
         int time_us;
-    } workers[16];
+    } workers[MAX_VOICE_WORKERS];
     int total_worker_time_us;
 };
 

--- a/hw/xbox/mcpx/apu/vp/vp.h
+++ b/hw/xbox/mcpx/apu/vp/vp.h
@@ -31,8 +31,6 @@
 #include "svf.h"
 #include "hrtf.h"
 
-#define NUM_VOICE_WORKERS 16
-
 typedef struct MCPXAPUState MCPXAPUState;
 
 typedef struct MCPXAPUVPSSLData {
@@ -65,7 +63,8 @@ typedef struct VoiceWorker {
 
 typedef struct VoiceWorkDispatch {
     QemuMutex lock;
-    VoiceWorker workers[NUM_VOICE_WORKERS];
+    int num_workers;
+    VoiceWorker *workers;
     bool workers_should_exit;
     QemuCond work_pending;
     uint64_t workers_pending;

--- a/ui/xui/debug.cc
+++ b/ui/xui/debug.cc
@@ -233,7 +233,7 @@ void DebugApuWindow::Draw()
         ImGui::Text(" W: #  us");
         ImGui::SameLine();
         ImGui::Text(" W: #  us");
-        for (int i = 0; i < 16; i++) {
+        for (int i = 0; i < dbg->vp.num_workers; i++) {
             if (i % 2) ImGui::SameLine();
             ImGui::Text("%2d:%2d %3d", i, dbg->vp.workers[i].num_voices,
                         dbg->vp.workers[i].time_us);


### PR DESCRIPTION
Adds a new config option to control number of workers. If the value of the option is 0 (default), then the logical CPU count is used as reported by SDL.