### PR TITLE
nvnet: Return actual MII status on MMIO reads

### DIFF
--- a/hw/xbox/mcpx/nvnet/nvnet.c
+++ b/hw/xbox/mcpx/nvnet/nvnet.c
@@ -781,10 +781,6 @@ static uint64_t nvnet_mmio_read(void *opaque, hwaddr addr, unsigned int size)
     uint64_t retval;
 
     switch (addr) {
-    case NVNET_MII_STATUS:
-        retval = 0;
-        break;
-
     default:
         retval = get_reg_ext(s, addr, size);
         break;


### PR DESCRIPTION
Since the neat changes in https://github.com/xemu-project/xemu/commit/43c68c22a0d621b40a344e3de0e1fc8b9454c391 I checking link state changes with nxdk.

I was finding the MII status register was just returning zeros even though we are setting the link change bit. This change fixes it.

