### PR TITLE
nv2a: Clamp vertex fog factor to non-exceptional float range

### DIFF
--- a/hw/xbox/nv2a/pgraph/glsl/vsh.c
+++ b/hw/xbox/nv2a/pgraph/glsl/vsh.c
@@ -54,6 +54,8 @@ MString *pgraph_gen_vsh_glsl(const ShaderState *state, bool prefix_outputs)
         GLSL_DEFINE(texMat3, GLSL_C_MAT4(NV_IGRAPH_XF_XFCTX_T3MAT))
 
         "\n"
+        "#define FLOAT_MAX uintBitsToFloat(0x7F7FFFFFu)\n"
+        "\n"
         "vec4 oPos = vec4(0.0,0.0,0.0,1.0);\n"
         "vec4 oD0 = vec4(0.0,0.0,0.0,1.0);\n"
         "vec4 oD1 = vec4(0.0,0.0,0.0,1.0);\n"
@@ -244,7 +246,13 @@ MString *pgraph_gen_vsh_glsl(const ShaderState *state, bool prefix_outputs)
             break;
         }
 
-        mstring_append(body, "  oFog = NaNToOne(vec4(fogFactor));\n");
+        /* Fog is clamped to min/max normal float values here to match HW
+         * interpolation. It is then clamped to [0,1] in the pixel shader.
+         */
+        // clang-format off
+        mstring_append(body,
+                       "  oFog = clamp(NaNToOne(vec4(fogFactor)), -FLOAT_MAX, FLOAT_MAX);\n");
+        // clang-format on
     } else {
         /* FIXME: Is the fog still calculated / passed somehow?!
          */


### PR DESCRIPTION
This addresses HW/driver-dependent handling of  `inf` and `-inf` values. The final clamping to [0,1] is already handled in the pixel shader after interpolation, this clamp range matches observed HW behavior in the fog tests.

Fixes #2270 on systems other than macOS (where the problem does not exist)

[Test results](https://abaire.github.io/xemu-dev_pgraph_test_results/fix_2270_clamp_vtx_fog_output/index.html)