### PR TITLE
use jammy instead of noble to support LTS and bookworm among other systems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,25 +174,25 @@ jobs:
           build_param: --debug
           artifact_name: xemu-ubuntu-x86_64-debug
           artifact_filename: xemu-ubuntu-x86_64-debug.tgz
-          runs-on: ubuntu-24.04
+          runs-on: ubuntu-22.04
         - arch: x86_64
           configuration: Release
           build_param:
           artifact_name: xemu-ubuntu-x86_64-release
           artifact_filename: xemu-ubuntu-x86_64-release.tgz
-          runs-on: ubuntu-24.04
+          runs-on: ubuntu-22.04
         - arch: aarch64
           configuration: Debug
           build_param: --debug
           artifact_name: xemu-ubuntu-aarch64-debug
           artifact_filename: xemu-ubuntu-aarch64-debug.tgz
-          runs-on: ubuntu-24.04-arm
+          runs-on: ubuntu-22.04-arm
         - arch: aarch64
           configuration: Release
           build_param:
           artifact_name: xemu-ubuntu-aarch64-release
           artifact_filename: xemu-ubuntu-aarch64-release.tgz
-          runs-on: ubuntu-24.04-arm
+          runs-on: ubuntu-22.04-arm
     steps:
     - name: Initialize compiler cache
       id: cache


### PR DESCRIPTION
Ran into this today trying to run on current Debian Bookworm which is `Debian GLIBC 2.36-9+deb12u10` , building on Jammy greatly expands compatibility. 