### PR TITLE
apu: Bail from audio sink callback on app exit

### DIFF
--- a/hw/xbox/mcpx/apu/apu.c
+++ b/hw/xbox/mcpx/apu/apu.c
@@ -207,6 +207,10 @@ static void monitor_sink_cb(void *opaque, uint8_t *stream, int free_b)
             sleep_ns(1000000);
             qemu_cond_broadcast(&s->cond);
         }
+        if (!runstate_is_running()) {
+            memset(stream, 0, free_b);
+            return;
+        }
     }
 
     int to_copy = MIN(free_b, avail);


### PR DESCRIPTION
In some edge cases, when the xbox application is not filling the audio fifo (as is the case with nxdk currently) xemu spins forever within the SDL audio callback function here. https://github.com/xemu-project/xemu/blob/8ca6b769f5d280efd2b224239bf4efd216dd15f8/hw/xbox/mcpx/apu/apu.c#L202

This resulted in xemu freezing when trying to exit as it would be unable to close the audio device. It would hang specifcally at these locations:

https://github.com/xemu-project/xemu/blob/8ca6b769f5d280efd2b224239bf4efd216dd15f8/audio/sdlaudio.c#L209
https://github.com/xemu-project/xemu/blob/8ca6b769f5d280efd2b224239bf4efd216dd15f8/audio/sdlaudio.c#L213

This fix checks if the application is trying to close and bails out of the callback function.

Doing some further reading from https://wiki.libsdl.org/SDL2/SDL_LockAudioDevice it says:
```
... SDL obtains this lock before calling your function, and releases it when the function returns.

If your application fails to unlock the device appropriately .... SDL_CloseAudioDevice will probably deadlock.
```