### PR TITLE
ui: Add labels to emulated/input device combos

### DIFF
--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -172,7 +172,14 @@ void MainMenuInputView::Draw()
         driver = DRIVER_DUKE_DISPLAY_NAME;
     else if (strcmp(driver, DRIVER_S) == 0)
         driver = DRIVER_S_DISPLAY_NAME;
-    
+
+    ImGui::Columns(2, "", false);
+    ImGui::SetColumnWidth(0, ImGui::GetWindowWidth()*0.25);
+
+    ImGui::Text("Emulated Device");
+    ImGui::SameLine(0, 0);
+    ImGui::NextColumn();
+
     ImGui::SetNextItemWidth(-FLT_MIN);
     if (ImGui::BeginCombo("###InputDrivers", driver,
                           ImGuiComboFlags_NoArrowButton)) {
@@ -204,9 +211,15 @@ void MainMenuInputView::Draw()
     }
     DrawComboChevron();
 
+    ImGui::NextColumn();
+
     //
     // Render input device combo
     //
+
+    ImGui::Text("Input Device");
+    ImGui::SameLine(0, 0);
+    ImGui::NextColumn();
 
     // List available input devices
     const char *not_connected = "Not Connected";


### PR DESCRIPTION
This system needs a bit of an overhaul, but for now let's disambiguate these combo boxes for people

![image](https://github.com/user-attachments/assets/bc7e7915-ecc9-4970-b879-bad4c5ff9eea)
