### PR TITLE
nv2a: Allocate only needed size for inline arrays

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/vertex.c
+++ b/hw/xbox/nv2a/pgraph/gl/vertex.c
@@ -223,9 +223,9 @@ unsigned int pgraph_gl_bind_inline_array(NV2AState *d)
 
     nv2a_profile_inc_counter(NV2A_PROF_GEOM_BUFFER_UPDATE_2);
     glBindBuffer(GL_ARRAY_BUFFER, r->gl_inline_array_buffer);
-    glBufferData(GL_ARRAY_BUFFER, NV2A_MAX_BATCH_LENGTH * sizeof(uint32_t),
-                 NULL, GL_STREAM_DRAW);
-    glBufferSubData(GL_ARRAY_BUFFER, 0, index_count * vertex_size, pg->inline_array);
+    GLsizeiptr buffer_size = index_count * vertex_size;
+    glBufferData(GL_ARRAY_BUFFER, buffer_size, NULL, GL_STREAM_DRAW);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, buffer_size, pg->inline_array);
     pgraph_gl_bind_vertex_attributes(d, 0, index_count-1, true, vertex_size,
                                   index_count-1);
 


### PR DESCRIPTION
Some HW/driver combinations appear to slow down dramatically when using very large GL buffers. Since the GL buffer supporting inline arrays is allocated after the guest `END`, the total size needed is known and the buffer may be sized appropriately.

It would be good to test performance in games that use relatively large inline arrays (e.g., "King of Fighters 2003").

Tested using the [High vertex count](https://github.com/abaire/nxdk_pgraph_tests/blob/c3c5864e4871aeec0c9652a8fd8b8260c7ac97d2/src/tests/high_vertex_count_tests.cpp#L1) crash-or-pass test on Darwin/M3 that uses 0x7FFFF vertices and the test still passes.

Fixes #2301