### PR TITLE
nv2a/vk: Update vertex ram buffer to finish only when drawing.

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/vertex.c
+++ b/hw/xbox/nv2a/pgraph/vk/vertex.c
@@ -53,21 +53,12 @@ void pgraph_vk_update_vertex_ram_buffer(PGRAPHState *pg, hwaddr offset,
     size_t end_bit = TARGET_PAGE_ALIGN(offset + size) / TARGET_PAGE_SIZE;
     size_t nbits = end_bit - start_bit;
 
-    // Check if vertex data overlaps with already uploaded data
-    bool overlaps_uploaded = find_next_bit(r->uploaded_bitmap, start_bit + nbits, start_bit) < end_bit;
-
-    // Only force flush if there's actual overlap AND we're in an active draw
-    // This reduces unnecessary flushes for sequential vertex uploads
-    if (overlaps_uploaded && r->in_draw) {
+    if (find_next_bit(r->uploaded_bitmap, start_bit + nbits, start_bit) < end_bit && r->in_draw) {
         // Vertex data changed while building the draw list. Finish drawing
         // before updating RAM buffer.
         pgraph_vk_finish(pg, VK_FINISH_REASON_VERTEX_BUFFER_DIRTY);
-    } else if (overlaps_uploaded && !r->in_draw) {
-        // If not actively drawing, just clear the conflicting bits instead of flushing
-        // This allows for better batching of vertex updates
-        bitmap_clear(r->uploaded_bitmap, start_bit, nbits);
     }
-    
+
     nv2a_profile_inc_counter(NV2A_PROF_GEOM_BUFFER_UPDATE_1);
     memcpy(r->storage_buffers[BUFFER_VERTEX_RAM].mapped + offset, data, size);
 


### PR DESCRIPTION
This handles bitmaps better when not drawing. This will improve performance in some known areas such as Dead or Alive 2 Ultimate's Burai Zenin stage and other areas with rain effects such as Miyama stage. In my personal testing it's increased performance in the affected areas by 50%, making each of the affected stages able to run at 60 FPS even at multiple internal render options. In the Video Debug this is most noticeable in the `FINISH_VERTEX_BUFFER_DIRTY` value.

Before:
<img width="1279" height="988" alt="image" src="https://github.com/user-attachments/assets/2d2fa4aa-7c89-475c-924d-0c7d942058ca" />


After:
<img width="1282" height="958" alt="image" src="https://github.com/user-attachments/assets/d701c502-7ea9-4b54-ac84-39d7aef80bd1" />
