### PR TITLE
nv2a: Fix edge cases leading to GL debug group stack overflows

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/draw.c
+++ b/hw/xbox/nv2a/pgraph/gl/draw.c
@@ -385,6 +385,7 @@ void pgraph_gl_draw_end(NV2AState *d)
         // off. This check only seems to trigger during the fragment
         // processing, it is legal to attempt a draw that is entirely
         // clipped regardless of 0x880. See xemu#635 for context.
+        NV2A_GL_DGROUP_END();
         return;
     }
 

--- a/hw/xbox/nv2a/pgraph/pgraph.c
+++ b/hw/xbox/nv2a/pgraph/pgraph.c
@@ -2498,6 +2498,7 @@ DEF_METHOD(NV097, SET_BEGIN_END)
     } else {
         if (pg->primitive_mode != PRIM_TYPE_INVALID) {
             NV2A_DPRINTF("Begin without End!\n");
+            return;
         }
         assert(parameter <= NV097_SET_BEGIN_END_OP_POLYGON);
         pg->primitive_mode = parameter;


### PR DESCRIPTION
As a bonus, this also correct the rendering behavior when END subcommands are omitted.

Fixes #2410 

Test: https://github.com/abaire/nxdk_pgraph_tests/commit/ffb0cc187ec9688c41adb01c9ccba905a1fe8de6
HW results: https://abaire.github.io/nxdk_pgraph_tests_golden_results/results/Degenerate_begin_end/index.html
PR results: https://abaire.github.io/xemu-dev_pgraph_test_results/fix_debug_stack_overflow_with_degenerate_begin_end_loops/index.html

The specific test matches HW perfectly:
HW: 
![xbox](https://raw.githubusercontent.com/abaire/nxdk_pgraph_tests_golden_results/refs/heads/main/results/Degenerate_begin_end/BeginWithoutEnd.png)

---
xemu with PR: 
![pr](https://raw.githubusercontent.com/abaire/xemu-dev_pgraph_test_results/refs/heads/fix_debug_stack_overflow_with_degenerate_begin_end_loops/results/xemu-0.8.82-82-g220ee456c4-fix_debug_stack_overflow_with_degenerate_begin_end_loops-220ee456c41857521f3786d006bb7116a6601c23/Darwin_arm64/gl_Apple_Apple_M3_Max/gslv_4.10/Degenerate_begin_end/BeginWithoutEnd.png)