### PR TITLE
nv2a: Fix handling of PVIDEO color key red channel

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/display.c
+++ b/hw/xbox/nv2a/pgraph/gl/display.c
@@ -242,7 +242,7 @@ static void render_display_pvideo_overlay(NV2AState *d)
     glUniform1ui(r->disp_rndr.pvideo_color_key_enable_loc,
                  color_key_enabled);
 
-    unsigned int color_key = d->pvideo.regs[NV_PVIDEO_COLOR_KEY] & 0xFFFFF;
+    unsigned int color_key = d->pvideo.regs[NV_PVIDEO_COLOR_KEY] & 0xFFFFFF;
     glUniform3f(r->disp_rndr.pvideo_color_key_loc,
                 GET_MASK(color_key, NV_PVIDEO_COLOR_KEY_RED) / 255.0,
                 GET_MASK(color_key, NV_PVIDEO_COLOR_KEY_GREEN) / 255.0,


### PR DESCRIPTION
I wasn't at my machine and missed that this was wrong for both the GL and VK paths, not just VK in #2428. 

The PVIDEO tests only used black and blue as the color key when the previous PR was written, the tests have been expanded such that many use a more interesting color.

Sorry!