### PR TITLE
nv2a: Implement texture LOD bias

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/renderer.h
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.h
@@ -80,6 +80,7 @@ typedef struct TextureBinding {
     bool border_color_set;
     GLenum gl_target;
     GLuint gl_texture;
+    uint32_t lod_bias;
 } TextureBinding;
 
 typedef struct ShaderModuleCacheKey {

--- a/hw/xbox/nv2a/pgraph/gl/renderer.h
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.h
@@ -73,6 +73,7 @@ typedef struct TextureBinding {
     unsigned int scale;
     unsigned int min_filter;
     unsigned int mag_filter;
+    uint32_t lod_bias;
     unsigned int addru;
     unsigned int addrv;
     unsigned int addrp;
@@ -80,7 +81,6 @@ typedef struct TextureBinding {
     bool border_color_set;
     GLenum gl_target;
     GLuint gl_texture;
-    uint32_t lod_bias;
 } TextureBinding;
 
 typedef struct ShaderModuleCacheKey {

--- a/hw/xbox/nv2a/pgraph/gl/texture.c
+++ b/hw/xbox/nv2a/pgraph/gl/texture.c
@@ -150,7 +150,8 @@ static void apply_texture_parameters(TextureBinding *binding,
     }
     if (lod_bias != binding->lod_bias) {
         binding->lod_bias = lod_bias;
-        glTexParameterf(binding->gl_target, GL_TEXTURE_LOD_BIAS, convert_lod_bias(lod_bias));
+        glTexParameterf(binding->gl_target, GL_TEXTURE_LOD_BIAS,
+                        pgraph_convert_lod_bias_to_float(lod_bias));
     }
 
     /* Texture wrapping */

--- a/hw/xbox/nv2a/pgraph/gl/texture.c
+++ b/hw/xbox/nv2a/pgraph/gl/texture.c
@@ -107,15 +107,6 @@ static bool check_texture_possibly_dirty(NV2AState *d,
     return possibly_dirty;
 }
 
-static inline float convert_lod_bias(uint32_t lod_bias)
-{
-    int sign_extended_bias = lod_bias;
-    if (lod_bias & (1 << 12)) {
-        sign_extended_bias |= ~NV_PGRAPH_TEXFILTER0_MIPMAP_LOD_BIAS;
-    }
-    return (float)sign_extended_bias / 256.f;
-}
-
 static void apply_texture_parameters(TextureBinding *binding,
                                      const BasicColorFormatInfo *f,
                                      unsigned int dimensionality,
@@ -126,11 +117,11 @@ static void apply_texture_parameters(TextureBinding *binding,
 {
     unsigned int min_filter = GET_MASK(filter, NV_PGRAPH_TEXFILTER0_MIN);
     unsigned int mag_filter = GET_MASK(filter, NV_PGRAPH_TEXFILTER0_MAG);
+    unsigned int lod_bias =
+        GET_MASK(filter, NV_PGRAPH_TEXFILTER0_MIPMAP_LOD_BIAS);
     unsigned int addru = GET_MASK(address, NV_PGRAPH_TEXADDRESS0_ADDRU);
     unsigned int addrv = GET_MASK(address, NV_PGRAPH_TEXADDRESS0_ADDRV);
     unsigned int addrp = GET_MASK(address, NV_PGRAPH_TEXADDRESS0_ADDRP);
-    unsigned int lod_bias =
-        GET_MASK(filter, NV_PGRAPH_TEXFILTER0_MIPMAP_LOD_BIAS);
 
     if (f->linear) {
         /* somtimes games try to set mipmap min filters on linear textures.
@@ -742,6 +733,7 @@ static TextureBinding* generate_texture(const TextureShape s,
     ret->data_hash = 0;
     ret->min_filter = 0xFFFFFFFF;
     ret->mag_filter = 0xFFFFFFFF;
+    ret->lod_bias = 0xFFFFFFFF;
     ret->addru = 0xFFFFFFFF;
     ret->addrv = 0xFFFFFFFF;
     ret->addrp = 0xFFFFFFFF;

--- a/hw/xbox/nv2a/pgraph/texture.h
+++ b/hw/xbox/nv2a/pgraph/texture.h
@@ -64,7 +64,7 @@ hwaddr pgraph_get_texture_palette_phys_addr_length(PGRAPHState *pg, int texture_
 TextureShape pgraph_get_texture_shape(PGRAPHState *pg, int texture_idx);
 size_t pgraph_get_texture_length(PGRAPHState *pg, TextureShape *shape);
 
-static inline float convert_lod_bias(uint32_t lod_bias)
+static inline float pgraph_convert_lod_bias_to_float(uint32_t lod_bias)
 {
     int sign_extended_bias = lod_bias;
     if (lod_bias & (1 << 12)) {

--- a/hw/xbox/nv2a/pgraph/texture.h
+++ b/hw/xbox/nv2a/pgraph/texture.h
@@ -64,4 +64,13 @@ hwaddr pgraph_get_texture_palette_phys_addr_length(PGRAPHState *pg, int texture_
 TextureShape pgraph_get_texture_shape(PGRAPHState *pg, int texture_idx);
 size_t pgraph_get_texture_length(PGRAPHState *pg, TextureShape *shape);
 
+static inline float convert_lod_bias(uint32_t lod_bias)
+{
+    int sign_extended_bias = lod_bias;
+    if (lod_bias & (1 << 12)) {
+        sign_extended_bias |= ~NV_PGRAPH_TEXFILTER0_MIPMAP_LOD_BIAS;
+    }
+    return (float)sign_extended_bias / 256.f;
+}
+
 #endif

--- a/hw/xbox/nv2a/pgraph/vk/texture.c
+++ b/hw/xbox/nv2a/pgraph/vk/texture.c
@@ -1336,7 +1336,7 @@ static void create_texture(PGRAPHState *pg, int texture_idx)
         min_filter == NV_PGRAPH_TEXFILTER0_MIN_BOX_NEARESTLOD ||
         min_filter == NV_PGRAPH_TEXFILTER0_MIN_TENT_NEARESTLOD;
 
-    float lod_bias = convert_lod_bias(
+    float lod_bias = pgraph_convert_lod_bias_to_float(
         GET_MASK(filter, NV_PGRAPH_TEXFILTER0_MIPMAP_LOD_BIAS));
     if (lod_bias > r->device_props.limits.maxSamplerLodBias) {
         lod_bias = r->device_props.limits.maxSamplerLodBias;

--- a/hw/xbox/nv2a/pgraph/vk/texture.c
+++ b/hw/xbox/nv2a/pgraph/vk/texture.c
@@ -1340,6 +1340,8 @@ static void create_texture(PGRAPHState *pg, int texture_idx)
         GET_MASK(filter, NV_PGRAPH_TEXFILTER0_MIPMAP_LOD_BIAS));
     if (lod_bias > r->device_props.limits.maxSamplerLodBias) {
         lod_bias = r->device_props.limits.maxSamplerLodBias;
+    } else if (lod_bias < -r->device_props.limits.maxSamplerLodBias) {
+        lod_bias = -r->device_props.limits.maxSamplerLodBias;
     }
 
     VkSamplerCreateInfo sampler_create_info = {


### PR DESCRIPTION
Fixes #767
Fixes #973
Fixes #1110
Fixes #1204
Fixes #2377

Tests: https://github.com/abaire/nxdk_pgraph_tests/blob/2aa0cb89543f3853a3830ba15a03c9f7dad58d69/src/tests/texture_lod_bias_tests.h#L1

HW results: https://abaire.github.io/nxdk_pgraph_tests_golden_results/results/Texture_LOD_Bias/index.html

PR results: https://github.com/abaire/xemu-dev_pgraph_test_results/blob/fix/implements_lod_bias/results/xemu-0.8.101-1-g3ece4e2a17-fix_implements_lod_bias-3ece4e2a170f38aef3f220ab007b090bbb29233b/Darwin_arm64/gl_Apple_Apple_M3_Max/gslv_4.10/Texture_LOD_Bias/LODBias.png