### PR TITLE
UI: Add games directory and allow switching of games via controller in popup-menu

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -7,6 +7,7 @@ general:
       type: bool
       default: true
   screenshot_dir: string
+  games_dir: string
   skip_boot_anim: bool
   # throttle_io: bool
   last_viewed_menu_index: integer

--- a/ui/xui/actions.cc
+++ b/ui/xui/actions.cc
@@ -36,8 +36,6 @@ void ActionEjectDisc(void)
 
 void ActionLoadDisc(void)
 {
-    Error *err = NULL;
-
     const char *iso_file_filters =
         "Disc Image Files (*.iso, *.xiso)\0*.iso;*.xiso\0All Files\0*.*\0";
     const char *new_disc_path =
@@ -48,7 +46,14 @@ void ActionLoadDisc(void)
         return;
     }
 
-    xemu_load_disc(new_disc_path, &err);
+    ActionLoadDiscFile(new_disc_path);
+}
+
+void ActionLoadDiscFile(const char *file_path)
+{
+    Error *err = NULL;
+    xemu_load_disc(file_path, &err);
+
     if (err) {
         xemu_queue_error_message(error_get_pretty(err));
         error_free(err);

--- a/ui/xui/actions.hh
+++ b/ui/xui/actions.hh
@@ -20,6 +20,7 @@
 
 void ActionEjectDisc();
 void ActionLoadDisc();
+void ActionLoadDiscFile(const char *file_path);
 void ActionTogglePause();
 void ActionReset();
 void ActionShutdown();

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -71,6 +71,7 @@ void MainMenuGeneralView::Draw()
            "Skip the full Xbox boot animation sequence");
     FilePicker("Screenshot output directory", &g_config.general.screenshot_dir,
                NULL, true);
+    FilePicker("Games directory", &g_config.general.games_dir, NULL, true);
     // toggle("Throttle DVD/HDD speeds", &g_config.general.throttle_io,
     //        "Limit DVD/HDD throughput to approximate Xbox load times");
 }

--- a/ui/xui/popup-menu.cc
+++ b/ui/xui/popup-menu.cc
@@ -19,6 +19,8 @@
 #include "ui/xemu-notifications.h"
 #include <string>
 #include <vector>
+#include <filesystem>
+#include <map>
 #include "misc.hh"
 #include "actions.hh"
 #include "font-manager.hh"
@@ -338,9 +340,69 @@ public:
     }
 };
 
+class GamesPopupMenu : public virtual PopupMenu {
+protected:
+    std::multimap<std::string, std::string> sorted_file_names;
+
+public:
+    void Show(const ImVec2 &direction) override
+    {
+        PopupMenu::Show(direction);
+        PopulateGameList();
+    }
+
+    bool DrawItems(PopupMenuItemDelegate &nav) override
+    {
+        bool pop = false;
+
+        if (m_focus && !m_pop_focus) {
+            ImGui::SetKeyboardFocusHere();
+        }
+
+        for (const auto &[label, file_path] : sorted_file_names) {
+            if (PopupMenuButton(label, ICON_FA_COMPACT_DISC)) {
+                ActionLoadDiscFile(file_path.c_str());
+                nav.ClearMenuStack();
+                pop = true;
+            }
+        }
+
+        if (sorted_file_names.size() == 0) {
+            if (PopupMenuButton("No games found", ICON_FA_SLIDERS)) {
+                nav.ClearMenuStack();
+                g_scene_mgr.PushScene(g_main_menu);
+            }
+        }
+
+        if (m_pop_focus) {
+            nav.PopFocus();
+        }
+        return pop;
+    }
+
+    void PopulateGameList() {
+        const char *games_dir = g_config.general.games_dir;
+
+        sorted_file_names.clear();
+        std::filesystem::path directory(games_dir);
+        if (std::filesystem::is_directory(directory)) {
+            for (const auto &file :
+                 std::filesystem::directory_iterator(directory)) {
+                const auto &file_path = file.path();
+                if (std::filesystem::is_regular_file(file_path) &&
+                    file_path.extension() == ".iso") {
+                    sorted_file_names.insert(
+                        { file_path.stem().string(), file_path });
+                }
+            }
+        }
+    }
+};
+
 class RootPopupMenu : public virtual PopupMenu {
 protected:
     SettingsPopupMenu settings;
+    GamesPopupMenu games;
     bool refocus_first_item;
 
 public:
@@ -377,6 +439,10 @@ public:
             xemu_snapshots_save(NULL, NULL);
             xemu_queue_notification("Created new snapshot");
             pop = true;
+        }
+        if (PopupMenuSubmenuButton("Games", ICON_FA_GAMEPAD)) {
+            nav.PushFocus();
+            nav.PushMenu(games);
         }
         if (PopupMenuButton("Eject Disc", ICON_FA_EJECT)) {
             ActionEjectDisc();

--- a/ui/xui/popup-menu.cc
+++ b/ui/xui/popup-menu.cc
@@ -390,9 +390,10 @@ public:
                  std::filesystem::directory_iterator(directory)) {
                 const auto &file_path = file.path();
                 if (std::filesystem::is_regular_file(file_path) &&
-                    file_path.extension() == ".iso") {
+                    (file_path.extension() == ".iso" ||
+                     file_path.extension() == ".xiso")) {
                     sorted_file_names.insert(
-                        { file_path.stem().string(), file_path });
+                        { file_path.stem().string(), file_path.string() });
                 }
             }
         }

--- a/ui/xui/popup-menu.hh
+++ b/ui/xui/popup-menu.hh
@@ -51,7 +51,7 @@ public:
     PopupMenu();
     void InitFocus();
     virtual ~PopupMenu();
-    void Show(const ImVec2 &direction);
+    virtual void Show(const ImVec2 &direction);
     void Hide(const ImVec2 &direction);
     bool IsAnimating();
     void Draw(PopupMenuItemDelegate &nav);


### PR DESCRIPTION
Finishing up PR #1627 on behalf of @TrentSeed 

This PR rebases the original changes against the latest master branch and extends the file filter to find `.xiso` extensions to match the behavior introduced to xemu since the creation of the original PR.

Fixes #1858