### PR TITLE
nv2a: Handle anisotropic filter setting

### DIFF
--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -539,6 +539,7 @@
 #define NV_PGRAPH_TEXCTL0_0                              0x000019CC
 #   define NV_PGRAPH_TEXCTL0_0_COLORKEYMODE                     0x03
 #   define NV_PGRAPH_TEXCTL0_0_ALPHAKILLEN                      (1 << 2)
+#   define NV_PGRAPH_TEXCTL0_0_MAX_ANISOTROPY                   0x30
 #   define NV_PGRAPH_TEXCTL0_0_MAX_LOD_CLAMP                    0x0003FFC0
 #   define NV_PGRAPH_TEXCTL0_0_MIN_LOD_CLAMP                    0x3FFC0000
 #   define NV_PGRAPH_TEXCTL0_0_ENABLE                           (1 << 30)

--- a/hw/xbox/nv2a/pgraph/gl/renderer.c
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.c
@@ -66,6 +66,9 @@ static void pgraph_gl_init(NV2AState *d, Error **errp)
 
     pg->uniform_attrs = 0;
     pg->swizzle_attrs = 0;
+
+    r->supported_extensions.texture_filter_anisotropic =
+        glo_check_extension("GL_EXT_texture_filter_anisotropic");
 }
 
 static void pgraph_gl_finalize(NV2AState *d)

--- a/hw/xbox/nv2a/pgraph/gl/renderer.h
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.h
@@ -234,6 +234,10 @@ typedef struct PGRAPHGLState {
 
     GLfloat supported_aliased_line_width_range[2];
     GLfloat supported_smooth_line_width_range[2];
+
+    struct supported_extensions {
+        GLboolean texture_filter_anisotropic;
+    } supported_extensions;
 } PGRAPHGLState;
 
 extern GloContext *g_nv2a_context_render;

--- a/hw/xbox/nv2a/pgraph/gl/texture.c
+++ b/hw/xbox/nv2a/pgraph/gl/texture.c
@@ -107,7 +107,8 @@ static bool check_texture_possibly_dirty(NV2AState *d,
     return possibly_dirty;
 }
 
-static void apply_texture_parameters(TextureBinding *binding,
+static void apply_texture_parameters(PGRAPHGLState *r,
+                                     TextureBinding *binding,
                                      const BasicColorFormatInfo *f,
                                      unsigned int dimensionality,
                                      unsigned int filter,
@@ -182,7 +183,10 @@ static void apply_texture_parameters(TextureBinding *binding,
         needs_border_color = needs_border_color || binding->addrp == NV_PGRAPH_TEXADDRESS0_ADDRU_BORDER;
     }
 
-    glTexParameterf(binding->gl_target, GL_TEXTURE_MAX_ANISOTROPY, max_anisotropy);
+    if (r->supported_extensions.texture_filter_anisotropic) {
+        glTexParameterf(binding->gl_target, GL_TEXTURE_MAX_ANISOTROPY_EXT,
+                        max_anisotropy);
+    }
 
     if (!is_bordered && needs_border_color) {
         if (!binding->border_color_set || binding->border_color != border_color) {
@@ -268,7 +272,8 @@ void pgraph_gl_bind_textures(NV2AState *d)
             if (reusable) {
                 glBindTexture(r->texture_binding[i]->gl_target,
                               r->texture_binding[i]->gl_texture);
-                apply_texture_parameters(r->texture_binding[i],
+                apply_texture_parameters(r,
+                                         r->texture_binding[i],
                                          &kelvin_color_format_info_map[state.color_format],
                                          state.dimensionality,
                                          filter,
@@ -379,7 +384,8 @@ void pgraph_gl_bind_textures(NV2AState *d)
             binding->scale = pg->surface_scale_factor;
         }
 
-        apply_texture_parameters(binding,
+        apply_texture_parameters(r,
+                                 binding,
                                  &kelvin_color_format_info_map[state.color_format],
                                  state.dimensionality,
                                  filter,

--- a/hw/xbox/nv2a/pgraph/vk/instance.c
+++ b/hw/xbox/nv2a/pgraph/vk/instance.c
@@ -547,6 +547,7 @@ static bool create_logical_device(PGRAPHState *pg, Error **errp)
         F(occlusionQueryPrecise, true),
         F(fillModeNonSolid, true),
         F(wideLines, false),
+        F(samplerAnisotropy, false),
         #undef F
         // clang-format on
     };

--- a/hw/xbox/nv2a/pgraph/vk/instance.c
+++ b/hw/xbox/nv2a/pgraph/vk/instance.c
@@ -540,14 +540,14 @@ static bool create_logical_device(PGRAPHState *pg, Error **errp)
             .enabled = &r->enabled_physical_device_features.n, \
             .required = req, \
         }
-        F(shaderClipDistance, true),
-        F(geometryShader, true),
-        F(shaderTessellationAndGeometryPointSize, true),
         F(depthClamp, true),
-        F(occlusionQueryPrecise, true),
         F(fillModeNonSolid, true),
-        F(wideLines, false),
+        F(geometryShader, true),
+        F(occlusionQueryPrecise, true),
         F(samplerAnisotropy, false),
+        F(shaderClipDistance, true),
+        F(shaderTessellationAndGeometryPointSize, true),
+        F(wideLines, false),
         #undef F
         // clang-format on
     };

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -206,6 +206,7 @@ typedef struct TextureKey {
     uint32_t filter;
     uint32_t address;
     uint32_t border_color;
+    uint32_t max_anisotropy;
 } TextureKey;
 
 typedef struct TextureBinding {

--- a/hw/xbox/nv2a/pgraph/vk/texture.c
+++ b/hw/xbox/nv2a/pgraph/vk/texture.c
@@ -1101,6 +1101,13 @@ static void create_texture(PGRAPHState *pg, int texture_idx)
         pgraph_reg_r(pg, NV_PGRAPH_BORDERCOLOR0 + texture_idx * 4);
     bool is_indexed = (state.color_format ==
             NV097_SET_TEXTURE_FORMAT_COLOR_SZ_I8_A8R8G8B8);
+    uint32_t xbox_max_anisotropy =
+        1 << (GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_TEXCTL0_0 + texture_idx*4),
+                       NV_PGRAPH_TEXCTL0_0_MAX_ANISOTROPY));
+    uint32_t max_anisotropy =
+        xbox_max_anisotropy <= r->device_props.limits.maxSamplerAnisotropy ?
+            xbox_max_anisotropy :
+            r->device_props.limits.maxSamplerAnisotropy;
 
     TextureKey key;
     memset(&key, 0, sizeof(key));
@@ -1354,9 +1361,8 @@ static void create_texture(PGRAPHState *pg, int texture_idx)
             GET_MASK(address, NV_PGRAPH_TEXADDRESS0_ADDRV)),
         .addressModeW = (state.dimensionality > 2) ? lookup_texture_address_mode(
             GET_MASK(address, NV_PGRAPH_TEXADDRESS0_ADDRP)) : 0,
-        .anisotropyEnable = VK_FALSE,
-        // .anisotropyEnable = VK_TRUE,
-        // .maxAnisotropy = properties.limits.maxSamplerAnisotropy,
+        .anisotropyEnable = max_anisotropy > 1,
+        .maxAnisotropy = max_anisotropy,
         .borderColor = vk_border_color,
         .compareEnable = VK_FALSE,
         .compareOp = VK_COMPARE_OP_ALWAYS,

--- a/hw/xbox/nv2a/pgraph/vk/texture.c
+++ b/hw/xbox/nv2a/pgraph/vk/texture.c
@@ -1360,8 +1360,9 @@ static void create_texture(PGRAPHState *pg, int texture_idx)
             GET_MASK(address, NV_PGRAPH_TEXADDRESS0_ADDRV)),
         .addressModeW = (state.dimensionality > 2) ? lookup_texture_address_mode(
             GET_MASK(address, NV_PGRAPH_TEXADDRESS0_ADDRP)) : 0,
-        .anisotropyEnable = r->enabled_physical_device_features.wideLines &&
-                            sampler_max_anisotropy > 1,
+        .anisotropyEnable =
+            r->enabled_physical_device_features.samplerAnisotropy &&
+            sampler_max_anisotropy > 1,
         .maxAnisotropy = sampler_max_anisotropy,
         .borderColor = vk_border_color,
         .compareEnable = VK_FALSE,


### PR DESCRIPTION
Implements handling of anisotropic filter level from SET_TEXTURE_CONTROL0.

Fixes #2444 (in conjunction with PR #2435 for `STEAL`)
Fixes #2385 (for whatever isn't already fixed by PR #2435)

Tests: https://github.com/abaire/nxdk_pgraph_tests/blob/4dc2b8f16749d0d9b9bd9e8c90b649944f96a662/src/tests/texture_anisotropy_tests.h#L10

HW results: https://abaire.github.io/nxdk_pgraph_tests_golden_results/results/Texture_anisotropy/index.html

PR results: https://abaire.github.io/xemu-dev_pgraph_test_results/fix_2444_respect_anisotropic_filter_level/index.html - Please note that there was a bleedover error in the test suite when I first ran the suite that tainted the diff for the `Texture_perspective_enable` result. If you manually compare the `Source` and `xemu Golden` images they are now identical.
