### PR TITLE
.github: Fix nesting of template field IDs

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -14,8 +14,8 @@ body:
 
         If you have questions about how to provide the information below, join the Discord server to get help from the community.
   - type: textarea
+    id: feature-request
     attributes:
-      id: feature-request
       label: Feature Request
       description: |
         A brief description of the requested feature. If appropriate, include screenshots or videos.
@@ -24,14 +24,14 @@ body:
     validations:
       required: true
   - type: textarea
+    id: alternatives
     attributes:
-      id: alternatives
       label: Alternatives
       description: Possible alternative options that you have considered.
     validations:
       required: false
   - type: textarea
+    id: additional-context
     attributes:
-      id: additional-context
       label: Additional Context
       description: Any other context or screenshots about the feature request.

--- a/.github/ISSUE_TEMPLATE/general-issue.yml
+++ b/.github/ISSUE_TEMPLATE/general-issue.yml
@@ -18,8 +18,8 @@ body:
 
         If you have questions about how to provide the information below, join the Discord server to get help from the community.
   - type: textarea
+    id: bug-description
     attributes:
-      id: bug-description
       label: Bug Description
       description: |
         A brief description of the problem, including steps to reproduce the issue and any relevant screenshots of the problem.
@@ -42,8 +42,8 @@ body:
     validations:
       required: true
   - type: textarea
+    id: expected-behavior
     attributes:
-      id: expected-behavior
       label: Expected Behavior
       description: A brief description of the expected behavior.
       placeholder: |
@@ -51,8 +51,8 @@ body:
     validations:
       required: true
   - type: textarea
+    id: xemu-version
     attributes:
-      id: xemu-version
       label: xemu Version
       description: Affected xemu version. You can find the xemu version within xemu by navigating to <kbd>Help</kbd>&rarr;<kbd>About</kbd>. If known, include the last known-working version of xemu.
       placeholder: |
@@ -62,8 +62,8 @@ body:
     validations:
       required: true
   - type: textarea
+    id: system-information
     attributes:
-      id: system-information
       label: System Information
       description: Basic information about your system.
       placeholder: |
@@ -72,7 +72,7 @@ body:
         GPU: NVIDIA Quadro P2000
         GPU Driver: 3.3.0 NVIDIA 450.119.03
   - type: textarea
+    id: additional-context
     attributes:
-      id: additional-context
       label: Additional Context
       description: Any additional information or log output.

--- a/.github/ISSUE_TEMPLATE/title-issue.yml
+++ b/.github/ISSUE_TEMPLATE/title-issue.yml
@@ -18,8 +18,8 @@ body:
 
         If you have questions about how to provide the information below, join the Discord server to get help from the community.
   - type: textarea
+    id: game-title
     attributes:
-      id: game-title
       label: Title
       description: Affected title URL and version information. You can find the title URL by searching for the title by name on [the compatibility tracking system](https://xemu.app/#compatibility).
       placeholder: |
@@ -29,8 +29,8 @@ body:
     validations:
       required: true
   - type: textarea
+    id: bug-description
     attributes:
-      id: bug-description
       label: Bug Description
       description: |
         A brief description of the problem, including steps to reproduce the issue and any relevant screenshots of the problem.
@@ -48,8 +48,8 @@ body:
     validations:
       required: true
   - type: textarea
+    id: expected-behavior
     attributes:
-      id: expected-behavior
       label: Expected Behavior
       description: A brief description of the expected behavior.
       placeholder: |
@@ -59,8 +59,8 @@ body:
     validations:
       required: true
   - type: textarea
+    id: xemu-version
     attributes:
-      id: xemu-version
       label: xemu Version
       description: Affected xemu version. You can find the xemu version within xemu by navigating to <kbd>Help</kbd>&rarr;<kbd>About</kbd>. If known, include the last known-working version of xemu.
       placeholder: |
@@ -70,8 +70,8 @@ body:
     validations:
       required: true
   - type: textarea
+    id: system-information
     attributes:
-      id: system-information
       label: System Information
       description: Basic information about your system.
       placeholder: |
@@ -80,7 +80,7 @@ body:
         GPU: NVIDIA Quadro P2000
         GPU Driver: 3.3.0 NVIDIA 450.119.03
   - type: textarea
+    id: additional-context
     attributes:
-      id: additional-context
       label: Additional Context
       description: Any additional information or log output.


### PR DESCRIPTION
Sorry, I messed up the position of the IDs when implementing based on my test repo. IDs need to be siblings of the attributes rather than children to make them accessible via URL params.