### PR TITLE
nv2a: Fix DstAlpha blending for const-alpha surface modes

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/draw.c
+++ b/hw/xbox/nv2a/pgraph/gl/draw.c
@@ -127,7 +127,7 @@ void pgraph_gl_clear_surface(NV2AState *d, uint32_t parameter)
     if (r->zeta_binding) {
         r->zeta_binding->cleared = full_clear && write_zeta;
     }
-    
+
     pg->clearing = false;
 }
 
@@ -167,10 +167,12 @@ void pgraph_gl_draw_begin(NV2AState *d)
 
     if (pgraph_reg_r(pg, NV_PGRAPH_BLEND) & NV_PGRAPH_BLEND_EN) {
         glEnable(GL_BLEND);
-        uint32_t sfactor = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_BLEND),
-                                    NV_PGRAPH_BLEND_SFACTOR);
-        uint32_t dfactor = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_BLEND),
-                                    NV_PGRAPH_BLEND_DFACTOR);
+        const uint32_t blend_reg = pgraph_reg_r(pg, NV_PGRAPH_BLEND);
+        uint32_t sfactor = fixup_blend_factor_for_surface(
+            GET_MASK(blend_reg, NV_PGRAPH_BLEND_SFACTOR), &pg->surface_shape);
+        uint32_t dfactor = fixup_blend_factor_for_surface(
+            GET_MASK(blend_reg, NV_PGRAPH_BLEND_DFACTOR), &pg->surface_shape);
+
         assert(sfactor < ARRAY_SIZE(pgraph_blend_factor_gl_map));
         assert(dfactor < ARRAY_SIZE(pgraph_blend_factor_gl_map));
         glBlendFunc(pgraph_blend_factor_gl_map[sfactor],

--- a/hw/xbox/nv2a/pgraph/meson.build
+++ b/hw/xbox/nv2a/pgraph/meson.build
@@ -3,6 +3,7 @@ specific_ss.add(files(
 	'profile.c',
 	'rdi.c',
 	's3tc.c',
+	'surface.c',
 	'swizzle.c',
 	'texture.c',
 	'vertex.c',

--- a/hw/xbox/nv2a/pgraph/surface.c
+++ b/hw/xbox/nv2a/pgraph/surface.c
@@ -1,0 +1,60 @@
+/*
+ * QEMU Geforce NV2A implementation
+ *
+ * Copyright (c) 2012 espes
+ * Copyright (c) 2015 Jannik Vogel
+ * Copyright (c) 2018-2025 Matt Borgerson
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "surface.h"
+
+#include "hw/xbox/nv2a/nv2a_regs.h"
+
+#if (NV_PGRAPH_BLEND_SFACTOR_DST_ALPHA !=                           \
+     NV_PGRAPH_BLEND_DFACTOR_DST_ALPHA) ||                          \
+    (NV_PGRAPH_BLEND_SFACTOR_ONE_MINUS_DST_ALPHA !=                 \
+     NV_PGRAPH_BLEND_DFACTOR_ONE_MINUS_DST_ALPHA) ||                \
+    (NV_PGRAPH_BLEND_SFACTOR_ONE != NV_PGRAPH_BLEND_DFACTOR_ONE) || \
+    (NV_PGRAPH_BLEND_SFACTOR_ZERO != NV_PGRAPH_BLEND_DFACTOR_ZERO)
+#error NV_PGRAPH_BLEND_SFACTOR defines expected to equal DFACTOR ones
+#endif
+
+uint32_t fixup_blend_factor_for_surface(uint32_t blend_factor,
+                                        const struct SurfaceShape *surface)
+{
+    switch (surface->color_format) {
+    case NV097_SET_SURFACE_FORMAT_COLOR_LE_X1R5G5B5_Z1R5G5B5:
+    case NV097_SET_SURFACE_FORMAT_COLOR_LE_X1R5G5B5_O1R5G5B5:
+    case NV097_SET_SURFACE_FORMAT_COLOR_LE_X8R8G8B8_Z8R8G8B8:
+    case NV097_SET_SURFACE_FORMAT_COLOR_LE_X8R8G8B8_O8R8G8B8:
+    case NV097_SET_SURFACE_FORMAT_COLOR_LE_X1A7R8G8B8_Z1A7R8G8B8:
+    case NV097_SET_SURFACE_FORMAT_COLOR_LE_X1A7R8G8B8_O1A7R8G8B8:
+        switch (blend_factor) {
+        case NV_PGRAPH_BLEND_SFACTOR_DST_ALPHA:
+            return NV_PGRAPH_BLEND_SFACTOR_ONE;
+        case NV_PGRAPH_BLEND_SFACTOR_ONE_MINUS_DST_ALPHA:
+            return NV_PGRAPH_BLEND_SFACTOR_ZERO;
+        default:
+            break;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return blend_factor;
+}

--- a/hw/xbox/nv2a/pgraph/surface.h
+++ b/hw/xbox/nv2a/pgraph/surface.h
@@ -22,6 +22,8 @@
 #ifndef HW_XBOX_NV2A_PGRAPH_SURFACE_H
 #define HW_XBOX_NV2A_PGRAPH_SURFACE_H
 
+#include <stdint.h>
+
 typedef struct SurfaceShape {
     unsigned int z_format;
     unsigned int color_format;
@@ -31,5 +33,10 @@ typedef struct SurfaceShape {
     unsigned int clip_width, clip_height;
     unsigned int anti_aliasing;
 } SurfaceShape;
+
+/**
+ * Returns a modified blend factor to match HW behavior for special surface formats.
+ */
+uint32_t fixup_blend_factor_for_surface(uint32_t blend_factor, const struct SurfaceShape *surface);
 
 #endif

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -35,8 +35,8 @@ void pgraph_vk_draw_begin(NV2AState *d)
     bool mask_blue = control_0 & NV_PGRAPH_CONTROL_0_BLUE_WRITE_ENABLE;
     bool color_write = mask_alpha || mask_red || mask_green || mask_blue;
     bool depth_test = control_0 & NV_PGRAPH_CONTROL_0_ZENABLE;
-    bool stencil_test =
-        pgraph_reg_r(pg, NV_PGRAPH_CONTROL_1) & NV_PGRAPH_CONTROL_1_STENCIL_TEST_ENABLE;
+    bool stencil_test = pgraph_reg_r(pg, NV_PGRAPH_CONTROL_1) &
+                        NV_PGRAPH_CONTROL_1_STENCIL_TEST_ENABLE;
     bool is_nop_draw = !(color_write || depth_test || stencil_test);
 
     pgraph_vk_surface_update(d, true, true, depth_test || stencil_test);
@@ -61,7 +61,8 @@ static VkPrimitiveTopology get_primitive_topology(PGRAPHState *pg)
     case PRIM_TYPE_LINES:
         return VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
     case PRIM_TYPE_LINE_LOOP:
-        // FIXME: line strips, except that the first and last vertices are also used as a line
+        // FIXME: line strips, except that the first and last vertices are also
+        // used as a line
         return VK_PRIMITIVE_TOPOLOGY_LINE_STRIP;
     case PRIM_TYPE_LINE_STRIP:
         return VK_PRIMITIVE_TOPOLOGY_LINE_STRIP;
@@ -275,9 +276,9 @@ static VkRenderPass create_render_pass(PGRAPHVkState *r, RenderPassState *state)
             .initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
             .finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
         };
-        color_reference = (VkAttachmentReference){
-            num_attachments, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-        };
+        color_reference =
+            (VkAttachmentReference){ num_attachments,
+                                     VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL };
         num_attachments++;
     }
 
@@ -294,7 +295,8 @@ static VkRenderPass create_render_pass(PGRAPHVkState *r, RenderPassState *state)
             .finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
         };
         depth_reference = (VkAttachmentReference){
-            num_attachments, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+            num_attachments,
+            VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
         };
         num_attachments++;
     }
@@ -315,15 +317,13 @@ static VkRenderPass create_render_pass(PGRAPHVkState *r, RenderPassState *state)
     }
 
     if (zeta) {
-        dependency.srcStageMask |=
-            VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
-            VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+        dependency.srcStageMask |= VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                                   VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
         dependency.srcAccessMask |=
             VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
             VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-        dependency.dstStageMask |=
-            VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
-            VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+        dependency.dstStageMask |= VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                                   VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
         dependency.dstAccessMask |=
             VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
             VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
@@ -351,7 +351,8 @@ static VkRenderPass create_render_pass(PGRAPHVkState *r, RenderPassState *state)
     return render_pass;
 }
 
-static VkRenderPass add_new_render_pass(PGRAPHVkState *r, RenderPassState *state)
+static VkRenderPass add_new_render_pass(PGRAPHVkState *r,
+                                        RenderPassState *state)
 {
     RenderPass new_pass;
     memcpy(&new_pass.state, state, sizeof(*state));
@@ -393,7 +394,7 @@ static void create_frame_buffer(PGRAPHState *pg)
         attachments[attachment_count++] = r->zeta_binding->image_view;
     }
 
-    SurfaceBinding *binding = r->color_binding ? : r->zeta_binding;
+    SurfaceBinding *binding = r->color_binding ?: r->zeta_binding;
 
     VkFramebufferCreateInfo create_info = {
         .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
@@ -476,7 +477,7 @@ static void create_clear_pipeline(PGRAPHState *pg)
                 .module = r->solid_frag_module->module,
                 .pName = "main",
             };
-     }
+    }
 
     VkPipelineVertexInputStateCreateInfo vertex_input = {
         .sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
@@ -734,8 +735,8 @@ static void create_pipeline(PGRAPHState *pg)
     uint32_t control_0 = pgraph_reg_r(pg, NV_PGRAPH_CONTROL_0);
     bool depth_test = control_0 & NV_PGRAPH_CONTROL_0_ZENABLE;
     bool depth_write = !!(control_0 & NV_PGRAPH_CONTROL_0_ZWRITEENABLE);
-    bool stencil_test =
-        pgraph_reg_r(pg, NV_PGRAPH_CONTROL_1) & NV_PGRAPH_CONTROL_1_STENCIL_TEST_ENABLE;
+    bool stencil_test = pgraph_reg_r(pg, NV_PGRAPH_CONTROL_1) &
+                        NV_PGRAPH_CONTROL_1_STENCIL_TEST_ENABLE;
 
     int num_active_shader_stages = 0;
     VkPipelineShaderStageCreateInfo shader_stages[3];
@@ -792,8 +793,8 @@ static void create_pipeline(PGRAPHState *pg)
         .sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
         .depthClampEnable = VK_TRUE,
         .rasterizerDiscardEnable = VK_FALSE,
-        .polygonMode = pgraph_polygon_mode_vk_map[r->shader_binding->state
-                                                      .geom.polygon_front_mode],
+        .polygonMode = pgraph_polygon_mode_vk_map[r->shader_binding->state.geom
+                                                      .polygon_front_mode],
         .lineWidth = 1.0f,
         .frontFace = (pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER) &
                       NV_PGRAPH_SETUPRASTER_FRONTFACE) ?
@@ -803,7 +804,8 @@ static void create_pipeline(PGRAPHState *pg)
         .pNext = rasterizer_next_struct,
     };
 
-    if (pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER) & NV_PGRAPH_SETUPRASTER_CULLENABLE) {
+    if (pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER) &
+        NV_PGRAPH_SETUPRASTER_CULLENABLE) {
         uint32_t cull_face = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER),
                                       NV_PGRAPH_SETUPRASTER_CULLCTRL);
         assert(cull_face < ARRAY_SIZE(pgraph_cull_face_vk_map));
@@ -825,8 +827,8 @@ static void create_pipeline(PGRAPHState *pg)
 
     if (depth_test) {
         depth_stencil.depthTestEnable = VK_TRUE;
-        uint32_t depth_func =
-            GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_CONTROL_0), NV_PGRAPH_CONTROL_0_ZFUNC);
+        uint32_t depth_func = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_CONTROL_0),
+                                       NV_PGRAPH_CONTROL_0_ZFUNC);
         assert(depth_func < ARRAY_SIZE(pgraph_depth_func_vk_map));
         depth_stencil.depthCompareOp = pgraph_depth_func_vk_map[depth_func];
     }
@@ -883,10 +885,12 @@ static void create_pipeline(PGRAPHState *pg)
     if (pgraph_reg_r(pg, NV_PGRAPH_BLEND) & NV_PGRAPH_BLEND_EN) {
         color_blend_attachment.blendEnable = VK_TRUE;
 
-        uint32_t sfactor =
-            GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_BLEND), NV_PGRAPH_BLEND_SFACTOR);
-        uint32_t dfactor =
-            GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_BLEND), NV_PGRAPH_BLEND_DFACTOR);
+        const uint32_t blend_reg = pgraph_reg_r(pg, NV_PGRAPH_BLEND);
+        uint32_t sfactor = fixup_blend_factor_for_surface(
+            GET_MASK(blend_reg, NV_PGRAPH_BLEND_SFACTOR), &pg->surface_shape);
+        uint32_t dfactor = fixup_blend_factor_for_surface(
+            GET_MASK(blend_reg, NV_PGRAPH_BLEND_DFACTOR), &pg->surface_shape);
+
         assert(sfactor < ARRAY_SIZE(pgraph_blend_factor_vk_map));
         assert(dfactor < ARRAY_SIZE(pgraph_blend_factor_vk_map));
         color_blend_attachment.srcColorBlendFactor =
@@ -1038,8 +1042,7 @@ static void push_vertex_attr_values(PGRAPHState *pg)
     if (num_uniform_attrs > 0) {
         vkCmdPushConstants(r->command_buffer, r->pipeline_binding->layout,
                            VK_SHADER_STAGE_VERTEX_BIT, 0,
-                           num_uniform_attrs * 4 * sizeof(float),
-                           &values);
+                           num_uniform_attrs * 4 * sizeof(float), &values);
     }
 }
 
@@ -1187,7 +1190,6 @@ static void begin_render_pass(PGRAPHState *pg)
     vkCmdBeginRenderPass(r->command_buffer, &render_pass_begin_info,
                          VK_SUBPASS_CONTENTS_INLINE);
     r->in_render_pass = true;
-
 }
 
 static void end_render_pass(PGRAPHVkState *r)
@@ -1199,7 +1201,8 @@ static void end_render_pass(PGRAPHVkState *r)
 }
 
 const enum NV2A_PROF_COUNTERS_ENUM finish_reason_to_counter_enum[] = {
-    [VK_FINISH_REASON_VERTEX_BUFFER_DIRTY] = NV2A_PROF_FINISH_VERTEX_BUFFER_DIRTY,
+    [VK_FINISH_REASON_VERTEX_BUFFER_DIRTY] =
+        NV2A_PROF_FINISH_VERTEX_BUFFER_DIRTY,
     [VK_FINISH_REASON_SURFACE_CREATE] = NV2A_PROF_FINISH_SURFACE_CREATE,
     [VK_FINISH_REASON_SURFACE_DOWN] = NV2A_PROF_FINISH_SURFACE_DOWN,
     [VK_FINISH_REASON_NEED_BUFFER_SPACE] = NV2A_PROF_FINISH_NEED_BUFFER_SPACE,
@@ -1228,10 +1231,11 @@ void pgraph_vk_finish(PGRAPHState *pg, FinishReason finish_reason)
         }
         VK_CHECK(vkEndCommandBuffer(r->command_buffer));
 
-        VkCommandBuffer cmd = pgraph_vk_begin_single_time_commands(pg); // FIXME: Cleanup
+        VkCommandBuffer cmd =
+            pgraph_vk_begin_single_time_commands(pg); // FIXME: Cleanup
         sync_staging_buffer(pg, cmd, BUFFER_INDEX_STAGING, BUFFER_INDEX);
         sync_staging_buffer(pg, cmd, BUFFER_VERTEX_INLINE_STAGING,
-                                BUFFER_VERTEX_INLINE);
+                            BUFFER_VERTEX_INLINE);
         sync_staging_buffer(pg, cmd, BUFFER_UNIFORM_STAGING, BUFFER_UNIFORM);
         bitmap_clear(r->uploaded_bitmap, 0, r->bitmap_size);
         flush_memory_buffer(pg, cmd);
@@ -1270,7 +1274,6 @@ void pgraph_vk_finish(PGRAPHState *pg, FinishReason finish_reason)
         if (finish_reason == VK_FINISH_REASON_FLIP_STALL ||
             (r->submit_count - r->allocator_last_submit_index) >
                 max_num_submits_before_budget_update) {
-
             // VMA queries budget via vmaSetCurrentFrameIndex
             vmaSetCurrentFrameIndex(r->allocator, r->submit_count);
             r->allocator_last_submit_index = r->submit_count;
@@ -1304,8 +1307,8 @@ void pgraph_vk_begin_command_buffer(PGRAPHState *pg)
         .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
         .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
     };
-    VK_CHECK(vkBeginCommandBuffer(r->command_buffer,
-                                  &command_buffer_begin_info));
+    VK_CHECK(
+        vkBeginCommandBuffer(r->command_buffer, &command_buffer_begin_info));
     r->command_buffer_start_time = pg->draw_time;
     r->in_command_buffer = true;
 }
@@ -1516,8 +1519,8 @@ void pgraph_vk_draw_end(NV2AState *d)
     bool mask_blue = control_0 & NV_PGRAPH_CONTROL_0_BLUE_WRITE_ENABLE;
     bool color_write = mask_alpha || mask_red || mask_green || mask_blue;
     bool depth_test = control_0 & NV_PGRAPH_CONTROL_0_ZENABLE;
-    bool stencil_test =
-        pgraph_reg_r(pg, NV_PGRAPH_CONTROL_1) & NV_PGRAPH_CONTROL_1_STENCIL_TEST_ENABLE;
+    bool stencil_test = pgraph_reg_r(pg, NV_PGRAPH_CONTROL_1) &
+                        NV_PGRAPH_CONTROL_1_STENCIL_TEST_ENABLE;
     bool is_nop_draw = !(color_write || depth_test || stencil_test);
 
     if (is_nop_draw) {
@@ -1581,8 +1584,8 @@ static void sync_vertex_ram_buffer(PGRAPHState *pg)
         end_addr = ROUND_UP(end_addr, TARGET_PAGE_SIZE);
 
         NV2A_VK_DPRINTF("- %d: %08" HWADDR_PRIx " %zd bytes"
-                          " -> %08" HWADDR_PRIx " %zd bytes", i,
-                        r->vertex_ram_buffer_syncs[i].addr,
+                        " -> %08" HWADDR_PRIx " %zd bytes",
+                        i, r->vertex_ram_buffer_syncs[i].addr,
                         r->vertex_ram_buffer_syncs[i].size, start_addr,
                         end_addr - start_addr);
 
@@ -1624,7 +1627,7 @@ static void sync_vertex_ram_buffer(PGRAPHState *pg)
         hwaddr addr = merged[i].addr;
         VkDeviceSize size = merged[i].size;
 
-        NV2A_VK_DPRINTF("- %d: %08"HWADDR_PRIx" %zd bytes", i, addr, size);
+        NV2A_VK_DPRINTF("- %d: %08" HWADDR_PRIx " %zd bytes", i, addr, size);
 
         if (memory_region_test_and_clear_dirty(d->vram, addr, size,
                                                DIRTY_MEMORY_NV2A)) {
@@ -1678,9 +1681,8 @@ void pgraph_vk_clear_surface(NV2AState *d, uint32_t parameter)
                          write_zeta ? " zeta" : "");
 
     begin_pre_draw(pg);
-    pgraph_vk_begin_debug_marker(r, r->command_buffer,
-        RGBA_BLUE, "Clear %08" HWADDR_PRIx,
-        binding->vram_addr);
+    pgraph_vk_begin_debug_marker(r, r->command_buffer, RGBA_BLUE,
+                                 "Clear %08" HWADDR_PRIx, binding->vram_addr);
     begin_draw(pg);
 
     // FIXME: What does hardware do when min >= max?
@@ -1864,29 +1866,30 @@ static bool ensure_buffer_space(PGRAPHState *pg, int index, VkDeviceSize size)
     return false;
 }
 
-static void get_size_and_count_for_format(VkFormat fmt, size_t *size, size_t *count)
+static void get_size_and_count_for_format(VkFormat fmt, size_t *size,
+                                          size_t *count)
 {
     static const struct {
         size_t size;
         size_t count;
     } table[] = {
-        [VK_FORMAT_R8_UNORM] =              { 1, 1 },
-        [VK_FORMAT_R8G8_UNORM] =            { 1, 2 },
-        [VK_FORMAT_R8G8B8_UNORM] =          { 1, 3 },
-        [VK_FORMAT_R8G8B8A8_UNORM] =        { 1, 4 },
-        [VK_FORMAT_R16_SNORM] =             { 2, 1 },
-        [VK_FORMAT_R16G16_SNORM] =          { 2, 2 },
-        [VK_FORMAT_R16G16B16_SNORM] =       { 2, 3 },
-        [VK_FORMAT_R16G16B16A16_SNORM] =    { 2, 4 },
-        [VK_FORMAT_R16_SSCALED] =           { 2, 1 },
-        [VK_FORMAT_R16G16_SSCALED] =        { 2, 2 },
-        [VK_FORMAT_R16G16B16_SSCALED] =     { 2, 3 },
-        [VK_FORMAT_R16G16B16A16_SSCALED] =  { 2, 4 },
-        [VK_FORMAT_R32_SFLOAT] =            { 4, 1 },
-        [VK_FORMAT_R32G32_SFLOAT] =         { 4, 2 },
-        [VK_FORMAT_R32G32B32_SFLOAT] =      { 4, 3 },
-        [VK_FORMAT_R32G32B32A32_SFLOAT] =   { 4, 4 },
-        [VK_FORMAT_R32_SINT] =              { 4, 1 },
+        [VK_FORMAT_R8_UNORM] = { 1, 1 },
+        [VK_FORMAT_R8G8_UNORM] = { 1, 2 },
+        [VK_FORMAT_R8G8B8_UNORM] = { 1, 3 },
+        [VK_FORMAT_R8G8B8A8_UNORM] = { 1, 4 },
+        [VK_FORMAT_R16_SNORM] = { 2, 1 },
+        [VK_FORMAT_R16G16_SNORM] = { 2, 2 },
+        [VK_FORMAT_R16G16B16_SNORM] = { 2, 3 },
+        [VK_FORMAT_R16G16B16A16_SNORM] = { 2, 4 },
+        [VK_FORMAT_R16_SSCALED] = { 2, 1 },
+        [VK_FORMAT_R16G16_SSCALED] = { 2, 2 },
+        [VK_FORMAT_R16G16B16_SSCALED] = { 2, 3 },
+        [VK_FORMAT_R16G16B16A16_SSCALED] = { 2, 4 },
+        [VK_FORMAT_R32_SFLOAT] = { 4, 1 },
+        [VK_FORMAT_R32G32_SFLOAT] = { 4, 2 },
+        [VK_FORMAT_R32G32B32_SFLOAT] = { 4, 3 },
+        [VK_FORMAT_R32G32B32A32_SFLOAT] = { 4, 4 },
+        [VK_FORMAT_R32_SINT] = { 4, 1 },
     };
 
     assert(fmt < ARRAY_SIZE(table));
@@ -1911,7 +1914,7 @@ static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
 
-    VertexBufferRemap remap = {0};
+    VertexBufferRemap remap = { 0 };
 
     VkDeviceAddress output_offset = 0;
 
@@ -1927,7 +1930,8 @@ static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
             &r->vertex_attribute_descriptions[desc_loc];
 
         size_t element_size, element_count;
-        get_size_and_count_for_format(attr->format, &element_size, &element_count);
+        get_size_and_count_for_format(attr->format, &element_size,
+                                      &element_count);
 
         bool offset_valid =
             (r->vertex_attribute_offsets[attr_id] % element_size == 0);
@@ -1951,8 +1955,8 @@ static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
         //         remap.map[attr_id].old_stride,
         //         remap.map[attr_id].new_stride);
 
-        output_offset =
-            remap.map[attr_id].offset + remap.map[attr_id].new_stride * num_vertices;
+        output_offset = remap.map[attr_id].offset +
+                        remap.map[attr_id].new_stride * num_vertices;
         desc->stride = remap.map[attr_id].new_stride;
     }
 
@@ -1960,11 +1964,14 @@ static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
 
     // reserve space
     if (remap.attributes) {
-        StorageBuffer *buffer = &r->storage_buffers[BUFFER_VERTEX_INLINE_STAGING];
+        StorageBuffer *buffer =
+            &r->storage_buffers[BUFFER_VERTEX_INLINE_STAGING];
         VkDeviceSize starting_offset = ROUND_UP(buffer->buffer_offset, 16);
         size_t total_space_required =
-            (starting_offset - buffer->buffer_offset) + remap.buffer_space_required;
-        ensure_buffer_space(pg, BUFFER_VERTEX_INLINE_STAGING, total_space_required);
+            (starting_offset - buffer->buffer_offset) +
+            remap.buffer_space_required;
+        ensure_buffer_space(pg, BUFFER_VERTEX_INLINE_STAGING,
+                            total_space_required);
         buffer->buffer_offset = ROUND_UP(buffer->buffer_offset, 16);
     }
 
@@ -2045,7 +2052,8 @@ void pgraph_vk_flush_draw(NV2AState *d)
         uint32_t max_element = 0;
         for (int i = 0; i < pg->draw_arrays_length; i++) {
             min_element = MIN(pg->draw_arrays_start[i], min_element);
-            max_element = MAX(max_element, pg->draw_arrays_start[i] + pg->draw_arrays_count[i]);
+            max_element = MAX(max_element, pg->draw_arrays_start[i] +
+                                               pg->draw_arrays_count[i]);
         }
         sync_vertex_ram_buffer(pg);
         VertexBufferRemap remap = remap_unaligned_attributes(pg, max_element);
@@ -2088,10 +2096,12 @@ void pgraph_vk_flush_draw(NV2AState *d)
             d, min_element, max_element, false, 0,
             pg->inline_elements[pg->inline_elements_length - 1]);
         sync_vertex_ram_buffer(pg);
-        VertexBufferRemap remap = remap_unaligned_attributes(pg, max_element + 1);
+        VertexBufferRemap remap =
+            remap_unaligned_attributes(pg, max_element + 1);
 
         begin_pre_draw(pg);
-        copy_remapped_attributes_to_inline_buffer(pg, remap, 0, max_element + 1);
+        copy_remapped_attributes_to_inline_buffer(pg, remap, 0,
+                                                  max_element + 1);
         VkDeviceSize buffer_offset = pgraph_vk_update_index_buffer(
             pg, pg->inline_elements, index_data_size);
         pgraph_vk_begin_debug_marker(r, r->command_buffer, RGBA_BLUE,
@@ -2150,7 +2160,7 @@ void pgraph_vk_flush_draw(NV2AState *d)
 
         VkDeviceSize inline_array_data_size = pg->inline_array_length * 4;
         ensure_buffer_space(pg, BUFFER_VERTEX_INLINE_STAGING,
-                               inline_array_data_size);
+                            inline_array_data_size);
 
         unsigned int offset = 0;
         for (int i = 0; i < NV2A_VERTEXSHADER_ATTRIBUTES; i++) {


### PR DESCRIPTION
This remaps DstAlpha to alternate source/destination factors when performing blending on target surfaces with forced alpha bits (e.g., NV097_SET_SURFACE_FORMAT_COLOR_LE_X8R8G8B8_Z8R8G8B8).

Fixes #2473

Tests: https://github.com/abaire/nxdk_pgraph_tests/blob/de548172ac3166f03f3a75999829ba17aade73aa/src/tests/blend_surface_tests.cpp#L249
HW results: https://abaire.github.io/nxdk_pgraph_tests_golden_results/results/Blend_surface/index.html

PR results: https://abaire.github.io/xemu-dev_pgraph_test_results/fix_2473_prevent_alpha_updates_for_forced_value_surfaces/index.html