### PR TITLE
nv2a: Prevent depth surface from being used as render buf

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/display.c
+++ b/hw/xbox/nv2a/pgraph/gl/display.c
@@ -378,7 +378,7 @@ void pgraph_gl_sync(NV2AState *d)
     d->vga.get_params(&d->vga, &vga_display_params);
 
     SurfaceBinding *surface = pgraph_gl_surface_get_within(d, d->pcrtc.start + vga_display_params.line_offset);
-    if (surface == NULL) {
+    if (surface == NULL || !surface->color) {
         qemu_event_set(&d->pgraph.sync_complete);
         return;
     }


### PR DESCRIPTION
Fixes #1227 