### PR TITLE
nv2a: Add VK physical device to config

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -146,6 +146,7 @@ display:
     validation_layers: bool
     debug_shaders: bool
     assert_on_validation_msg: bool
+    preferred_physical_device: string
   quality:
     surface_scale:
       type: integer


### PR DESCRIPTION
Just doing the bare minimum here to unblock anybody with unfortunate device ordering (like the VK machine I briefly had access to for testing). 

Eventually it'd be good to add a settings UI for this and maybe switch to device IDs instead of names; I'm not sure what gets displayed in a system with two identical GPUs. I could have it dump the device ID when it enumerates available devices so that users could cut and paste that into the config, if preferred.