### PR TITLE
nv2a: Prevent GL assert on END without BEGIN

### DIFF
--- a/hw/xbox/nv2a/pgraph/pgraph.c
+++ b/hw/xbox/nv2a/pgraph/pgraph.c
@@ -2497,6 +2497,8 @@ DEF_METHOD(NV097, SET_BEGIN_END)
     if (parameter == NV097_SET_BEGIN_END_OP_END) {
         if (pg->primitive_mode == PRIM_TYPE_INVALID) {
             NV2A_DPRINTF("End without Begin!\n");
+            pgraph_reset_inline_buffers(pg);
+            return;
         }
         nv2a_profile_inc_counter(NV2A_PROF_BEGIN_ENDS);
         d->pgraph.renderer->ops.draw_end(d);


### PR DESCRIPTION
Fixes an assert case in debug mode by ignoring end's without begins (similar to begin without end).