### PR TITLE
Add non-"ignore"-able assert macros, user-friendly VK_CHECK, and durable fatal error logging

### DIFF
--- a/hw/xbox/nv2a/debug.c
+++ b/hw/xbox/nv2a/debug.c
@@ -1,0 +1,84 @@
+/*
+ * Geforce NV2A PGRAPH OpenGL Renderer debug routines
+ *
+ * Copyright (c) 2025 Matt Borgerson
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "qemu/osdep.h"
+
+#include "hw/xbox/nv2a/debug_gl.h"
+
+#include <stdio.h>
+
+#ifdef XEMU_DEBUG_BUILD
+
+static GLenum framebuffer_attachments[] = { GL_COLOR_ATTACHMENT0,
+                                            GL_DEPTH_ATTACHMENT,
+                                            GL_STENCIL_ATTACHMENT,
+                                            GL_DEPTH_STENCIL_ATTACHMENT };
+
+void gl_debug_assert_framebuffer_complete(const char *source_file, int line)
+{
+    GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    if (status == GL_FRAMEBUFFER_COMPLETE) {
+        return;
+    }
+
+    fprintf(stderr,
+            "OpenGL framebuffer status: 0x%X (%d) != "
+            "GL_FRAMEBUFFER_COMPLETE at %s:%d\n",
+            status, status, source_file, line);
+
+    GLint objectType, objectName;
+    for (int i = 0; i < ARRAY_SIZE(framebuffer_attachments); ++i) {
+        GLenum attachment = framebuffer_attachments[i];
+
+        glGetFramebufferAttachmentParameteriv(
+            GL_FRAMEBUFFER, attachment, GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE,
+            &objectType);
+
+        if (objectType == GL_NONE) {
+            fprintf(stderr, "\t0x%X: GL_NONE\n", attachment);
+        } else {
+            glGetFramebufferAttachmentParameteriv(
+                GL_FRAMEBUFFER, attachment,
+                GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &objectName);
+
+            fprintf(stderr, "\t0x%X: type=%d, name=%d\n", attachment,
+                    objectType, objectName);
+
+            if (objectType == GL_TEXTURE) {
+                GLint width, height, internalFormat, prev_tex;
+                glGetIntegerv(GL_TEXTURE_BINDING_2D, &prev_tex);
+                glBindTexture(GL_TEXTURE_2D, objectName);
+                glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH,
+                                         &width);
+                glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT,
+                                         &height);
+                glGetTexLevelParameteriv(GL_TEXTURE_2D, 0,
+                                         GL_TEXTURE_INTERNAL_FORMAT,
+                                         &internalFormat);
+                fprintf(stderr, "\t\tTexture: %dx%d, format=0x%X\n", width,
+                        height, internalFormat);
+                glBindTexture(GL_TEXTURE_2D, prev_tex);
+            }
+        }
+    }
+
+    assert(!"OpenGL GL_FRAMEBUFFER status != GL_FRAMEBUFFER_COMPLETE");
+}
+
+#endif // ifdef XEMU_DEBUG_BUILD

--- a/hw/xbox/nv2a/debug.c
+++ b/hw/xbox/nv2a/debug.c
@@ -1,5 +1,5 @@
 /*
- * Geforce NV2A PGRAPH OpenGL Renderer debug routines
+ * Geforce NV2A PGRAPH general debug routines
  *
  * Copyright (c) 2025 Matt Borgerson
  *
@@ -19,9 +19,56 @@
 
 #include "qemu/osdep.h"
 
+#include "hw/xbox/nv2a/debug.h"
 #include "hw/xbox/nv2a/debug_gl.h"
 
-#include <stdio.h>
+#include "qemu/osdep.h"
+
+
+static gchar *fatal_error_log_path = NULL;
+
+void nv2a_set_fatal_error_log_path(const gchar *path)
+{
+    if (fatal_error_log_path) {
+        g_free(fatal_error_log_path);
+    }
+
+    fatal_error_log_path = path ? g_strdup(path) : NULL;
+}
+
+void nv2a_log_fatal_error(const char *msg, ...)
+{
+    FILE *error_log = stderr;
+    if (fatal_error_log_path) {
+        error_log = fopen(fatal_error_log_path, "w");
+        if (!error_log) {
+            fprintf(stderr, "Failed to open fatal error log at '%s'\n",
+                    fatal_error_log_path);
+            error_log = stderr;
+        }
+    }
+
+    time_t now = time(NULL);
+    struct tm *local_time = localtime(&now);
+
+    char timestamp[32] = {
+        0,
+    };
+    strftime(timestamp, sizeof(timestamp), "%Y%m%d at %T", local_time);
+
+    fprintf(error_log, "%s\n", timestamp);
+
+    va_list args;
+    va_start(args, msg);
+    vfprintf(error_log, msg, args);
+    va_end(args);
+
+    fprintf(error_log, "\n\n");
+
+    if (error_log != stderr) {
+        fclose(error_log);
+    }
+}
 
 #ifdef XEMU_DEBUG_BUILD
 

--- a/hw/xbox/nv2a/debug.h
+++ b/hw/xbox/nv2a/debug.h
@@ -24,11 +24,38 @@
 
 #include <stdint.h>
 
-#define NV2A_XPRINTF(x, ...) do { \
-    if (x) { \
-        fprintf(stderr, "nv2a: " __VA_ARGS__); \
-    } \
-} while (0)
+#include "qemu/osdep.h"
+
+#define NV2A_XPRINTF(x, ...)                       \
+    do {                                           \
+        if (x) {                                   \
+            fprintf(stderr, "nv2a: " __VA_ARGS__); \
+        }                                          \
+    } while (0)
+
+#define NV2A_ASSERT_FATAL(x)                                             \
+    do {                                                                 \
+        if (!(x)) {                                                      \
+            nv2a_log_fatal_error("Check failed!\n'%s'\nat %s:%d\n", #x,  \
+                                 __FILE__, __LINE__);                    \
+            assert((x) &&                                                \
+                   "A fatal error occurred. Check the xemu fatal error " \
+                   "log in your home directory for details.");           \
+            exit(127);                                                   \
+        }                                                                \
+    } while (0)
+
+#define NV2A_ASSERT_FATAL_FRIENDLY(x, msg)                                     \
+    do {                                                                       \
+        if (!(x)) {                                                            \
+            nv2a_log_fatal_error("%s\n\nCheck failed!\n'%s'\nat %s:%d\n", msg, \
+                                 #x, __FILE__, __LINE__);                      \
+            assert((x) && msg &&                                               \
+                   "A fatal error occurred. Check the xemu fatal error log "   \
+                   "in your home directory for details.");                     \
+            exit(127);                                                         \
+        }                                                                      \
+    } while (0)
 
 #ifndef DEBUG_NV2A
 # define DEBUG_NV2A 0
@@ -150,6 +177,14 @@ static inline void nv2a_profile_inc_counter(enum NV2A_PROF_COUNTERS_ENUM cnt)
 {
     g_nv2a_stats.frame_working.counters[cnt] += 1;
 }
+
+void nv2a_set_fatal_error_log_path(const gchar *path);
+
+/**
+ * Writes a fatal error message to the fatal error log and forcibly kills the
+ * application.
+ */
+void nv2a_log_fatal_error(const char *msg, ...);
 
 #ifdef CONFIG_RENDERDOC
 void nv2a_dbg_renderdoc_init(void);

--- a/hw/xbox/nv2a/debug_gl.h
+++ b/hw/xbox/nv2a/debug_gl.h
@@ -1,0 +1,38 @@
+#ifndef XEMU_HW_XBOX_NV2A_DEBUG_GL_H_
+#define XEMU_HW_XBOX_NV2A_DEBUG_GL_H_
+
+#ifdef XEMU_DEBUG_BUILD
+
+#define ASSERT_NO_GL_ERROR()                                                 \
+    do {                                                                 \
+        GLenum error = glGetError();                                     \
+        if (error != GL_NO_ERROR) {                                      \
+            fprintf(stderr, "OpenGL error: 0x%X (%d) at %s:%d\n", error, \
+                    error, __FILE__, __LINE__);                          \
+            assert(!"OpenGL error detected");                            \
+        }                                                                \
+    } while (0)
+
+#define ASSERT_FRAMEBUFFER_COMPLETE()                                         \
+    do {                                                                     \
+        GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);            \
+        if (status != GL_FRAMEBUFFER_COMPLETE) {                             \
+            fprintf(stderr,                                                  \
+                    "OpenGL framebuffer status: 0x%X (%d) != "               \
+                    "GL_FRAMEBUFFER_COMPLETE at %s:%d\n",                    \
+                    status, status, __FILE__, __LINE__);                     \
+            assert(                                                          \
+                !"OpenGL GL_FRAMEBUFFER status != GL_FRAMEBUFFER_COMPLETE"); \
+        }                                                                    \
+    } while (0)
+
+#else
+
+#define ASSERT_NO_GL_ERROR() assert(glGetError() == GL_NO_ERROR)
+
+#define ASSERT_FRAMEBUFFER_COMPLETE() \
+    assert(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE)
+
+#endif // XEMU_DEBUG_BUILD
+
+#endif // XEMU_HW_XBOX_NV2A_DEBUG_GL_H_

--- a/hw/xbox/nv2a/debug_gl.h
+++ b/hw/xbox/nv2a/debug_gl.h
@@ -1,30 +1,50 @@
+/*
+ * Geforce NV2A PGRAPH OpenGL Renderer debug routines
+ *
+ * Copyright (c) 2025 Matt Borgerson
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef XEMU_HW_XBOX_NV2A_DEBUG_GL_H_
 #define XEMU_HW_XBOX_NV2A_DEBUG_GL_H_
 
 #ifdef XEMU_DEBUG_BUILD
 
-#define ASSERT_NO_GL_ERROR()                                                 \
+#include <epoxy/gl.h>
+
+#define ASSERT_NO_GL_ERROR()                                             \
     do {                                                                 \
-        GLenum error = glGetError();                                     \
-        if (error != GL_NO_ERROR) {                                      \
+        int error_count = 0;                                             \
+        GLenum error;                                                    \
+        while ((error = glGetError()) != GL_NO_ERROR) {                  \
+            ++error_count;                                               \
             fprintf(stderr, "OpenGL error: 0x%X (%d) at %s:%d\n", error, \
                     error, __FILE__, __LINE__);                          \
-            assert(!"OpenGL error detected");                            \
         }                                                                \
+        assert(!error_count && "OpenGL error(s) detected");              \
     } while (0)
 
-#define ASSERT_FRAMEBUFFER_COMPLETE()                                         \
-    do {                                                                     \
-        GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);            \
-        if (status != GL_FRAMEBUFFER_COMPLETE) {                             \
-            fprintf(stderr,                                                  \
-                    "OpenGL framebuffer status: 0x%X (%d) != "               \
-                    "GL_FRAMEBUFFER_COMPLETE at %s:%d\n",                    \
-                    status, status, __FILE__, __LINE__);                     \
-            assert(                                                          \
-                !"OpenGL GL_FRAMEBUFFER status != GL_FRAMEBUFFER_COMPLETE"); \
-        }                                                                    \
-    } while (0)
+#if defined(__clang__) && defined(__FILE_NAME__)
+#define ASSERT_FRAMEBUFFER_COMPLETE() \
+    gl_debug_assert_framebuffer_complete(__FILE_NAME__, __LINE__)
+#else
+#define ASSERT_FRAMEBUFFER_COMPLETE() \
+    gl_debug_assert_framebuffer_complete(__FILE__, __LINE__)
+#endif
+
+void gl_debug_assert_framebuffer_complete(const char *source_file, int line);
 
 #else
 

--- a/hw/xbox/nv2a/debug_gl.h
+++ b/hw/xbox/nv2a/debug_gl.h
@@ -20,38 +20,47 @@
 #ifndef XEMU_HW_XBOX_NV2A_DEBUG_GL_H_
 #define XEMU_HW_XBOX_NV2A_DEBUG_GL_H_
 
-#ifdef XEMU_DEBUG_BUILD
-
 #include <epoxy/gl.h>
 
-#define ASSERT_NO_GL_ERROR()                                             \
-    do {                                                                 \
-        int error_count = 0;                                             \
-        GLenum error;                                                    \
-        while ((error = glGetError()) != GL_NO_ERROR) {                  \
-            ++error_count;                                               \
-            fprintf(stderr, "OpenGL error: 0x%X (%d) at %s:%d\n", error, \
-                    error, __FILE__, __LINE__);                          \
-        }                                                                \
-        assert(!error_count && "OpenGL error(s) detected");              \
+#define ASSERT_NO_GL_ERROR()                                                 \
+    do {                                                                     \
+        int error_count = 0;                                                 \
+        GLenum error;                                                        \
+        while ((error = glGetError()) != GL_NO_ERROR) {                      \
+            ++error_count;                                                   \
+            fprintf(stderr, "OpenGL error: 0x%X (%d) at %s:%d\n", error,     \
+                    error, __FILE__, __LINE__);                              \
+            nv2a_log_fatal_error("OpenGL error 0x%X (%d) detected at %s:%d", \
+                                 error, error, __FILE__, __LINE__);          \
+        }                                                                    \
+        assert(!error_count && "OpenGL error(s) detected");                  \
     } while (0)
 
-#if defined(__clang__) && defined(__FILE_NAME__)
-#define ASSERT_FRAMEBUFFER_COMPLETE() \
-    gl_debug_assert_framebuffer_complete(__FILE_NAME__, __LINE__)
-#else
+
+#ifdef XEMU_DEBUG_BUILD
+
 #define ASSERT_FRAMEBUFFER_COMPLETE() \
     gl_debug_assert_framebuffer_complete(__FILE__, __LINE__)
-#endif
 
 void gl_debug_assert_framebuffer_complete(const char *source_file, int line);
 
 #else
 
-#define ASSERT_NO_GL_ERROR() assert(glGetError() == GL_NO_ERROR)
-
-#define ASSERT_FRAMEBUFFER_COMPLETE() \
-    assert(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE)
+#define ASSERT_FRAMEBUFFER_COMPLETE()                             \
+    do {                                                          \
+        GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER); \
+        if (status != GL_FRAMEBUFFER_COMPLETE) {                  \
+            fprintf(stderr,                                       \
+                    "OpenGL framebuffer status 0x%X (%d) != "     \
+                    "GL_FRAMEBUFFER_COMPLETE at %s:%d\n",         \
+                    status, status, __FILE__, __LINE__);          \
+            nv2a_log_fatal_error(                                 \
+                "OpenGL framebuffer status not complete: 0x%X "   \
+                "(%d)\nat %s:%d\n",                               \
+                status, status, __FILE__, __LINE__);              \
+            assert(status == GL_FRAMEBUFFER_COMPLETE);            \
+        }                                                         \
+    } while (0)
 
 #endif // XEMU_DEBUG_BUILD
 

--- a/hw/xbox/nv2a/meson.build
+++ b/hw/xbox/nv2a/meson.build
@@ -1,4 +1,5 @@
 specific_ss.add(files(
+	'debug.c',
 	'nv2a.c',
 	'pbus.c',
 	'pcrtc.c',

--- a/hw/xbox/nv2a/pgraph/gl/debug.c
+++ b/hw/xbox/nv2a/pgraph/gl/debug.c
@@ -35,13 +35,7 @@
 #include "thirdparty/renderdoc_app.h"
 #endif
 
-#define CHECK_GL_ERROR() do { \
-  GLenum error = glGetError(); \
-  if (error != GL_NO_ERROR) {  \
-      fprintf(stderr, "OpenGL error: 0x%X (%d) at %s:%d\n", error, error, __FILE__, __LINE__); \
-      assert(!"OpenGL error detected");                                                        \
-  } \
-} while(0)
+#include "hw/xbox/nv2a/debug_gl.h"
 
 static bool has_GL_GREMEDY_frame_terminator = false;
 static bool has_GL_KHR_debug = false;
@@ -65,7 +59,7 @@ void gl_debug_initialize(void)
          */
 #else
        glEnable(GL_DEBUG_OUTPUT);
-       assert(glGetError() == GL_NO_ERROR);
+       ASSERT_NO_GL_ERROR();
 #endif
     }
 
@@ -112,13 +106,13 @@ void gl_debug_group_begin(const char *fmt, ...)
     }
 
     /* Check for errors before starting real commands in group */
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 }
 
 void gl_debug_group_end(void)
 {
     /* Check for errors when leaving group */
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 
     /* Debug group end */
     if (has_GL_KHR_debug) {
@@ -142,13 +136,12 @@ void gl_debug_label(GLenum target, GLuint name, const char *fmt, ...)
 
     glObjectLabel(target, name, n, buffer);
 
-    GLenum err = glGetError();
-    assert(err == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 }
 
 void gl_debug_frame_terminator(void)
 {
-    CHECK_GL_ERROR();
+    ASSERT_NO_GL_ERROR();
 
 #ifdef CONFIG_RENDERDOC
     if (nv2a_dbg_renderdoc_available()) {
@@ -190,7 +183,7 @@ void gl_debug_frame_terminator(void)
 #endif
     if (has_GL_GREMEDY_frame_terminator) {
         glFrameTerminatorGREMEDY();
-        CHECK_GL_ERROR();
+        ASSERT_NO_GL_ERROR();
     }
 }
 

--- a/hw/xbox/nv2a/pgraph/gl/display.c
+++ b/hw/xbox/nv2a/pgraph/gl/display.c
@@ -21,6 +21,7 @@
 
 #include "qemu/osdep.h"
 #include "hw/display/vga_int.h"
+#include "hw/xbox/nv2a/debug_gl.h"
 #include "hw/xbox/nv2a/nv2a_int.h"
 #include "hw/xbox/nv2a/pgraph/util.h"
 #include "renderer.h"
@@ -103,7 +104,7 @@ void pgraph_gl_init_display(NV2AState *d)
     glBufferData(GL_ARRAY_BUFFER, 0, NULL, GL_STATIC_DRAW);
     glGenFramebuffers(1, &r->disp_rndr.fbo);
     glGenTextures(1, &r->disp_rndr.pvideo_tex);
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 
     glo_set_current(g_nv2a_context_render);
 }
@@ -336,7 +337,7 @@ static void render_display(NV2AState *d, SurfaceBinding *surface)
         GL_TEXTURE_2D, r->gl_display_buffer, 0);
     GLenum DrawBuffers[1] = {GL_COLOR_ATTACHMENT0};
     glDrawBuffers(1, DrawBuffers);
-    assert(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+    ASSERT_FRAMEBUFFER_COMPLETE();
 
     glBindTexture(GL_TEXTURE_2D, surface->gl_buffer);
     glBindVertexArray(r->disp_rndr.vao);
@@ -388,13 +389,13 @@ void pgraph_gl_sync(NV2AState *d)
     /* Wait for queued commands to complete */
     pgraph_gl_upload_surface_data(d, surface, !tcg_enabled());
     gl_fence();
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 
     /* Render framebuffer in display context */
     glo_set_current(g_nv2a_context_display);
     render_display(d, surface);
     gl_fence();
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 
     /* Switch back to original context */
     glo_set_current(g_nv2a_context_render);

--- a/hw/xbox/nv2a/pgraph/gl/shaders.c
+++ b/hw/xbox/nv2a/pgraph/gl/shaders.c
@@ -25,6 +25,7 @@
 
 #include "xemu-version.h"
 #include "ui/xemu-settings.h"
+#include "hw/xbox/nv2a/debug_gl.h"
 #include "hw/xbox/nv2a/pgraph/util.h"
 #include "debug.h"
 #include "renderer.h"
@@ -306,7 +307,7 @@ void pgraph_gl_shader_write_cache_reload_list(PGRAPHState *pg)
 
 bool pgraph_gl_shader_load_from_memory(ShaderBinding *binding)
 {
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 
     if (!binding->program) {
         return false;
@@ -682,7 +683,7 @@ void pgraph_gl_shader_cache_to_disk(ShaderBinding *binding)
     GLsizei program_size_copied;
     glGetProgramBinary(binding->gl_program, program_size, &program_size_copied,
                        &binding->program_format, binding->program);
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 
     binding->program_size = program_size_copied;
     binding->cached = true;
@@ -736,7 +737,7 @@ static void apply_uniform_updates(const UniformInfo *info, int *locs,
         }
     }
 
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 }
 
 // FIXME: Dirty tracking

--- a/hw/xbox/nv2a/pgraph/gl/surface.c
+++ b/hw/xbox/nv2a/pgraph/gl/surface.c
@@ -21,6 +21,7 @@
 
 #include "hw/xbox/nv2a/pgraph/pgraph.h"
 #include "ui/xemu-settings.h"
+#include "hw/xbox/nv2a/debug_gl.h"
 #include "hw/xbox/nv2a/nv2a_int.h"
 #include "hw/xbox/nv2a/pgraph/swizzle.h"
 #include "debug.h"
@@ -233,8 +234,8 @@ static void render_surface_to(NV2AState *d, SurfaceBinding *surface,
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, gl_target,
                            gl_texture, 0);
     glDrawBuffers(1, draw_buffers);
-    assert(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_FRAMEBUFFER_COMPLETE();
+    ASSERT_NO_GL_ERROR();
 
     float color[] = { 0.0f, 0.0f, 0.0f, 0.0f };
     glBindTexture(GL_TEXTURE_2D, surface->gl_buffer);
@@ -648,8 +649,7 @@ static void bind_current_surface(NV2AState *d)
     }
 
     if (r->color_binding || r->zeta_binding) {
-        assert(glCheckFramebufferStatus(GL_FRAMEBUFFER) ==
-               GL_FRAMEBUFFER_COMPLETE);
+        ASSERT_FRAMEBUFFER_COMPLETE();
     }
 }
 
@@ -708,7 +708,7 @@ static void surface_download_to_buffer(NV2AState *d, SurfaceBinding *surface,
     glFramebufferTexture2D(GL_FRAMEBUFFER, surface->fmt.gl_attachment,
                            GL_TEXTURE_2D, surface->gl_buffer, 0);
 
-    assert(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+    ASSERT_FRAMEBUFFER_COMPLETE();
 
     /* Read surface into memory */
     uint8_t *gl_read_buf = pixels;
@@ -1268,8 +1268,7 @@ static void update_surface_part(NV2AState *d, bool upload, bool color)
 
         glFramebufferTexture2D(GL_FRAMEBUFFER, entry.fmt.gl_attachment,
                                GL_TEXTURE_2D, found->gl_buffer, 0);
-        assert(glCheckFramebufferStatus(GL_FRAMEBUFFER) ==
-               GL_FRAMEBUFFER_COMPLETE);
+        ASSERT_FRAMEBUFFER_COMPLETE();
 
         surface->buffer_dirty = false;
     }

--- a/hw/xbox/nv2a/pgraph/gl/vertex.c
+++ b/hw/xbox/nv2a/pgraph/gl/vertex.c
@@ -20,6 +20,7 @@
  */
 
 #include "hw/xbox/nv2a/nv2a_regs.h"
+#include "hw/xbox/nv2a/debug_gl.h"
 #include <hw/xbox/nv2a/nv2a_int.h>
 #include "debug.h"
 #include "renderer.h"
@@ -280,7 +281,7 @@ void pgraph_gl_init_buffers(NV2AState *d)
     glGenVertexArrays(1, &r->gl_vertex_array);
     glBindVertexArray(r->gl_vertex_array);
 
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 }
 
 void pgraph_gl_finalize_buffers(PGRAPHState *pg)

--- a/hw/xbox/nv2a/pgraph/vk/debug.h
+++ b/hw/xbox/nv2a/pgraph/vk/debug.h
@@ -61,6 +61,22 @@ extern int nv2a_vk_dgroup_indent;
         }                                                                    \
     } while (0)
 
+#define VK_CHECK_FRIENDLY(x, msg)                                            \
+    do {                                                                     \
+        VkResult vk_result = (x);                                            \
+        if (vk_result != VK_SUCCESS) {                                       \
+            fprintf(stderr, "vk_result = %d\n", vk_result);                  \
+            nv2a_log_fatal_error(                                            \
+                "%s\nvk check failed: vk_result = %d\nat %s:%d\n", msg,      \
+                vk_result, __FILE__, __LINE__);                              \
+            assert((x) && msg &&                                             \
+                   "A fatal error occurred. Check the xemu fatal error log " \
+                   "in your home directory for details.");                   \
+            exit(127);                                                       \
+        }                                                                    \
+    } while (0)
+
+
 void pgraph_vk_debug_frame_terminator(void);
 
 #endif

--- a/hw/xbox/nv2a/pgraph/vk/debug.h
+++ b/hw/xbox/nv2a/pgraph/vk/debug.h
@@ -40,19 +40,25 @@ extern int nv2a_vk_dgroup_indent;
         nv2a_vk_dgroup_indent++;                        \
     } while (0)
 
-#define NV2A_VK_DGROUP_END(...)             \
-    do {                                    \
-        nv2a_vk_dgroup_indent--;            \
-        assert(nv2a_vk_dgroup_indent >= 0); \
+#define NV2A_VK_DGROUP_END(...)                        \
+    do {                                               \
+        nv2a_vk_dgroup_indent--;                       \
+        NV2A_ASSERT_FATAL(nv2a_vk_dgroup_indent >= 0); \
     } while (0)
 
-#define VK_CHECK(x)                                           \
-    do {                                                      \
-        VkResult vk_result = (x);                             \
-        if (vk_result != VK_SUCCESS) {                        \
-            fprintf(stderr, "vk_result = %d\n", vk_result);   \
-        }                                                     \
-        assert(vk_result == VK_SUCCESS && "vk check failed"); \
+#define VK_CHECK(x)                                                          \
+    do {                                                                     \
+        VkResult vk_result = (x);                                            \
+        if (vk_result != VK_SUCCESS) {                                       \
+            fprintf(stderr, "vk_result = %d\n", vk_result);                  \
+            nv2a_log_fatal_error(                                            \
+                "vk check failed: vk_result = %d\nat %s:%d\n", vk_result,    \
+                __FILE__, __LINE__);                                         \
+            assert((x) &&                                                    \
+                   "A fatal error occurred. Check the xemu fatal error log " \
+                   "in your home directory for details.");                   \
+            exit(127);                                                       \
+        }                                                                    \
     } while (0)
 
 void pgraph_vk_debug_frame_terminator(void);

--- a/hw/xbox/nv2a/pgraph/vk/display.c
+++ b/hw/xbox/nv2a/pgraph/vk/display.c
@@ -20,6 +20,8 @@
 #include "renderer.h"
 #include <math.h>
 
+#include "hw/xbox/nv2a/debug_gl.h"
+
 static uint8_t *convert_texture_data__CR8YB8CB8YA8(uint8_t *data_out,
                                                    const uint8_t *data_in,
                                                    unsigned int width,
@@ -682,7 +684,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
 
     glCreateMemoryObjectsEXT(1, &d->gl_memory_obj);
     glImportMemoryWin32HandleEXT(d->gl_memory_obj, memory_requirements.size, GL_HANDLE_TYPE_OPAQUE_WIN32_EXT, d->handle);
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 
 #else
 
@@ -697,7 +699,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
     glImportMemoryFdEXT(d->gl_memory_obj, memory_requirements.size,
                         GL_HANDLE_TYPE_OPAQUE_FD_EXT, d->fd);
     assert(glIsMemoryObjectEXT(d->gl_memory_obj));
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 
 #endif // WIN32
 
@@ -711,7 +713,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
     glTexStorageMem2DEXT(GL_TEXTURE_2D, 1, gl_internal_format,
                          image_create_info.extent.width,
                          image_create_info.extent.height, d->gl_memory_obj, 0);
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 
 #endif // HAVE_EXTERNAL_MEMORY
 

--- a/hw/xbox/nv2a/pgraph/vk/surface.c
+++ b/hw/xbox/nv2a/pgraph/vk/surface.c
@@ -796,13 +796,16 @@ static void create_surface_image(PGRAPHState *pg, SurfaceBinding *surface)
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
     };
 
-    VK_CHECK(vmaCreateImage(r->allocator, &image_create_info,
-                            &alloc_create_info, &surface->image,
-                            &surface->allocation, NULL));
+    VK_CHECK_FRIENDLY(vmaCreateImage(r->allocator, &image_create_info,
+                                     &alloc_create_info, &surface->image,
+                                     &surface->allocation, NULL),
+                      "Likely out of video memory");
 
-    VK_CHECK(vmaCreateImage(r->allocator, &image_create_info,
-                            &alloc_create_info, &surface->image_scratch,
-                            &surface->allocation_scratch, NULL));
+    VK_CHECK_FRIENDLY(vmaCreateImage(r->allocator, &image_create_info,
+                                     &alloc_create_info,
+                                     &surface->image_scratch,
+                                     &surface->allocation_scratch, NULL),
+                      "Likely out of video memory");
     surface->image_scratch_current_layout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageViewCreateInfo image_view_create_info = {

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -53,6 +53,7 @@
 
 #include "hw/xbox/smbus.h" // For eject, drive tray
 #include "hw/xbox/nv2a/nv2a.h"
+#include "hw/xbox/nv2a/debug_gl.h"
 #include "ui/xemu-notifications.h"
 
 #include <stb_image.h>
@@ -824,7 +825,7 @@ static void gl_render_frame(struct xemu_console *scon)
      */
     GLuint tex = nv2a_get_framebuffer_surface();
 
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 
     if (tex == 0) {
         xemu_main_loop_lock();
@@ -861,7 +862,7 @@ static void gl_render_frame(struct xemu_console *scon)
 
     nv2a_release_framebuffer_surface();
     SDL_GL_SwapWindow(scon->real_window);
-    assert(glGetError() == GL_NO_ERROR);
+    ASSERT_NO_GL_ERROR();
 
     qatomic_set(&rendering, false);
 

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -53,6 +53,7 @@
 
 #include "hw/xbox/smbus.h" // For eject, drive tray
 #include "hw/xbox/nv2a/nv2a.h"
+#include "hw/xbox/nv2a/debug.h"
 #include "hw/xbox/nv2a/debug_gl.h"
 #include "ui/xemu-notifications.h"
 
@@ -1309,6 +1310,11 @@ int main(int argc, char **argv)
     fprintf(stderr, "xemu_version: %s\n", xemu_version);
     fprintf(stderr, "xemu_commit: %s\n", xemu_commit);
     fprintf(stderr, "xemu_date: %s\n", xemu_date);
+
+    gchar *fatal_error_log_path = g_build_filename(g_get_home_dir(), "xemu-fatal-error.log", NULL);
+    nv2a_set_fatal_error_log_path(fatal_error_log_path);
+    fprintf(stderr, "xemu fatal error log path: %s\n", fatal_error_log_path);
+    g_free(fatal_error_log_path);
 
     init_sdl_app_metadata();
 


### PR DESCRIPTION
This PR attempts to address a few problems:

* There are a number of GitHub issues that are unnecessarily confusing because users hit "Ignore" on the Windows assertion failure dialog. This adds an `exit` call after the asserts so that ignoring the assert will not allow continued operation in an undefined state
* There have been a number of users with low spec GPUs looking for help w/ VK_CHECK failures due to lack of VRAM. This adds a "friendly" version of the VK_CHECK macro that allows a contextual error message to be included (in this case suggesting use of GL due to lack of VRAM)
* Many errors are reported with screenshots of the assertion failure message rather than the log details. This writes assertion failures to a new `xemu-fatal-error.log` file in the user's home directory and mentions the existence of that file in the assertion message. It also logs actual error values to that log, so there's more data than "glGetError returned some error".


This extends PR #2453, since there is some overlap in intent, and could replace it or be rebased after that PR is merged.
