### PR TITLE
nv2a: Update Conexant field counter on vblank

### DIFF
--- a/hw/xbox/smbus.h
+++ b/hw/xbox/smbus.h
@@ -31,6 +31,12 @@ void smbus_fs454_init(I2CBus *smbus, int address);
 void smbus_xcalibur_init(I2CBus *smbus, int address);
 void smbus_adm1032_init(I2CBus *smbus, int address);
 
+/**
+ * Must be called on every vblank interrupt to update the Conexant field
+ * counter.
+ */
+void smbus_cx25871_notify_vblank(void);
+
 bool xbox_smc_avpack_to_reg(const char *avpack, uint8_t *value);
 void xbox_smc_append_avpack_hint(Error **errp);
 void xbox_smc_append_smc_version_hint(Error **errp);

--- a/hw/xbox/smbus_cx25871.c
+++ b/hw/xbox/smbus_cx25871.c
@@ -117,3 +117,13 @@ void smbus_cx25871_init(I2CBus *smbus, int address)
     qdev_prop_set_uint8(dev, "address", address);
     qdev_realize_and_unref(dev, (BusState *)smbus, &error_fatal);
 }
+
+void smbus_cx25871_notify_vblank(void)
+{
+    Object *obj = object_resolve_path_type("", TYPE_SMBUS_CX25871, NULL);
+    if (obj) {
+        SMBusCX25871Device *cx = SMBUS_CX25871(obj);
+        cx->registers[0x06] =
+            (cx->registers[0x06] & 0xF0) | ((cx->registers[0x06] + 1) & 0x03);
+    }
+}

--- a/hw/xbox/smbus_cx25871.c
+++ b/hw/xbox/smbus_cx25871.c
@@ -46,6 +46,8 @@ typedef struct SMBusCX25871Device {
     uint8_t cmd;
 } SMBusCX25871Device;
 
+static SMBusCX25871Device *conexant_device = NULL;
+
 static void smbus_cx25871_quick_cmd(SMBusDevice *dev, uint8_t read)
 {
     DPRINTF("smbus_cx25871_quick_cmd: addr=0x%02x read=%d\n", dev->i2c.address, read);
@@ -116,14 +118,22 @@ void smbus_cx25871_init(I2CBus *smbus, int address)
     dev = qdev_new(TYPE_SMBUS_CX25871);
     qdev_prop_set_uint8(dev, "address", address);
     qdev_realize_and_unref(dev, (BusState *)smbus, &error_fatal);
+
+    Object *obj = object_resolve_path_type("", TYPE_SMBUS_CX25871, NULL);
+    if (obj) {
+        conexant_device = SMBUS_CX25871(obj);
+    }
 }
 
 void smbus_cx25871_notify_vblank(void)
 {
-    Object *obj = object_resolve_path_type("", TYPE_SMBUS_CX25871, NULL);
-    if (obj) {
-        SMBusCX25871Device *cx = SMBUS_CX25871(obj);
-        cx->registers[0x06] =
-            (cx->registers[0x06] & 0xF0) | ((cx->registers[0x06] + 1) & 0x03);
+    if (unlikely(!conexant_device)) {
+        return;
     }
+
+#define FIELD_CNT_MASK 0x0F
+    conexant_device->registers[0x06] =
+        (conexant_device->registers[0x06] & (~FIELD_CNT_MASK)) |
+        ((conexant_device->registers[0x06] + 1) & FIELD_CNT_MASK);
+#undef FIELD_CNT_MASK
 }


### PR DESCRIPTION
DreamWorks: Over the Hedge performs D3D resets before playing FMVs at startup. As a part of this process, an initialization is performed that checks to see if a DirectX frame counter aligns with the counter reported by the TV encoder (at least if Conexant is the encoder, it looks like it is bypassed for other cases). If there is a mismatch, the DirectX frame counter is incremented.

This can cause an issue where the vblank interrupt handler misses the expected frame counter, causing it to fail to update the nv2a buffer read index via the NV_PGRAPH_INCREMENT PGRAPH register. In this particular title, this leads to a livelock where the pushbuffer is waiting on a buffer flip that cannot be triggered until the current buffer is marked as read via the register write.

This change populates the low nibble of the Conexant device with a simple frame counter. See https://xboxdevwiki.net/Video_Encoder for a link to the datasheet.

Unfortunately testing this on HW has proved difficult, as some state is changed during D3D Present calls that causes SMBus reads to stop providing accurate data. Thus, this change is mostly a guess at the actual behavior along with some light testing without using D3D that shows the field value incrementing from 0-3 and wrapping around forever, presumably aligned with vsync.

Fixes #1962