### PR TITLE
mcpx/vp: Dont know what to call this :^)

### DIFF
--- a/hw/xbox/mcpx/apu/vp/vp.c
+++ b/hw/xbox/mcpx/apu/vp/vp.c
@@ -1105,7 +1105,6 @@ static int voice_get_samples(MCPXAPUState *d, uint32_t v, float samples[][2],
                 cbo = lbo;
             } else {
                 cbo = ebo;
-                voice_off(d, v);
                 DPRINTF("end of buffer!\n");
             }
         }


### PR DESCRIPTION
Titles built with debug dsound assert with `Voice not in software active list`. This fixes this, I'm not sure what to actually put for a name here, it seems elsewhere the hardware (us) is what controls turning on/off voices, but here it's wrong.