### PR TITLE
Add nearest filtering method to menubar.

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -151,6 +151,10 @@ display:
     surface_scale:
       type: integer
       default: 1
+  filtering:
+    type: enum
+    values: [linear, nearest]
+    default: linear
   window:
     fullscreen_on_startup: bool
     fullscreen_exclusive: bool

--- a/ui/xui/gl-helpers.cc
+++ b/ui/xui/gl-helpers.cc
@@ -888,6 +888,17 @@ void RenderFramebuffer(GLint tex, int width, int height, bool flip, float scale[
 {
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, tex);
+    
+    switch (g_config.display.filtering) {
+    case CONFIG_DISPLAY_FILTERING_LINEAR:
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    break;
+    case CONFIG_DISPLAY_FILTERING_NEAREST:
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    break;
+    }
 
     DecalShader *s = g_framebuffer_shader;
     s->flip = flip;

--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -199,6 +199,8 @@ void ShowMainMenu()
             ImGui::SameLine();
             HelpMarker("Controls how the rendered content should be scaled "
                        "into the window");
+            ImGui::Combo("Filter Method", &g_config.display.filtering,
+                         "Linear\0Nearest\0");
             ImGui::Combo("Aspect Ratio", &g_config.display.ui.aspect_ratio,
                          "Native\0Auto\0""4:3\0""16:9\0");
             if (ImGui::MenuItem("Fullscreen", SHORTCUT_MENU_TEXT(Alt + F),


### PR DESCRIPTION
Here is something to allow the user to change to nearest filtering without having to use third party programs.
This allows you to play games at 1x resolution without the blurring from scaling.
Hopefully this useful to someone.

<img width="1047" height="756" alt="nearest-filtering" src="https://github.com/user-attachments/assets/ce9494c5-1535-4129-9b4c-347c05c25ecd" />

Animations comparing linear and nearest filtering:
![linear-nearest](https://github.com/user-attachments/assets/b3785554-241e-48e0-b2d4-c78711e738d5)

![linear-nearest-2](https://github.com/user-attachments/assets/9eec2004-ee32-4f6c-97e2-ade866770220)
