### PR TITLE
ui: Add integer scaling.

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -272,7 +272,7 @@ display:
       default: true
     fit:
       type: enum
-      values: [center, scale, stretch]
+      values: [center, integer, scale, stretch]
       default: scale
     aspect_ratio:
       type: enum

--- a/ui/xui/gl-helpers.cc
+++ b/ui/xui/gl-helpers.cc
@@ -884,7 +884,8 @@ void ScaleDimensions(int src_width, int src_height, int max_width, int max_heigh
     }
 }
 
-void RenderFramebuffer(GLint tex, int width, int height, bool flip, float scale[2])
+void RenderFramebuffer(GLint tex, int offset_x, int offset_y, int width,
+                       int height, bool flip, float scale[2])
 {
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, tex);
@@ -902,7 +903,7 @@ void RenderFramebuffer(GLint tex, int width, int height, bool flip, float scale[
 
     DecalShader *s = g_framebuffer_shader;
     s->flip = flip;
-    glViewport(0, 0, width, height);
+    glViewport(offset_x, offset_y, width, height);
     glUseProgram(s->prog);
     glBindVertexArray(s->vao);
     glUniform1i(s->flipy_loc, s->flip);
@@ -943,7 +944,8 @@ static float GetDisplayAspectRatio(int width, int height)
 void RenderFramebuffer(GLint tex, int width, int height, bool flip)
 {
     int tw, th;
-    float scale[2];
+    float scale[2] = {1.f, 1.f};
+    int offset_x = 0, offset_y = 0;
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, tex);
@@ -953,14 +955,42 @@ void RenderFramebuffer(GLint tex, int width, int height, bool flip)
     // Calculate scaling factors
     if (g_config.display.ui.fit == CONFIG_DISPLAY_UI_FIT_STRETCH) {
         // Stretch to fit
-        scale[0] = 1.0;
-        scale[1] = 1.0;
     } else if (g_config.display.ui.fit == CONFIG_DISPLAY_UI_FIT_CENTER) {
         // Centered
         float t_ratio = GetDisplayAspectRatio(tw, th);
-        scale[0] = t_ratio*(float)th/(float)width;
-        scale[1] = (float)th/(float)height;
-    } else {
+        int fb_height = th;
+        int fb_width = (int)(fb_height * t_ratio);
+        offset_x = (width - fb_width) / 2;
+        offset_y = (height - fb_height) / 2;
+        width = fb_width;
+        height = fb_height;
+    } else if (g_config.display.ui.fit == CONFIG_DISPLAY_UI_FIT_INTEGER) {
+        // Integer scale
+        float t_ratio = GetDisplayAspectRatio(tw, th);
+
+        float fb_width_with_ratio = th * t_ratio;
+        float factor_width = (float)width / fb_width_with_ratio;
+        float factor_height = (float)height / (float)th;
+        float factor_value = std::min(factor_width, factor_height);
+
+        float final_factor;
+        if (factor_value >= 1.0) {
+          // Upscale. Floor value down to integer, truncating decimals
+          final_factor = std::floor(factor_value); // 1, 2...
+        } else {
+          // Downscale. Invert the value, round it up to an integer, invert it again
+          final_factor = 1.0 / std::ceil(1.0 / factor_value); // 0.5, 0.333...
+        }
+
+        float final_height = (float)th * final_factor; // For downscaling precision
+        int fb_height = (int)final_height;
+        int fb_width = (int)(final_height * t_ratio);
+        // Center the image, update the dimensions
+        offset_x = (width - fb_width) / 2;
+        offset_y = (height - fb_height) / 2;
+        width = fb_width;
+        height = fb_height;
+      } else {
         float t_ratio = GetDisplayAspectRatio(tw, th);
         float w_ratio = (float)width/(float)height;
         if (w_ratio >= t_ratio) {
@@ -972,7 +1002,7 @@ void RenderFramebuffer(GLint tex, int width, int height, bool flip)
         }
     }
 
-    RenderFramebuffer(tex, width, height, flip, scale);
+    RenderFramebuffer(tex, offset_x, offset_y, width, height, flip, scale);
 }
 
 bool RenderFramebufferToPng(GLuint tex, bool flip, std::vector<uint8_t> &png, int max_width, int max_height)
@@ -998,7 +1028,7 @@ bool RenderFramebufferToPng(GLuint tex, bool flip, std::vector<uint8_t> &png, in
     bool blend = glIsEnabled(GL_BLEND);
     if (blend) glDisable(GL_BLEND);
     float scale[2] = {1.0, 1.0};
-    RenderFramebuffer(tex, width, height, !flip, scale);
+    RenderFramebuffer(tex, 0, 0, width, height, !flip, scale);
     if (blend) glEnable(GL_BLEND);
     glPixelStorei(GL_PACK_ROW_LENGTH, width);
     glPixelStorei(GL_PACK_IMAGE_HEIGHT, height);

--- a/ui/xui/gl-helpers.hh
+++ b/ui/xui/gl-helpers.hh
@@ -50,7 +50,7 @@ void RenderControllerPort(float frame_x, float frame_y, int i,
 void RenderXmu(float frame_x, float frame_y, uint32_t primary_color,
                uint32_t secondary_color);
 void RenderFramebuffer(GLint tex, int width, int height, bool flip);
-void RenderFramebuffer(GLint tex, int width, int height, bool flip, float scale[2]);
+void RenderFramebuffer(GLint tex, int offset_x, int offset_y, int width, int height, bool flip, float scale[2]);
 bool RenderFramebufferToPng(GLuint tex, bool flip, std::vector<uint8_t> &png, int max_width = 0, int max_height = 0);
 void SaveScreenshot(GLuint tex, bool flip);
 void ScaleDimensions(int src_width, int src_height, int max_width, int max_height, int *out_width, int *out_height);

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -824,6 +824,7 @@ void MainMenuDisplayView::Draw()
            "Enable xemu user interface animations");
     ChevronCombo("Display mode", &g_config.display.ui.fit,
                  "Center\0"
+                 "Integer\0"
                  "Scale\0"
                  "Stretch\0",
                  "Select how the framebuffer should fit or scale into the window");

--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -199,7 +199,7 @@ void ShowMainMenu()
             }
 
             ImGui::Combo("Display Mode", &g_config.display.ui.fit,
-                         "Center\0Scale\0Stretch\0");
+                         "Center\0Integer\0Scale\0Stretch\0");
             ImGui::SameLine();
             HelpMarker("Controls how the rendered content should be scaled "
                        "into the window");

--- a/ui/xui/popup-menu.cc
+++ b/ui/xui/popup-menu.cc
@@ -260,7 +260,7 @@ public:
     bool DrawItems(PopupMenuItemDelegate &nav) override
     {
         const char *values[] = {
-            "Center", "Scale", "Stretch"
+            "Center", "Integer", "Scale", "Stretch"
         };
 
         for (int i = 0; i < CONFIG_DISPLAY_UI_FIT__COUNT; i++) {


### PR DESCRIPTION
This adds integer scaling to xemu. If you want to play in fullscreen but keep the game at the intended resolution, this is useful.
Allows xemu to be more compatible with certain shaders.
Hopefully someone finds it useful.

<img width="1920" height="1080" alt="integer-scaling" src="https://github.com/user-attachments/assets/d89c2c09-c701-4d24-bdf6-807e0961e515" />

Fixes #1354
