### PR TITLE
nv2a: Implement PTIMER alarm interrupts

### DIFF
--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -560,7 +560,6 @@ static const VMStateDescription vmstate_nv2a = {
         VMSTATE_UINT32(ptimer.numerator, NV2AState),
         VMSTATE_UINT32(ptimer.denominator, NV2AState),
         VMSTATE_UINT32(ptimer.alarm_time, NV2AState),
-        VMSTATE_UINT64(ptimer.time_offset, NV2AState),
         VMSTATE_UINT32_ARRAY(pfb.regs, NV2AState, 0x1000),
         VMSTATE_UINT32(pcrtc.pending_interrupts, NV2AState),
         VMSTATE_UINT32(pcrtc.enabled_interrupts, NV2AState),
@@ -576,6 +575,7 @@ static const VMStateDescription vmstate_nv2a = {
         VMSTATE_UNUSED(1),
         VMSTATE_BOOL(pgraph.waiting_for_context_switch, NV2AState),
         VMSTATE_UINT32(ptimer.alarm_time_high, NV2AState),
+        VMSTATE_UINT64(ptimer.time_offset, NV2AState),
         VMSTATE_END_OF_LIST()
     },
 };

--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -329,6 +329,7 @@ static void nv2a_reset(NV2AState *d)
     d->pfifo.pending_interrupts = 0;
     d->ptimer.pending_interrupts = 0;
     d->ptimer.alarm_time = 0xFFFFFFFF;
+    d->ptimer.time_offset = 0;
     d->pcrtc.pending_interrupts = 0;
 
     for (int i = 0; i < 256; i++) {
@@ -453,7 +454,7 @@ const VMStateDescription vmstate_nv2a_pgraph_vertex_attributes = {
 
 static const VMStateDescription vmstate_nv2a = {
     .name = "nv2a",
-    .version_id = 3,
+    .version_id = 4,
     .minimum_version_id = 1,
     .post_save = nv2a_post_save,
     .post_load = nv2a_post_load,
@@ -559,6 +560,8 @@ static const VMStateDescription vmstate_nv2a = {
         VMSTATE_UINT32(ptimer.numerator, NV2AState),
         VMSTATE_UINT32(ptimer.denominator, NV2AState),
         VMSTATE_UINT32(ptimer.alarm_time, NV2AState),
+        VMSTATE_UINT32(ptimer.alarm_time_high, NV2AState),
+        VMSTATE_UINT64(ptimer.time_offset, NV2AState),
         VMSTATE_UINT32_ARRAY(pfb.regs, NV2AState, 0x1000),
         VMSTATE_UINT32(pcrtc.pending_interrupts, NV2AState),
         VMSTATE_UINT32(pcrtc.enabled_interrupts, NV2AState),

--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -45,6 +45,14 @@ void nv2a_update_irq(NV2AState *d)
         d->pmc.pending_interrupts &= ~NV_PMC_INTR_0_PGRAPH;
     }
 
+    /* PTIMER */
+    ptimer_process_alarm(d);
+    if (d->ptimer.pending_interrupts & d->ptimer.enabled_interrupts) {
+        d->pmc.pending_interrupts |= NV_PMC_INTR_0_PTIMER_PENDING;
+    } else {
+        d->pmc.pending_interrupts &= ~NV_PMC_INTR_0_PTIMER_PENDING;
+    }
+
     if (d->pmc.pending_interrupts && d->pmc.enabled_interrupts) {
         trace_nv2a_irq(d->pmc.pending_interrupts);
         pci_irq_assert(PCI_DEVICE(d));
@@ -320,6 +328,7 @@ static void nv2a_reset(NV2AState *d)
     d->pmc.pending_interrupts = 0;
     d->pfifo.pending_interrupts = 0;
     d->ptimer.pending_interrupts = 0;
+    d->ptimer.alarm_time = 0xFFFFFFFF;
     d->pcrtc.pending_interrupts = 0;
 
     for (int i = 0; i < 256; i++) {

--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -47,9 +47,9 @@ void nv2a_update_irq(NV2AState *d)
 
     /* PTIMER */
     if (d->ptimer.pending_interrupts & d->ptimer.enabled_interrupts) {
-        d->pmc.pending_interrupts |= NV_PMC_INTR_0_PTIMER_PENDING;
+        d->pmc.pending_interrupts |= NV_PMC_INTR_0_PTIMER;
     } else {
-        d->pmc.pending_interrupts &= ~NV_PMC_INTR_0_PTIMER_PENDING;
+        d->pmc.pending_interrupts &= ~NV_PMC_INTR_0_PTIMER;
     }
 
     if (d->pmc.pending_interrupts && d->pmc.enabled_interrupts) {
@@ -457,8 +457,6 @@ static const VMStateDescription vmstate_nv2a = {
     .post_save = nv2a_post_save,
     .post_load = nv2a_post_load,
     .pre_load = nv2a_pre_load,
-    // NOTE: New fields should be appended, regardless of similarity to existing
-    //       fields.
     .fields = (VMStateField[]) {
         // FIXME: Split this up into subsections
         VMSTATE_PCI_DEVICE(parent_obj, NV2AState),

--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -557,7 +557,7 @@ static const VMStateDescription vmstate_nv2a = {
         VMSTATE_UINT32(ptimer.enabled_interrupts, NV2AState),
         VMSTATE_UINT32(ptimer.numerator, NV2AState),
         VMSTATE_UINT32(ptimer.denominator, NV2AState),
-        VMSTATE_UINT32(ptimer.alarm_time, NV2AState),
+        VMSTATE_UNUSED(4),
         VMSTATE_UINT32_ARRAY(pfb.regs, NV2AState, 0x1000),
         VMSTATE_UINT32(pcrtc.pending_interrupts, NV2AState),
         VMSTATE_UINT32(pcrtc.enabled_interrupts, NV2AState),
@@ -572,8 +572,9 @@ static const VMStateDescription vmstate_nv2a = {
         VMSTATE_BOOL(pgraph.waiting_for_nop, NV2AState),
         VMSTATE_UNUSED(1),
         VMSTATE_BOOL(pgraph.waiting_for_context_switch, NV2AState),
-        VMSTATE_UINT32(ptimer.alarm_time_high, NV2AState),
-        VMSTATE_UINT64(ptimer.time_offset, NV2AState),
+        VMSTATE_UINT64_V(ptimer.alarm_time, NV2AState, 4),
+        VMSTATE_UINT64_V(ptimer.time_offset, NV2AState, 4),
+        VMSTATE_TIMER_V(ptimer.timer, NV2AState, 4),
         VMSTATE_END_OF_LIST()
     },
 };

--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -117,6 +117,7 @@ typedef struct NV2AState {
         uint32_t alarm_time;
         uint32_t alarm_time_high;
         uint64_t time_offset;
+        QEMUTimer timer;
     } ptimer;
 
     struct {
@@ -222,6 +223,7 @@ void *nv_dma_map(NV2AState *d, hwaddr dma_obj_address, hwaddr *len);
 hwaddr nv_clip_gpu_tile_blit(NV2AState *d, hwaddr blit_base_address,
                              hwaddr len);
 
-void ptimer_process_alarm(NV2AState *d);
+void ptimer_init(NV2AState *d);
+void ptimer_reset(NV2AState *d);
 
 #endif

--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -115,6 +115,8 @@ typedef struct NV2AState {
         uint32_t numerator;
         uint32_t denominator;
         uint32_t alarm_time;
+        uint32_t alarm_time_high;
+        uint64_t time_offset;
     } ptimer;
 
     struct {

--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -220,4 +220,6 @@ void *nv_dma_map(NV2AState *d, hwaddr dma_obj_address, hwaddr *len);
 hwaddr nv_clip_gpu_tile_blit(NV2AState *d, hwaddr blit_base_address,
                              hwaddr len);
 
+void ptimer_process_alarm(NV2AState *d);
+
 #endif

--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -114,8 +114,7 @@ typedef struct NV2AState {
         uint32_t enabled_interrupts;
         uint32_t numerator;
         uint32_t denominator;
-        uint32_t alarm_time;
-        uint32_t alarm_time_high;
+        uint64_t alarm_time;
         uint64_t time_offset;
         QEMUTimer timer;
     } ptimer;

--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -63,6 +63,7 @@
 #define NV_PMC_INTR_0                                    0x00000100
 #   define NV_PMC_INTR_0_PFIFO                                 (1 << 8)
 #   define NV_PMC_INTR_0_PGRAPH                               (1 << 12)
+#   define NV_PMC_INTR_0_PTIMER_PENDING                       (1 << 20)
 #   define NV_PMC_INTR_0_PCRTC                                (1 << 24)
 #   define NV_PMC_INTR_0_PBUS                                 (1 << 28)
 #   define NV_PMC_INTR_0_SOFTWARE                             (1 << 31)

--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -63,7 +63,7 @@
 #define NV_PMC_INTR_0                                    0x00000100
 #   define NV_PMC_INTR_0_PFIFO                                 (1 << 8)
 #   define NV_PMC_INTR_0_PGRAPH                               (1 << 12)
-#   define NV_PMC_INTR_0_PTIMER_PENDING                       (1 << 20)
+#   define NV_PMC_INTR_0_PTIMER                               (1 << 20)
 #   define NV_PMC_INTR_0_PCRTC                                (1 << 24)
 #   define NV_PMC_INTR_0_PBUS                                 (1 << 28)
 #   define NV_PMC_INTR_0_SOFTWARE                             (1 << 31)

--- a/hw/xbox/nv2a/ptimer.c
+++ b/hw/xbox/nv2a/ptimer.c
@@ -22,15 +22,16 @@
 
 #include "nv2a_int.h"
 
-#define INVALID_TIMER_VALUE 0xffffffff
 #define CLOCK_HIGH_MASK 0x1fffffff
 #define CLOCK_LOW_MASK 0x7ffffff
+#define ALARM_MASK 0xffffffe0
 
 static void ptimer_alarm_fired(void *opaque);
 
 void ptimer_reset(NV2AState *d)
 {
-    d->ptimer.alarm_time = INVALID_TIMER_VALUE;
+    d->ptimer.alarm_time = 0;
+    d->ptimer.alarm_time_high = 0;
     d->ptimer.time_offset = 0;
     timer_del(&d->ptimer.timer);
 }
@@ -49,10 +50,12 @@ static uint64_t ptimer_get_absolute_clock(NV2AState *d)
                     d->ptimer.denominator, d->ptimer.numerator);
 }
 
-//! Returns the NV2A time relative to the last time register modification.
-static uint64_t ptimer_get_relative_clock(NV2AState *d, uint64_t absolute_clock)
+//! Returns the NV2A time adjusted by the last time register modification and
+//! shifted into range.
+static uint64_t get_ptimer_clock(NV2AState *d, uint64_t absolute_clock)
 {
-    return absolute_clock + d->ptimer.time_offset;
+    return ((absolute_clock + d->ptimer.time_offset) << 5) &
+           0x1fffffffffffffffLL;
 }
 
 static uint64_t ptimer_ticks_to_ns(NV2AState *d, uint64_t ticks)
@@ -65,52 +68,41 @@ static uint64_t ptimer_ticks_to_ns(NV2AState *d, uint64_t ticks)
 
 static void schedule_qemu_timer(NV2AState *d)
 {
-    if (d->ptimer.alarm_time == INVALID_TIMER_VALUE) {
-        timer_del(&d->ptimer.timer);
+    if (!(d->ptimer.enabled_interrupts & NV_PTIMER_INTR_EN_0_ALARM)) {
         return;
     }
 
-    uint64_t now_abs = ptimer_get_absolute_clock(d);
-    uint64_t now_guest = ptimer_get_relative_clock(d, now_abs);
+    uint64_t now = get_ptimer_clock(d, ptimer_get_absolute_clock(d));
+    uint64_t alarm_time = (uint64_t)d->ptimer.alarm_time +
+                          ((uint64_t)d->ptimer.alarm_time_high << 32);
 
-    uint64_t alarm_val_shifted = d->ptimer.alarm_time;
-    uint64_t alarm_ticks_low = (alarm_val_shifted >> 5) & CLOCK_LOW_MASK;
-    uint64_t alarm_ticks_high = d->ptimer.alarm_time_high & CLOCK_HIGH_MASK;
-
-    uint64_t target_guest = (alarm_ticks_high << 27) | alarm_ticks_low;
-
-    if (target_guest <= now_guest) {
-        timer_mod(&d->ptimer.timer, qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL));
-    } else {
-        uint64_t diff_ticks = target_guest - now_guest;
-        uint64_t diff_ns = ptimer_ticks_to_ns(d, diff_ticks);
-
-        timer_mod(&d->ptimer.timer,
-                  qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) + diff_ns);
+    uint64_t diff_ns = 0;
+    if (alarm_time > now) {
+        diff_ns = ptimer_ticks_to_ns(d, (alarm_time - now) >> 5);
     }
+    timer_mod(&d->ptimer.timer,
+              qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) + diff_ns);
 }
 
 static void ptimer_alarm_fired(void *opaque)
 {
     NV2AState *d = (NV2AState *)opaque;
 
-    if (d->ptimer.alarm_time == INVALID_TIMER_VALUE) {
+    if (!(d->ptimer.enabled_interrupts & NV_PTIMER_INTR_EN_0_ALARM)) {
         return;
     }
 
-    uint64_t now = ptimer_get_absolute_clock(d);
-    uint64_t guest_clock = ptimer_get_relative_clock(d, now);
+    uint64_t now = get_ptimer_clock(d, ptimer_get_absolute_clock(d));
+    uint64_t alarm_time =
+        d->ptimer.alarm_time + ((uint64_t)d->ptimer.alarm_time_high << 32);
 
-    uint32_t current_time_low = (guest_clock & CLOCK_LOW_MASK) << 5;
-    uint32_t current_time_high = (guest_clock >> 27) & CLOCK_HIGH_MASK;
-
-    if (d->ptimer.alarm_time <= current_time_low ||
-        d->ptimer.alarm_time_high < current_time_high) {
+    if (alarm_time <= now) {
         d->ptimer.pending_interrupts |= NV_PTIMER_INTR_0_ALARM;
-        d->ptimer.alarm_time = INVALID_TIMER_VALUE;
-
+        d->ptimer.alarm_time_high = now >> 32;
         nv2a_update_irq(d);
     }
+
+    schedule_qemu_timer(d);
 }
 
 uint64_t ptimer_read(void *opaque, hwaddr addr, unsigned int size)
@@ -132,15 +124,16 @@ uint64_t ptimer_read(void *opaque, hwaddr addr, unsigned int size)
         r = d->ptimer.denominator;
         break;
     case NV_PTIMER_TIME_0: {
-        uint64_t now =
-            ptimer_get_relative_clock(d, ptimer_get_absolute_clock(d));
-        r = (now & CLOCK_LOW_MASK) << 5;
+        uint64_t now = get_ptimer_clock(d, ptimer_get_absolute_clock(d));
+        r = now & 0xffffffff;
     } break;
     case NV_PTIMER_TIME_1: {
-        uint64_t now =
-            ptimer_get_relative_clock(d, ptimer_get_absolute_clock(d));
-        r = (now >> 27) & CLOCK_HIGH_MASK;
+        uint64_t now = get_ptimer_clock(d, ptimer_get_absolute_clock(d));
+        r = (now >> 32) & CLOCK_HIGH_MASK;
     } break;
+    case NV_PTIMER_ALARM_0:
+        r = d->ptimer.alarm_time;
+        break;
     default:
         break;
     }
@@ -162,47 +155,46 @@ void ptimer_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
         break;
     case NV_PTIMER_INTR_EN_0:
         d->ptimer.enabled_interrupts = val;
+        if (val) {
+            schedule_qemu_timer(d);
+        } else {
+            timer_del(&d->ptimer.timer);
+        }
         nv2a_update_irq(d);
         break;
     case NV_PTIMER_DENOMINATOR:
         d->ptimer.denominator = val;
-        assert(d->ptimer.alarm_time == INVALID_TIMER_VALUE);
+        schedule_qemu_timer(d);
         break;
     case NV_PTIMER_NUMERATOR:
         d->ptimer.numerator = val;
-        assert(d->ptimer.alarm_time == INVALID_TIMER_VALUE);
+        schedule_qemu_timer(d);
         break;
     case NV_PTIMER_ALARM_0: {
-        uint64_t now =
-            ptimer_get_relative_clock(d, ptimer_get_absolute_clock(d));
-        d->ptimer.alarm_time = val;
-        d->ptimer.alarm_time_high = (now >> 27) & CLOCK_HIGH_MASK;
+        uint64_t now = get_ptimer_clock(d, ptimer_get_absolute_clock(d));
 
-        if (d->ptimer.alarm_time == INVALID_TIMER_VALUE) {
-            timer_del(&d->ptimer.timer);
-        } else {
-            schedule_qemu_timer(d);
+        d->ptimer.alarm_time = val & ALARM_MASK;
+        d->ptimer.alarm_time_high = (now >> 32);
+        if (val <= (now & ALARM_MASK)) {
+            ++d->ptimer.alarm_time_high;
         }
+        schedule_qemu_timer(d);
     } break;
     case NV_PTIMER_TIME_0: {
         uint64_t absolute_clock = ptimer_get_absolute_clock(d);
-        uint64_t guest_clock = ptimer_get_relative_clock(d, absolute_clock);
-        uint64_t target_guest =
-            (guest_clock & ~CLOCK_LOW_MASK) | ((val >> 5) & CLOCK_LOW_MASK);
-        d->ptimer.time_offset = target_guest - absolute_clock;
-        if (d->ptimer.alarm_time != INVALID_TIMER_VALUE) {
-            schedule_qemu_timer(d);
-        }
+        uint64_t now = get_ptimer_clock(d, absolute_clock);
+        uint64_t target_relative =
+            (now & 0xffffffff00000000LL) | (((val >> 5) & CLOCK_LOW_MASK) << 5);
+        d->ptimer.time_offset = target_relative - absolute_clock;
+        schedule_qemu_timer(d);
     } break;
     case NV_PTIMER_TIME_1: {
         uint64_t absolute_clock = ptimer_get_absolute_clock(d);
-        uint64_t guest_clock = ptimer_get_relative_clock(d, absolute_clock);
-        uint64_t target_guest =
-            (guest_clock & CLOCK_LOW_MASK) | ((val & CLOCK_HIGH_MASK) << 27);
-        d->ptimer.time_offset = target_guest - absolute_clock;
-        if (d->ptimer.alarm_time != INVALID_TIMER_VALUE) {
-            schedule_qemu_timer(d);
-        }
+        uint64_t now = get_ptimer_clock(d, absolute_clock);
+        uint64_t target_relative =
+            (now & 0xffffffff) | ((val & CLOCK_HIGH_MASK) << 32);
+        d->ptimer.time_offset = target_relative - absolute_clock;
+        schedule_qemu_timer(d);
     } break;
     default:
         break;

--- a/hw/xbox/nv2a/ptimer.c
+++ b/hw/xbox/nv2a/ptimer.c
@@ -1,9 +1,10 @@
 /*
  * QEMU Geforce NV2A implementation
+ * PTIMER - time measurement and time-based alarms
  *
  * Copyright (c) 2012 espes
  * Copyright (c) 2015 Jannik Vogel
- * Copyright (c) 2018-2021 Matt Borgerson
+ * Copyright (c) 2018-2025 Matt Borgerson
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,31 +22,84 @@
 
 #include "nv2a_int.h"
 
+#define INVALID_TIMER_VALUE 0xffffffff
 #define CLOCK_HIGH_MASK 0x1fffffff
 #define CLOCK_LOW_MASK 0x7ffffff
 
-/* PTIMER - time measurement and time-based alarms */
-static uint64_t ptimer_get_host_clock(NV2AState *d)
+static void ptimer_alarm_fired(void *opaque);
+
+void ptimer_reset(NV2AState *d)
+{
+    d->ptimer.alarm_time = INVALID_TIMER_VALUE;
+    d->ptimer.time_offset = 0;
+    timer_del(&d->ptimer.timer);
+}
+
+void ptimer_init(NV2AState *d)
+{
+    timer_init_ns(&d->ptimer.timer, QEMU_CLOCK_VIRTUAL, ptimer_alarm_fired, d);
+    ptimer_reset(d);
+}
+
+static uint64_t ptimer_get_absolute_clock(NV2AState *d)
 {
     return muldiv64(muldiv64(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL),
                              d->pramdac.core_clock_freq,
                              NANOSECONDS_PER_SECOND),
-                    d->ptimer.denominator,
-                    d->ptimer.numerator);
+                    d->ptimer.denominator, d->ptimer.numerator);
 }
 
-static uint64_t ptimer_get_guest_clock(NV2AState *d, uint64_t host_clock)
+//! Returns the NV2A time relative to the last time register modification.
+static uint64_t ptimer_get_relative_clock(NV2AState *d, uint64_t absolute_clock)
 {
-    return host_clock + d->ptimer.time_offset;
+    return absolute_clock + d->ptimer.time_offset;
 }
 
-void ptimer_process_alarm(NV2AState *d)
+static uint64_t ptimer_ticks_to_ns(NV2AState *d, uint64_t ticks)
 {
-    if (d->ptimer.alarm_time == 0xFFFFFFFF) {
+    uint64_t gpu_ticks =
+        muldiv64(ticks, d->ptimer.numerator, d->ptimer.denominator);
+    return muldiv64(gpu_ticks, NANOSECONDS_PER_SECOND,
+                    d->pramdac.core_clock_freq);
+}
+
+static void schedule_qemu_timer(NV2AState *d)
+{
+    if (d->ptimer.alarm_time == INVALID_TIMER_VALUE) {
+        timer_del(&d->ptimer.timer);
         return;
     }
-    uint64_t now = ptimer_get_host_clock(d);
-    uint64_t guest_clock = ptimer_get_guest_clock(d, now);
+
+    uint64_t now_abs = ptimer_get_absolute_clock(d);
+    uint64_t now_guest = ptimer_get_relative_clock(d, now_abs);
+
+    uint64_t alarm_val_shifted = d->ptimer.alarm_time;
+    uint64_t alarm_ticks_low = (alarm_val_shifted >> 5) & CLOCK_LOW_MASK;
+    uint64_t alarm_ticks_high = d->ptimer.alarm_time_high & CLOCK_HIGH_MASK;
+
+    uint64_t target_guest = (alarm_ticks_high << 27) | alarm_ticks_low;
+
+    if (target_guest <= now_guest) {
+        timer_mod(&d->ptimer.timer, qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL));
+    } else {
+        uint64_t diff_ticks = target_guest - now_guest;
+        uint64_t diff_ns = ptimer_ticks_to_ns(d, diff_ticks);
+
+        timer_mod(&d->ptimer.timer,
+                  qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) + diff_ns);
+    }
+}
+
+static void ptimer_alarm_fired(void *opaque)
+{
+    NV2AState *d = (NV2AState *)opaque;
+
+    if (d->ptimer.alarm_time == INVALID_TIMER_VALUE) {
+        return;
+    }
+
+    uint64_t now = ptimer_get_absolute_clock(d);
+    uint64_t guest_clock = ptimer_get_relative_clock(d, now);
 
     uint32_t current_time_low = (guest_clock & CLOCK_LOW_MASK) << 5;
     uint32_t current_time_high = (guest_clock >> 27) & CLOCK_HIGH_MASK;
@@ -53,7 +107,9 @@ void ptimer_process_alarm(NV2AState *d)
     if (d->ptimer.alarm_time <= current_time_low ||
         d->ptimer.alarm_time_high < current_time_high) {
         d->ptimer.pending_interrupts |= NV_PTIMER_INTR_0_ALARM;
-        d->ptimer.alarm_time = 0xFFFFFFFF;
+        d->ptimer.alarm_time = INVALID_TIMER_VALUE;
+
+        nv2a_update_irq(d);
     }
 }
 
@@ -76,11 +132,13 @@ uint64_t ptimer_read(void *opaque, hwaddr addr, unsigned int size)
         r = d->ptimer.denominator;
         break;
     case NV_PTIMER_TIME_0: {
-        uint64_t now = ptimer_get_guest_clock(d, ptimer_get_host_clock(d));
+        uint64_t now =
+            ptimer_get_relative_clock(d, ptimer_get_absolute_clock(d));
         r = (now & CLOCK_LOW_MASK) << 5;
     } break;
     case NV_PTIMER_TIME_1: {
-        uint64_t now = ptimer_get_guest_clock(d, ptimer_get_host_clock(d));
+        uint64_t now =
+            ptimer_get_relative_clock(d, ptimer_get_absolute_clock(d));
         r = (now >> 27) & CLOCK_HIGH_MASK;
     } break;
     default:
@@ -108,28 +166,43 @@ void ptimer_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
         break;
     case NV_PTIMER_DENOMINATOR:
         d->ptimer.denominator = val;
+        assert(d->ptimer.alarm_time == INVALID_TIMER_VALUE);
         break;
     case NV_PTIMER_NUMERATOR:
         d->ptimer.numerator = val;
+        assert(d->ptimer.alarm_time == INVALID_TIMER_VALUE);
         break;
     case NV_PTIMER_ALARM_0: {
-        uint64_t now = ptimer_get_guest_clock(d, ptimer_get_host_clock(d));
+        uint64_t now =
+            ptimer_get_relative_clock(d, ptimer_get_absolute_clock(d));
         d->ptimer.alarm_time = val;
         d->ptimer.alarm_time_high = (now >> 27) & CLOCK_HIGH_MASK;
+
+        if (d->ptimer.alarm_time == INVALID_TIMER_VALUE) {
+            timer_del(&d->ptimer.timer);
+        } else {
+            schedule_qemu_timer(d);
+        }
     } break;
     case NV_PTIMER_TIME_0: {
-        uint64_t host_clock = ptimer_get_host_clock(d);
-        uint64_t guest_clock = ptimer_get_guest_clock(d, host_clock);
+        uint64_t absolute_clock = ptimer_get_absolute_clock(d);
+        uint64_t guest_clock = ptimer_get_relative_clock(d, absolute_clock);
         uint64_t target_guest =
             (guest_clock & ~CLOCK_LOW_MASK) | ((val >> 5) & CLOCK_LOW_MASK);
-        d->ptimer.time_offset = target_guest - host_clock;
+        d->ptimer.time_offset = target_guest - absolute_clock;
+        if (d->ptimer.alarm_time != INVALID_TIMER_VALUE) {
+            schedule_qemu_timer(d);
+        }
     } break;
     case NV_PTIMER_TIME_1: {
-        uint64_t host_clock = ptimer_get_host_clock(d);
-        uint64_t guest_clock = ptimer_get_guest_clock(d, host_clock);
+        uint64_t absolute_clock = ptimer_get_absolute_clock(d);
+        uint64_t guest_clock = ptimer_get_relative_clock(d, absolute_clock);
         uint64_t target_guest =
             (guest_clock & CLOCK_LOW_MASK) | ((val & CLOCK_HIGH_MASK) << 27);
-        d->ptimer.time_offset = target_guest - host_clock;
+        d->ptimer.time_offset = target_guest - absolute_clock;
+        if (d->ptimer.alarm_time != INVALID_TIMER_VALUE) {
+            schedule_qemu_timer(d);
+        }
     } break;
     default:
         break;

--- a/hw/xbox/nv2a/ptimer.c
+++ b/hw/xbox/nv2a/ptimer.c
@@ -31,6 +31,19 @@ static uint64_t ptimer_get_clock(NV2AState *d)
                     d->ptimer.numerator);
 }
 
+void ptimer_process_alarm(NV2AState *d)
+{
+    if (d->ptimer.alarm_time == 0xFFFFFFFF) {
+        return;
+    }
+
+    uint32_t current_time_low = (ptimer_get_clock(d) & 0x7ffffff) << 5;
+    if (d->ptimer.alarm_time <= current_time_low) {
+        d->ptimer.pending_interrupts |= NV_PTIMER_INTR_0_ALARM;
+        d->ptimer.alarm_time = 0xFFFFFFFF;
+    }
+}
+
 uint64_t ptimer_read(void *opaque, hwaddr addr, unsigned int size)
 {
     NV2AState *d = opaque;

--- a/hw/xbox/nv2a/ptimer.c
+++ b/hw/xbox/nv2a/ptimer.c
@@ -21,8 +21,11 @@
 
 #include "nv2a_int.h"
 
+#define CLOCK_HIGH_MASK 0x1fffffff
+#define CLOCK_LOW_MASK 0x7ffffff
+
 /* PTIMER - time measurement and time-based alarms */
-static uint64_t ptimer_get_clock(NV2AState *d)
+static uint64_t ptimer_get_host_clock(NV2AState *d)
 {
     return muldiv64(muldiv64(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL),
                              d->pramdac.core_clock_freq,
@@ -31,14 +34,24 @@ static uint64_t ptimer_get_clock(NV2AState *d)
                     d->ptimer.numerator);
 }
 
+static uint64_t ptimer_get_guest_clock(NV2AState *d, uint64_t host_clock)
+{
+    return host_clock + d->ptimer.time_offset;
+}
+
 void ptimer_process_alarm(NV2AState *d)
 {
     if (d->ptimer.alarm_time == 0xFFFFFFFF) {
         return;
     }
+    uint64_t now = ptimer_get_host_clock(d);
+    uint64_t guest_clock = ptimer_get_guest_clock(d, now);
 
-    uint32_t current_time_low = (ptimer_get_clock(d) & 0x7ffffff) << 5;
-    if (d->ptimer.alarm_time <= current_time_low) {
+    uint32_t current_time_low = (guest_clock & CLOCK_LOW_MASK) << 5;
+    uint32_t current_time_high = (guest_clock >> 27) & CLOCK_HIGH_MASK;
+
+    if (d->ptimer.alarm_time <= current_time_low ||
+        d->ptimer.alarm_time_high < current_time_high) {
         d->ptimer.pending_interrupts |= NV_PTIMER_INTR_0_ALARM;
         d->ptimer.alarm_time = 0xFFFFFFFF;
     }
@@ -62,12 +75,14 @@ uint64_t ptimer_read(void *opaque, hwaddr addr, unsigned int size)
     case NV_PTIMER_DENOMINATOR:
         r = d->ptimer.denominator;
         break;
-    case NV_PTIMER_TIME_0:
-        r = (ptimer_get_clock(d) & 0x7ffffff) << 5;
-        break;
-    case NV_PTIMER_TIME_1:
-        r = (ptimer_get_clock(d) >> 27) & 0x1fffffff;
-        break;
+    case NV_PTIMER_TIME_0: {
+        uint64_t now = ptimer_get_guest_clock(d, ptimer_get_host_clock(d));
+        r = (now & CLOCK_LOW_MASK) << 5;
+    } break;
+    case NV_PTIMER_TIME_1: {
+        uint64_t now = ptimer_get_guest_clock(d, ptimer_get_host_clock(d));
+        r = (now >> 27) & CLOCK_HIGH_MASK;
+    } break;
     default:
         break;
     }
@@ -97,9 +112,25 @@ void ptimer_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
     case NV_PTIMER_NUMERATOR:
         d->ptimer.numerator = val;
         break;
-    case NV_PTIMER_ALARM_0:
+    case NV_PTIMER_ALARM_0: {
+        uint64_t now = ptimer_get_guest_clock(d, ptimer_get_host_clock(d));
         d->ptimer.alarm_time = val;
-        break;
+        d->ptimer.alarm_time_high = (now >> 27) & CLOCK_HIGH_MASK;
+    } break;
+    case NV_PTIMER_TIME_0: {
+        uint64_t host_clock = ptimer_get_host_clock(d);
+        uint64_t guest_clock = ptimer_get_guest_clock(d, host_clock);
+        uint64_t target_guest =
+            (guest_clock & ~CLOCK_LOW_MASK) | ((val >> 5) & CLOCK_LOW_MASK);
+        d->ptimer.time_offset = target_guest - host_clock;
+    } break;
+    case NV_PTIMER_TIME_1: {
+        uint64_t host_clock = ptimer_get_host_clock(d);
+        uint64_t guest_clock = ptimer_get_guest_clock(d, host_clock);
+        uint64_t target_guest =
+            (guest_clock & CLOCK_LOW_MASK) | ((val & CLOCK_HIGH_MASK) << 27);
+        d->ptimer.time_offset = target_guest - host_clock;
+    } break;
     default:
         break;
     }

--- a/hw/xbox/nv2a/ptimer.c
+++ b/hw/xbox/nv2a/ptimer.c
@@ -22,16 +22,36 @@
 
 #include "nv2a_int.h"
 
-#define CLOCK_HIGH_MASK 0x1fffffff
-#define CLOCK_LOW_MASK 0x7ffffff
-#define ALARM_MASK 0xffffffe0
+#define CLOCK_HIGH_MASK 0x1fffffffULL
+#define ALARM_MASK 0xffffffe0ULL
+
+#define PTIMER_REG_TIME_HIGH_MASK ((uint64_t)CLOCK_HIGH_MASK << 32)
+#define PTIMER_REG_TIME_LOW_MASK 0xffffffffULL
+#define PTIMER_REG_TIME_MASK (PTIMER_REG_TIME_HIGH_MASK | ALARM_MASK)
+
+#define PTIMER_INTERNAL_TIME_MASK (PTIMER_REG_TIME_MASK >> 5)
+
+#define PTIMER_INTERNAL_TO_REG_TIME(internal_ticks) \
+    (((uint64_t)(internal_ticks) << 5) & PTIMER_REG_TIME_MASK)
+
+#define PTIMER_REG_TO_INTERNAL_TIME(reg_time) \
+    (((uint64_t)(reg_time) >> 5) & PTIMER_INTERNAL_TIME_MASK)
+
+#define PTIMER_MAKE_REG_TIME(time_1, time_0)          \
+    ((((uint64_t)(time_1) & CLOCK_HIGH_MASK) << 32) | \
+     ((uint64_t)(time_0) & PTIMER_REG_TIME_LOW_MASK))
+
+#define PTIMER_REG_TIME_GET_TIME_0(reg_time) \
+    ((uint32_t)((reg_time) & PTIMER_REG_TIME_LOW_MASK))
+
+#define PTIMER_REG_TIME_GET_TIME_1(reg_time) \
+    ((uint32_t)(((reg_time) >> 32) & CLOCK_HIGH_MASK))
 
 static void ptimer_alarm_fired(void *opaque);
 
 void ptimer_reset(NV2AState *d)
 {
     d->ptimer.alarm_time = 0;
-    d->ptimer.alarm_time_high = 0;
     d->ptimer.time_offset = 0;
     timer_del(&d->ptimer.timer);
 }
@@ -50,36 +70,59 @@ static uint64_t ptimer_get_absolute_clock(NV2AState *d)
                     d->ptimer.denominator, d->ptimer.numerator);
 }
 
-//! Returns the NV2A time adjusted by the last time register modification and
-//! shifted into range.
-static uint64_t get_ptimer_clock(NV2AState *d, uint64_t absolute_clock)
+static inline uint64_t get_internal_clock(NV2AState *d, uint64_t absolute_clock)
 {
-    return ((absolute_clock + d->ptimer.time_offset) << 5) &
-           0x1fffffffffffffffLL;
+    return (absolute_clock + d->ptimer.time_offset) & PTIMER_INTERNAL_TIME_MASK;
 }
 
-static uint64_t ptimer_ticks_to_ns(NV2AState *d, uint64_t ticks)
+static inline uint64_t get_reg_time(NV2AState *d)
+{
+    uint64_t internal_clock =
+        get_internal_clock(d, ptimer_get_absolute_clock(d));
+    return PTIMER_INTERNAL_TO_REG_TIME(internal_clock);
+}
+
+static uint64_t ptimer_ticks_to_ns(NV2AState *d, uint64_t internal_ticks)
 {
     uint64_t gpu_ticks =
-        muldiv64(ticks, d->ptimer.numerator, d->ptimer.denominator);
+        muldiv64(internal_ticks, d->ptimer.numerator, d->ptimer.denominator);
     return muldiv64(gpu_ticks, NANOSECONDS_PER_SECOND,
                     d->pramdac.core_clock_freq);
 }
 
+static inline uint64_t ptimer_alarm_distance(uint64_t reg_now,
+                                             uint64_t alarm_time)
+{
+    uint64_t diff = (alarm_time - reg_now) & PTIMER_REG_TIME_MASK;
+    if (diff > (PTIMER_REG_TIME_MASK >> 1)) {
+        return 0;
+    }
+    return diff;
+}
+
+static inline bool is_alarm_reached(uint64_t reg_now, uint64_t alarm_time)
+{
+    return !ptimer_alarm_distance(reg_now, alarm_time);
+}
+
+static inline uint64_t advance_alarm_epoch(uint64_t reg_time)
+{
+    return (reg_time + (1ULL << 32)) & PTIMER_REG_TIME_MASK;
+}
+
 static void schedule_qemu_timer(NV2AState *d)
 {
-    if (!(d->ptimer.enabled_interrupts & NV_PTIMER_INTR_EN_0_ALARM)) {
-        return;
-    }
-
-    uint64_t now = get_ptimer_clock(d, ptimer_get_absolute_clock(d));
-    uint64_t alarm_time = (uint64_t)d->ptimer.alarm_time +
-                          ((uint64_t)d->ptimer.alarm_time_high << 32);
-
+    uint64_t reg_now = get_reg_time(d);
+    uint64_t diff_reg_time =
+        ptimer_alarm_distance(reg_now, d->ptimer.alarm_time);
     uint64_t diff_ns = 0;
-    if (alarm_time > now) {
-        diff_ns = ptimer_ticks_to_ns(d, (alarm_time - now) >> 5);
+
+    if (diff_reg_time > 0) {
+        uint64_t internal_diff_ticks =
+            PTIMER_REG_TO_INTERNAL_TIME(diff_reg_time);
+        diff_ns = ptimer_ticks_to_ns(d, internal_diff_ticks);
     }
+
     timer_mod(&d->ptimer.timer,
               qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) + diff_ns);
 }
@@ -87,18 +130,11 @@ static void schedule_qemu_timer(NV2AState *d)
 static void ptimer_alarm_fired(void *opaque)
 {
     NV2AState *d = (NV2AState *)opaque;
+    uint64_t reg_now = get_reg_time(d);
 
-    if (!(d->ptimer.enabled_interrupts & NV_PTIMER_INTR_EN_0_ALARM)) {
-        return;
-    }
-
-    uint64_t now = get_ptimer_clock(d, ptimer_get_absolute_clock(d));
-    uint64_t alarm_time =
-        d->ptimer.alarm_time + ((uint64_t)d->ptimer.alarm_time_high << 32);
-
-    if (alarm_time <= now) {
+    if (is_alarm_reached(reg_now, d->ptimer.alarm_time)) {
         d->ptimer.pending_interrupts |= NV_PTIMER_INTR_0_ALARM;
-        d->ptimer.alarm_time_high = now >> 32;
+        d->ptimer.alarm_time = advance_alarm_epoch(d->ptimer.alarm_time);
         nv2a_update_irq(d);
     }
 
@@ -112,6 +148,16 @@ uint64_t ptimer_read(void *opaque, hwaddr addr, unsigned int size)
     uint64_t r = 0;
     switch (addr) {
     case NV_PTIMER_INTR_0:
+        if (timer_pending(&d->ptimer.timer)) {
+            uint64_t reg_now = get_reg_time(d);
+            if (is_alarm_reached(reg_now, d->ptimer.alarm_time)) {
+                d->ptimer.pending_interrupts |= NV_PTIMER_INTR_0_ALARM;
+                d->ptimer.alarm_time =
+                    advance_alarm_epoch(d->ptimer.alarm_time);
+                nv2a_update_irq(d);
+                schedule_qemu_timer(d);
+            }
+        }
         r = d->ptimer.pending_interrupts;
         break;
     case NV_PTIMER_INTR_EN_0:
@@ -124,15 +170,15 @@ uint64_t ptimer_read(void *opaque, hwaddr addr, unsigned int size)
         r = d->ptimer.denominator;
         break;
     case NV_PTIMER_TIME_0: {
-        uint64_t now = get_ptimer_clock(d, ptimer_get_absolute_clock(d));
-        r = now & 0xffffffff;
+        uint64_t reg_now = get_reg_time(d);
+        r = PTIMER_REG_TIME_GET_TIME_0(reg_now);
     } break;
     case NV_PTIMER_TIME_1: {
-        uint64_t now = get_ptimer_clock(d, ptimer_get_absolute_clock(d));
-        r = (now >> 32) & CLOCK_HIGH_MASK;
+        uint64_t reg_now = get_reg_time(d);
+        r = PTIMER_REG_TIME_GET_TIME_1(reg_now);
     } break;
     case NV_PTIMER_ALARM_0:
-        r = d->ptimer.alarm_time;
+        r = PTIMER_REG_TIME_GET_TIME_0(d->ptimer.alarm_time);
         break;
     default:
         break;
@@ -155,46 +201,59 @@ void ptimer_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
         break;
     case NV_PTIMER_INTR_EN_0:
         d->ptimer.enabled_interrupts = val;
-        if (val) {
-            schedule_qemu_timer(d);
-        } else {
-            timer_del(&d->ptimer.timer);
+        if (val && timer_pending(&d->ptimer.timer)) {
+            uint64_t reg_now = get_reg_time(d);
+            if (is_alarm_reached(reg_now, d->ptimer.alarm_time)) {
+                d->ptimer.pending_interrupts |= NV_PTIMER_INTR_0_ALARM;
+                d->ptimer.alarm_time =
+                    advance_alarm_epoch(d->ptimer.alarm_time);
+                schedule_qemu_timer(d);
+            }
         }
         nv2a_update_irq(d);
         break;
     case NV_PTIMER_DENOMINATOR:
         d->ptimer.denominator = val;
-        schedule_qemu_timer(d);
+        if (timer_pending(&d->ptimer.timer)) {
+            schedule_qemu_timer(d);
+        }
         break;
     case NV_PTIMER_NUMERATOR:
         d->ptimer.numerator = val;
-        schedule_qemu_timer(d);
+        if (timer_pending(&d->ptimer.timer)) {
+            schedule_qemu_timer(d);
+        }
         break;
     case NV_PTIMER_ALARM_0: {
-        uint64_t now = get_ptimer_clock(d, ptimer_get_absolute_clock(d));
-
-        d->ptimer.alarm_time = val & ALARM_MASK;
-        d->ptimer.alarm_time_high = (now >> 32);
-        if (val <= (now & ALARM_MASK)) {
-            ++d->ptimer.alarm_time_high;
+        uint64_t reg_now = get_reg_time(d);
+        uint32_t now_low = PTIMER_REG_TIME_GET_TIME_0(reg_now);
+        uint32_t val_low = val & ALARM_MASK;
+        uint64_t target = (reg_now & ~PTIMER_REG_TIME_LOW_MASK) | val_low;
+        if (val_low <= (now_low & ALARM_MASK)) {
+            target = advance_alarm_epoch(target);
         }
+        d->ptimer.alarm_time = target & PTIMER_REG_TIME_MASK;
         schedule_qemu_timer(d);
     } break;
     case NV_PTIMER_TIME_0: {
-        uint64_t absolute_clock = ptimer_get_absolute_clock(d);
-        uint64_t now = get_ptimer_clock(d, absolute_clock);
-        uint64_t target_relative =
-            (now & 0xffffffff00000000LL) | (((val >> 5) & CLOCK_LOW_MASK) << 5);
-        d->ptimer.time_offset = target_relative - absolute_clock;
-        schedule_qemu_timer(d);
+        uint64_t current_reg_time = get_reg_time(d);
+        uint64_t target_reg_time = PTIMER_MAKE_REG_TIME(
+            PTIMER_REG_TIME_GET_TIME_1(current_reg_time), val & ALARM_MASK);
+        uint64_t target_internal = PTIMER_REG_TO_INTERNAL_TIME(target_reg_time);
+        d->ptimer.time_offset = target_internal - ptimer_get_absolute_clock(d);
+        if (timer_pending(&d->ptimer.timer)) {
+            schedule_qemu_timer(d);
+        }
     } break;
     case NV_PTIMER_TIME_1: {
-        uint64_t absolute_clock = ptimer_get_absolute_clock(d);
-        uint64_t now = get_ptimer_clock(d, absolute_clock);
-        uint64_t target_relative =
-            (now & 0xffffffff) | ((val & CLOCK_HIGH_MASK) << 32);
-        d->ptimer.time_offset = target_relative - absolute_clock;
-        schedule_qemu_timer(d);
+        uint64_t current_reg_time = get_reg_time(d);
+        uint64_t target_reg_time = PTIMER_MAKE_REG_TIME(
+            val, PTIMER_REG_TIME_GET_TIME_0(current_reg_time));
+        uint64_t target_internal = PTIMER_REG_TO_INTERNAL_TIME(target_reg_time);
+        d->ptimer.time_offset = target_internal - ptimer_get_absolute_clock(d);
+        if (timer_pending(&d->ptimer.timer)) {
+            schedule_qemu_timer(d);
+        }
     } break;
     default:
         break;


### PR DESCRIPTION
Looks like the PTIMER alarm handling was started but never finished. This implements my best guess at what the HW is doing (it's hard to test with a nanosecond timer). It fixes the blocked loading for Def Jam: Fight for NY, which I determined to be caused by a event handle never being set due to the lack of an alarm interrupt in the same DPC that handles video blanking and other PMC interrupts. The PTIMER pending flag is known from the nxdk:
https://github.com/XboxDev/nxdk/blob/d0ae96acc926a6c3f6254b289a1a9a3c1db182f1/lib/pbkit/outer.h#L83

[See PTIMER tests in nxdk_low_level_nv2a_tests](https://github.com/abaire/nxdk_low_level_nv2a_tests)

Improves #1124 - it will now reliably get to the "Press start" screen but appears to still freeze later on due to a slightly different timing issue.