### PR TITLE
nv2a: Check GL_LINK_STATUS when loading cached shaders

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/shaders.c
+++ b/hw/xbox/nv2a/pgraph/gl/shaders.c
@@ -324,6 +324,15 @@ bool pgraph_gl_shader_load_from_memory(ShaderBinding *binding)
         return false;
     }
 
+    GLint link_status = GL_FALSE;
+    glGetProgramiv(gl_program, GL_LINK_STATUS, &link_status);
+    if (!link_status) {
+        NV2A_DPRINTF(
+            "failed to load shader binary from disk: link status is FALSE\n");
+        glDeleteProgram(gl_program);
+        return false;
+    }
+
     glUseProgram(gl_program);
 
     g_free(binding->program);


### PR DESCRIPTION
The GL docs indicate that GL_LINK_STATUS will be set to false in cases where the cached binary cannot be loaded successfully. This seems to be separate from the listed glGetError failure modes, indicating that both likely need to be tested.

Fixes #2370