### PR TITLE
ui: Align shortcut handling with ImGui Ctrl/Cmd model

### DIFF
--- a/ui/xui/misc.hh
+++ b/ui/xui/misc.hh
@@ -55,12 +55,21 @@ std::string string_format( const std::string& format, Args ... args )
     return std::string( buf.get(), buf.get() + size - 1 ); // We don't want the '\0' inside
 }
 
-static inline bool IsShortcutKeyPressed(int scancode)
+static inline bool IsShortcutKeyPressed(ImGuiKey key)
 {
     ImGuiIO& io = ImGui::GetIO();
-    const bool is_osx = io.ConfigMacOSXBehaviors;
-    const bool is_shortcut_key = (is_osx ? (io.KeySuper && !io.KeyCtrl) : (io.KeyCtrl && !io.KeySuper)) && !io.KeyAlt && !io.KeyShift; // OS X style: Shortcuts using Cmd/Super instead of Ctrl
-    return is_shortcut_key && ImGui::IsKeyPressed((enum ImGuiKey)scancode);
+
+    // Disallow Alt/Shift for plain shortcuts
+    if (io.KeyAlt || io.KeyShift) {
+        return false;
+    }
+
+    // ImGui input model (>= v1.92.5):
+    // On macOS Ctrl/Cmd are swapped internally by ImGui,
+    // so using Ctrl as the shortcut modifier is cross-platform idiomatic.
+    const bool shortcut_mod = io.KeyCtrl;
+
+    return shortcut_mod && ImGui::IsKeyPressed(key);
 }
 
 static inline float mix(float a, float b, float t)

--- a/ui/xui/misc.hh
+++ b/ui/xui/misc.hh
@@ -59,17 +59,11 @@ static inline bool IsShortcutKeyPressed(ImGuiKey key)
 {
     ImGuiIO& io = ImGui::GetIO();
 
-    // Disallow Alt/Shift for plain shortcuts
     if (io.KeyAlt || io.KeyShift) {
         return false;
     }
 
-    // ImGui input model (>= v1.92.5):
-    // On macOS Ctrl/Cmd are swapped internally by ImGui,
-    // so using Ctrl as the shortcut modifier is cross-platform idiomatic.
-    const bool shortcut_mod = io.KeyCtrl;
-
-    return shortcut_mod && ImGui::IsKeyPressed(key);
+    return io.KeyCtrl && ImGui::IsKeyPressed(key);
 }
 
 static inline float mix(float a, float b, float t)


### PR DESCRIPTION
### Summary

This PR updates shortcut detection logic to match Dear ImGui’s current input model,
where Ctrl and Cmd are automatically swapped on macOS.

### Background

Starting with ImGui v1.92.5, the shortcut modifier handling was simplified:
Ctrl/Cmd mapping on macOS is now handled internally by ImGui, and
`ImGuiMod_Shortcut` was removed.

As a result, application code no longer needs to special-case macOS
or explicitly check for `KeySuper`.

### What changed

- Removed legacy macOS-specific shortcut branching
- Rely on `Ctrl` as the canonical cross-platform shortcut modifier
- Preserve existing behavior by rejecting Alt/Shift for plain shortcuts

### References

- Dear ImGui v1.92.5 release notes
- Commit: “Inputs: swap Ctrl and Cmd on macOS X, remove ImGuiMod_Shortcut”
  https://github.com/ocornut/imgui/commit/7747106