### PR TITLE
ui: use F11 to toggle fullscreen

### DIFF
--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -71,6 +71,10 @@ void ProcessKeyboardShortcuts(void)
         ActionScreenshot();
     }
 
+    if (ImGui::IsKeyPressed(ImGuiKey_F11)) {
+        xemu_toggle_fullscreen();
+    }
+
 #ifdef CONFIG_RENDERDOC
     if (ImGui::IsKeyPressed(ImGuiKey_F10) && nv2a_dbg_renderdoc_available()) {
         ImGuiIO& io = ImGui::GetIO();
@@ -201,7 +205,7 @@ void ShowMainMenu()
                        "into the window");
             ImGui::Combo("Aspect Ratio", &g_config.display.ui.aspect_ratio,
                          "Native\0Auto\0""4:3\0""16:9\0");
-            if (ImGui::MenuItem("Fullscreen", SHORTCUT_MENU_TEXT(Alt + F),
+            if (ImGui::MenuItem("Fullscreen", "F11",
                                 xemu_is_fullscreen(), true)) {
                 xemu_toggle_fullscreen();
             }


### PR DESCRIPTION
Fixes #2601. `Ctr+Alt+F` might still work because I didn't change the code in `handle_keydown`.