### PR TITLE
ui: Fix use-after-free when new controller mapping is added

### DIFF
--- a/ui/xemu-controllers.h
+++ b/ui/xemu-controllers.h
@@ -23,8 +23,6 @@
 #include "xemu-input.h"
 #include <SDL.h>
 
-#ifdef __cplusplus
-
 enum class RebindEventResult {
     Ignore,
     Complete,
@@ -70,16 +68,5 @@ public:
     {
     }
 };
-
-extern "C" {
-#endif // __cplusplus
-
-extern int *g_keyboard_scancode_map[25];
-
-GamepadMappings *xemu_settings_load_gamepad_mapping(const char *guid, bool reset_to_default);
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
 
 #endif // XEMU_CONTROLLERS_H

--- a/ui/xemu-input.h
+++ b/ui/xemu-input.h
@@ -68,12 +68,6 @@ enum controller_state_axis_index {
     CONTROLLER_AXIS__COUNT,
 };
 
-#ifdef __cplusplus
-using GamepadMappings = struct config::input::gamepad_mappings;
-#else
-typedef struct gamepad_mappings GamepadMappings;
-#endif
-
 enum controller_input_device_type {
     INPUT_DEVICE_SDL_KEYBOARD,
     INPUT_DEVICE_SDL_GAMECONTROLLER,
@@ -127,6 +121,8 @@ extern const char *bound_drivers[4];
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+extern int *g_keyboard_scancode_map[25];
 
 void xemu_input_init(void);
 void xemu_input_process_sdl_events(const SDL_Event *event); // SDL_CONTROLLERDEVICEADDED, SDL_CONTROLLERDEVICEREMOVED

--- a/ui/xemu-settings.cc
+++ b/ui/xemu-settings.cc
@@ -261,54 +261,75 @@ void remove_net_nat_forward_ports(unsigned int index)
     cnode->store_to_struct(&g_config);
 }
 
-GamepadMappings *xemu_settings_load_gamepad_mapping(const char *guid, bool reset_to_default)
+bool xemu_settings_load_gamepad_mapping(const char *guid,
+                                        GamepadMappings **mapping)
 {
     unsigned int i;
     unsigned int gamepad_mappings_count = g_config.input.gamepad_mappings_count;
     for (i = 0; i < gamepad_mappings_count; ++i) {
-        auto *mapping = &g_config.input.gamepad_mappings[i];
-        if (strcmp(mapping->gamepad_id, guid) != 0) {
-          continue;
-        }
-
-        if (reset_to_default) {
-          break;
+        *mapping = &g_config.input.gamepad_mappings[i];
+        if (strcmp((*mapping)->gamepad_id, guid) != 0) {
+            continue;
         }
 
         // Migrate global 'allow_vibration' setting to the controller config
         if (!g_config.input.allow_vibration) {
-            mapping->enable_rumble = g_config.input.allow_vibration;
+            (*mapping)->enable_rumble = g_config.input.allow_vibration;
         }
 
-        return mapping;
+        return false;
     }
 
     auto cnode = config_tree.child("input")->child("gamepad_mappings");
     cnode->update_from_struct(&g_config);
     cnode->free_allocations(&g_config);
 
-    CNode *mapping_node;
-    if (reset_to_default && i < gamepad_mappings_count) {
-      mapping_node = &cnode->children[i];
-      mapping_node->reset_to_defaults();
-    } else {
-      cnode->children.push_back(*cnode->array_item_type);
-      mapping_node = &cnode->children.back();
-    }
+    cnode->children.push_back(*cnode->array_item_type);
+    CNode *mapping_node = &cnode->children.back();
 
     mapping_node->child("gamepad_id")->set_string(guid);
 
     cnode->store_to_struct(&g_config);
 
-    auto *mapping = &g_config.input
-      .gamepad_mappings[g_config.input.gamepad_mappings_count - 1];
+    *mapping =
+        &g_config.input
+             .gamepad_mappings[g_config.input.gamepad_mappings_count - 1];
 
     // Migrate global 'allow_vibration' setting to the controller config
     if (!g_config.input.allow_vibration) {
-        mapping->enable_rumble = g_config.input.allow_vibration;
+        (*mapping)->enable_rumble = g_config.input.allow_vibration;
     }
 
-    return mapping;
+    return true;
+}
+
+void xemu_settings_reset_controller_mapping(const char *guid)
+{
+    unsigned int gamepad_mappings_count = g_config.input.gamepad_mappings_count;
+
+    unsigned int i;
+    struct config::input::gamepad_mappings *mapping;
+
+    for (i = 0; i < gamepad_mappings_count; ++i) {
+        mapping = &g_config.input.gamepad_mappings[i];
+        if (strcmp(mapping->gamepad_id, guid) == 0) {
+            break;
+        }
+    }
+
+    if (i == gamepad_mappings_count) {
+        return;
+    }
+
+    CNode *cnode = config_tree.child("input")->child("gamepad_mappings");
+    cnode->update_from_struct(&g_config);
+
+    // Careful not to free the mapping array, as other controllers may be using
+    // it
+    CNode *mapping_node = &cnode->children[i];
+    mapping_node->reset_to_defaults();
+    mapping_node->child("gamepad_id")->set_string(guid);
+    mapping_node->store_to_struct(mapping);
 }
 
 void xemu_settings_reset_keyboard_mapping(void)

--- a/ui/xemu-settings.h
+++ b/ui/xemu-settings.h
@@ -34,6 +34,12 @@ extern "C" {
 
 #include "xemu-config.h"
 
+#ifdef __cplusplus
+using GamepadMappings = struct config::input::gamepad_mappings;
+#else
+typedef struct gamepad_mappings GamepadMappings;
+#endif
+
 extern struct config g_config;
 
 // Override the default config file paths
@@ -66,6 +72,15 @@ static inline void xemu_settings_set_string(const char **str, const char *new_st
 
 void add_net_nat_forward_ports(int host, int guest, CONFIG_NET_NAT_FORWARD_PORTS_PROTOCOL protocol);
 void remove_net_nat_forward_ports(unsigned int index);
+
+
+// Load gamepad mapping for controller with 'guid', setting the mapping pointer
+// to the config entry. Returns true if the mapping did not previously exist.
+bool xemu_settings_load_gamepad_mapping(const char *guid,
+                                        GamepadMappings **mapping);
+
+// Reset controller mapping to default settings.
+void xemu_settings_reset_controller_mapping(const char *guid);
 
 // Reset keyboard mappings to default settings.
 void xemu_settings_reset_keyboard_mapping(void);

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -358,6 +358,8 @@ void MainMenuInputView::Draw()
     ImGui::SetCursorPos(pos);
 
     if (bound_state) {
+        ImGui::PushID(active);
+
         SectionTitle("Expansion Slots");
         // Begin a 2-column layout to render the expansion slots
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
@@ -514,51 +516,53 @@ void MainMenuInputView::Draw()
 
         ImGui::PopStyleVar(); // ItemSpacing
         ImGui::Columns(1);
-    }
 
-    SectionTitle("Mapping");
-    ImVec4 tc = ImGui::GetStyle().Colors[ImGuiCol_Header];
-    tc.w = 0.0f;
-    ImGui::PushStyleColor(ImGuiCol_Header, tc);
+        SectionTitle("Mapping");
+        ImVec4 tc = ImGui::GetStyle().Colors[ImGuiCol_Header];
+        tc.w = 0.0f;
+        ImGui::PushStyleColor(ImGuiCol_Header, tc);
 
-    if (ImGui::CollapsingHeader("Input Mapping")) {
-        float p = ImGui::GetFrameHeight() * 0.3;
-        ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, ImVec2(p, p));
-        if (ImGui::BeginTable("input_remap_tbl", 2,
-                              ImGuiTableFlags_RowBg |
-                                  ImGuiTableFlags_Borders)) {
-            ImGui::TableSetupColumn("Emulated Input");
-            ImGui::TableSetupColumn("Host Input");
-            ImGui::TableHeadersRow();
+        if (ImGui::CollapsingHeader("Input Mapping")) {
+            float p = ImGui::GetFrameHeight() * 0.3;
+            ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, ImVec2(p, p));
+            if (ImGui::BeginTable("input_remap_tbl", 2,
+                                  ImGuiTableFlags_RowBg |
+                                      ImGuiTableFlags_Borders)) {
+                ImGui::TableSetupColumn("Emulated Input");
+                ImGui::TableSetupColumn("Host Input");
+                ImGui::TableHeadersRow();
 
-            PopulateTableController(bound_state);
+                PopulateTableController(bound_state);
 
-            ImGui::EndTable();
+                ImGui::EndTable();
+            }
+            ImGui::PopStyleVar();
         }
-        ImGui::PopStyleVar();
-    }
 
-    if (bound_state && bound_state->type == INPUT_DEVICE_SDL_GAMECONTROLLER) {
-        Toggle("Enable Rumble", &bound_state->controller_map->enable_rumble);
-        Toggle("Invert Left X Axis",
-               &bound_state->controller_map->controller_mapping
-                    .invert_axis_left_x);
-        Toggle("Invert Left Y Axis",
-               &bound_state->controller_map->controller_mapping
-                    .invert_axis_left_y);
-        Toggle("Invert Right X Axis",
-               &bound_state->controller_map->controller_mapping
-                    .invert_axis_right_x);
-        Toggle("Invert Right Y Axis",
-               &bound_state->controller_map->controller_mapping
-                    .invert_axis_right_y);
-    }
+        if (bound_state->type == INPUT_DEVICE_SDL_GAMECONTROLLER) {
+            Toggle("Enable Rumble",
+                   &bound_state->controller_map->enable_rumble);
+            Toggle("Invert Left X Axis",
+                   &bound_state->controller_map->controller_mapping
+                        .invert_axis_left_x);
+            Toggle("Invert Left Y Axis",
+                   &bound_state->controller_map->controller_mapping
+                        .invert_axis_left_y);
+            Toggle("Invert Right X Axis",
+                   &bound_state->controller_map->controller_mapping
+                        .invert_axis_right_x);
+            Toggle("Invert Right Y Axis",
+                   &bound_state->controller_map->controller_mapping
+                        .invert_axis_right_y);
+        }
 
-    if (ImGui::Button("Reset to Default")) {
-      xemu_input_reset_input_mapping(bound_state);
-    }
+        if (ImGui::Button("Reset to Default")) {
+            xemu_input_reset_input_mapping(bound_state);
+        }
 
-    ImGui::PopStyleColor();
+        ImGui::PopStyleColor();
+        ImGui::PopID();
+    }
 
     SectionTitle("Options");
     Toggle("Auto-bind controllers", &g_config.input.auto_bind,


### PR DESCRIPTION
When a new controller mapping is added to the controller mapping array in the xemu config, the array is reallocated, and any existing pointers become invalid and must be reset.

Fixes #2625 