### PR TITLE
meson: Update imgui

### DIFF
--- a/subprojects/imgui.wrap
+++ b/subprojects/imgui.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url=https://github.com/xemu-project/imgui
-revision=7219d617a32b594f9a80b2356aec42e0e939e938
+revision=b911105fca3ca1b025706dd168e5798070f143a1
 depth=1


### PR DESCRIPTION
Integrates the macOS retina fixes from [imgui#1](https://github.com/xemu-project/imgui/pull/1).
Closes #1666