### PR TITLE
build: Fix MSYS2 Building

### DIFF
--- a/python/scripts/mkvenv.py
+++ b/python/scripts/mkvenv.py
@@ -683,7 +683,7 @@ def pip_install(
     if not online:
         full_args += ["--no-index"]
     if wheels_dir:
-        full_args += ["--find-links", f"file://{str(wheels_dir)}"]
+        full_args += ["--find-links", f"{wheels_dir}"]
     full_args += list(args)
     subprocess.run(
         full_args,

--- a/ui/xemu-snapshots.h
+++ b/ui/xemu-snapshots.h
@@ -20,11 +20,12 @@
 #ifndef XEMU_SNAPSHOTS_H
 #define XEMU_SNAPSHOTS_H
 
+#include "qemu/osdep.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include "qemu/osdep.h"
 #include "block/snapshot.h"
 #include <epoxy/gl.h>
 

--- a/ui/xui/common.hh
+++ b/ui/xui/common.hh
@@ -31,9 +31,10 @@
 #include <misc/cpp/imgui_stdlib.h>
 #include <stb_image.h>
 
+#include "qemu/osdep.h"
+
 extern "C" {
 // Include necessary QEMU headers
-#include "qemu/osdep.h"
 #include "qapi/error.h"
 #include "system/runstate.h"
 #include "hw/xbox/mcpx/apu/apu_debug.h"


### PR DESCRIPTION
I build xemu using MSYS2's  UCRT64 environment and I use `cmd` instead of `bash`. This patch makes it build. There is also another patch for QEMU necessary, but I already submitted it upstream and it has been merged.