### PR TITLE
ci: Enable Incremental LTO

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -20,7 +20,8 @@ jobs:
       ARTIFACT_NAME: xemu-ubuntu-${{ matrix.arch }}-${{ matrix.configuration }}
       CCACHE_DIR: /tmp/xemu-ccache
       CCACHE_MAXSIZE: 512M
-      XEMU_BUILD_OPTIONS: ${{ matrix.configuration == 'debug' && '--debug' || '' }}
+      LTO_CACHE_DIR: /tmp/xemu-lto-cache
+      LTO_CACHE_MAXSIZE: 512m
       DEB_BUILD_MAINT_OPTIONS: optimize=-lto
       DEB_CFLAGS_MAINT_APPEND: -gdwarf-4 -gstrict-dwarf
       DEB_CXXFLAGS_MAINT_APPEND: -gdwarf-4 -gstrict-dwarf
@@ -33,11 +34,29 @@ jobs:
       RANLIB: llvm-ranlib-21
       NM: llvm-nm-21
     steps:
+    - name: Setup build options
+      run: |
+        if [[ "${{ matrix.configuration }}" == "debug" ]]; then
+          opts=(
+            --debug
+          )
+        else
+          opts=(
+            --extra-ldflags="-Wl,--thinlto-cache-policy=cache_size_bytes=$LTO_CACHE_MAXSIZE"
+            -Db_lto=true
+            -Db_lto_mode=thin
+            -Db_thinlto_cache=true
+            -Db_thinlto_cache_dir="$LTO_CACHE_DIR"
+          )
+        fi
+        echo "XEMU_BUILD_OPTIONS=${opts[*]}" >> "$GITHUB_ENV"
     - name: Initialize compiler cache
       id: cache
       uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v4
       with:
-        path: /tmp/xemu-ccache
+        path: |
+          ${{ env.CCACHE_DIR }}
+          ${{ env.LTO_CACHE_DIR }}
         key: cache-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-${{ github.sha }}
         restore-keys: cache-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-
     - name: Download source package

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -21,6 +21,7 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       CCACHE_DIR: ${{ github.workspace }}/xemu-ccache
       CCACHE_MAXSIZE: 512M
+      LTO_CACHE_DIR: ${{ github.workspace }}/xemu-lto-cache
     steps:
     - name: Download source package
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v4
@@ -43,18 +44,32 @@ jobs:
       uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v4
       with:
         path: |
-          xemu-ccache
           macos-pkgs
+          ${{ env.CCACHE_DIR }}
+          ${{ env.LTO_CACHE_DIR }}
         key: cache-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-${{ github.sha }}
         restore-keys: cache-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-
     - name: Setup ccache
       run: |
         echo "PATH=/opt/homebrew/opt/ccache/libexec:$PATH" >> "$GITHUB_ENV"
         ccache -z
+    - name: Setup build options
+      run: |
+        if [[ "${{ matrix.configuration }}" == "debug" ]]; then
+          opts=(
+            --debug
+          )
+        else
+          opts=(
+            -Db_lto=true
+            -Db_lto_mode=thin
+            -Db_thinlto_cache=true
+            -Db_thinlto_cache_dir="$LTO_CACHE_DIR"
+          )
+        fi
+        echo "XEMU_BUILD_OPTIONS=${opts[*]}" >> "$GITHUB_ENV"
     - name: Compile
-      env:
-        BUILD_FLAGS: ${{ matrix.configuration == 'debug' && '--debug' || '' }}
-      run: ./build.sh -a ${{ matrix.arch }} ${BUILD_FLAGS}
+      run: ./build.sh -a ${{ matrix.arch }} ${XEMU_BUILD_OPTIONS}
     - name: Report ccache stats
       run: ccache -s
     - name: Package

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       CCACHE_DIR: /tmp/xemu-ccache
       CCACHE_MAXSIZE: 512M
+      LTO_CACHE_DIR: /tmp/xemu-lto-ccache
     steps:
     - name: Download source package
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v4
@@ -37,6 +38,7 @@ jobs:
       with:
         path: |
           ${{ env.CCACHE_DIR }}
+          ${{ env.LTO_CACHE_DIR }}
         key: cache-wincross-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-${{ github.sha }}
         restore-keys: cache-wincross-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-
     - name: Setup ccache
@@ -47,6 +49,17 @@ jobs:
           opts=(
             --debug
           )
+        elif [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+          opts=(
+            --extra-cflags="-flto-incremental=${LTO_CACHE_DIR} -flto-partition=cache"
+            -Db_lto=true
+          )
+        elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
+          # FIXME: llvm-mingw ThinLTO has an issue with `qemu_build_not_reached_always`
+          #        being intentionaly undefined (to ensure 'unreachable' paths are
+          #        optimized out). Regular LTO doesn't pass cv2pdb. Resolve linking
+          #        failure and have llvm toolchain generate PDB directly.
+          opts=()
         fi
         echo "XEMU_BUILD_OPTIONS=${opts[*]}" >> "$GITHUB_ENV"
     - name: Compile

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,9 +17,9 @@ jobs:
         arch: [x86_64, arm64]
         configuration: [debug, release]
     env:
-      DOCKER_IMAGE_NAME: ghcr.io/xemu-project/xemu-win64-toolchain:sha-0d06ce8
       CCACHE_DIR: /tmp/xemu-ccache
       CCACHE_MAXSIZE: 512M
+      DOCKER_IMAGE_NAME: ghcr.io/xemu-project/xemu-win64-toolchain-${{ matrix.arch == 'x86_64' && 'gcc:sha-18018f1' || 'llvm:sha-18018f1' }}
     steps:
     - name: Download source package
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v4
@@ -49,7 +49,7 @@ jobs:
           CROSSAR=aarch64-w64-mingw32.static-ar
         else
           CROSSPREFIX=x86_64-w64-mingw32.static-
-          CROSSAR=x86_64-w64-mingw32.static-ar
+          CROSSAR=x86_64-w64-mingw32.static-gcc-ar
         fi
         echo "CROSSPREFIX=${CROSSPREFIX}" >> "$GITHUB_ENV"
         echo "CROSSAR=${CROSSAR}" >> "$GITHUB_ENV"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,6 +18,8 @@ jobs:
         configuration: [debug, release]
     env:
       DOCKER_IMAGE_NAME: ghcr.io/xemu-project/xemu-win64-toolchain:sha-0d06ce8
+      CCACHE_DIR: /tmp/xemu-ccache
+      CCACHE_MAXSIZE: 512M
     steps:
     - name: Download source package
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v4
@@ -29,7 +31,8 @@ jobs:
       id: cache
       uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v4
       with:
-        path: /tmp/xemu-ccache
+        path: |
+          ${{ env.CCACHE_DIR }}
         key: cache-wincross-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-${{ github.sha }}
         restore-keys: cache-wincross-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-
     - name: Pull Docker image
@@ -39,12 +42,12 @@ jobs:
         CROSSPREFIX: ${{ matrix.arch == 'arm64' && 'aarch64' || matrix.arch }}-w64-mingw32.static-
         BUILD_FLAGS: ${{ matrix.configuration == 'debug' && '--debug' || '' }}
       run: |
-        mkdir -p /tmp/xemu-ccache
+        mkdir -p ${CCACHE_DIR}
         docker run --rm \
           -v $PWD:/xemu -w /xemu \
-          -v /tmp/xemu-ccache:/tmp/xemu-ccache \
-          -e CCACHE_DIR=/tmp/xemu-ccache \
-          -e CCACHE_MAXSIZE=512M \
+          -v ${CCACHE_DIR}:${CCACHE_DIR} \
+          -e CCACHE_DIR=${CCACHE_DIR} \
+          -e CCACHE_MAXSIZE=${CCACHE_MAXSIZE} \
           -e CROSSPREFIX=${CROSSPREFIX} \
           -e CROSSAR=${CROSSPREFIX}ar \
           -u $(id -u):$(id -g) \

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -16,10 +16,14 @@ jobs:
       matrix:
         arch: [x86_64, arm64]
         configuration: [debug, release]
+    container:
+      image: ghcr.io/xemu-project/xemu-win64-toolchain-${{ matrix.arch == 'x86_64' && 'gcc:sha-18018f1' || 'llvm:sha-18018f1' }}
+    defaults:
+      run:
+        shell: bash
     env:
       CCACHE_DIR: /tmp/xemu-ccache
       CCACHE_MAXSIZE: 512M
-      DOCKER_IMAGE_NAME: ghcr.io/xemu-project/xemu-win64-toolchain-${{ matrix.arch == 'x86_64' && 'gcc:sha-18018f1' || 'llvm:sha-18018f1' }}
     steps:
     - name: Download source package
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v4
@@ -35,6 +39,8 @@ jobs:
           ${{ env.CCACHE_DIR }}
         key: cache-wincross-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-${{ github.sha }}
         restore-keys: cache-wincross-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-
+    - name: Setup ccache
+      run: ccache -z
     - name: Setup build options
       run: |
         if [[ "${{ matrix.configuration }}" == "debug" ]]; then
@@ -43,31 +49,10 @@ jobs:
           )
         fi
         echo "XEMU_BUILD_OPTIONS=${opts[*]}" >> "$GITHUB_ENV"
-
-        if [[ "${{ matrix.arch }}" == "arm64" ]]; then
-          CROSSPREFIX=aarch64-w64-mingw32.static-
-          CROSSAR=aarch64-w64-mingw32.static-ar
-        else
-          CROSSPREFIX=x86_64-w64-mingw32.static-
-          CROSSAR=x86_64-w64-mingw32.static-gcc-ar
-        fi
-        echo "CROSSPREFIX=${CROSSPREFIX}" >> "$GITHUB_ENV"
-        echo "CROSSAR=${CROSSAR}" >> "$GITHUB_ENV"
-    - name: Pull Docker image
-      run: docker pull $DOCKER_IMAGE_NAME
     - name: Compile
-      run: |
-        mkdir -p ${CCACHE_DIR}
-        docker run --rm \
-          -v $PWD:/xemu -w /xemu \
-          -v ${CCACHE_DIR}:${CCACHE_DIR} \
-          -e CCACHE_DIR=${CCACHE_DIR} \
-          -e CCACHE_MAXSIZE=${CCACHE_MAXSIZE} \
-          -e CROSSPREFIX=${CROSSPREFIX} \
-          -e CROSSAR=${CROSSAR} \
-          -u $(id -u):$(id -g) \
-          $DOCKER_IMAGE_NAME \
-            bash -c "ccache -z; ./build.sh -p win64-cross ${XEMU_BUILD_OPTIONS} && ccache -s"
+      run: ./build.sh -p win64-cross ${XEMU_BUILD_OPTIONS}
+    - name: Report ccache stats
+      run: ccache -s
     - name: Upload build artifact
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v4
       with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -35,12 +35,27 @@ jobs:
           ${{ env.CCACHE_DIR }}
         key: cache-wincross-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-${{ github.sha }}
         restore-keys: cache-wincross-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-
+    - name: Setup build options
+      run: |
+        if [[ "${{ matrix.configuration }}" == "debug" ]]; then
+          opts=(
+            --debug
+          )
+        fi
+        echo "XEMU_BUILD_OPTIONS=${opts[*]}" >> "$GITHUB_ENV"
+
+        if [[ "${{ matrix.arch }}" == "arm64" ]]; then
+          CROSSPREFIX=aarch64-w64-mingw32.static-
+          CROSSAR=aarch64-w64-mingw32.static-ar
+        else
+          CROSSPREFIX=x86_64-w64-mingw32.static-
+          CROSSAR=x86_64-w64-mingw32.static-ar
+        fi
+        echo "CROSSPREFIX=${CROSSPREFIX}" >> "$GITHUB_ENV"
+        echo "CROSSAR=${CROSSAR}" >> "$GITHUB_ENV"
     - name: Pull Docker image
       run: docker pull $DOCKER_IMAGE_NAME
     - name: Compile
-      env:
-        CROSSPREFIX: ${{ matrix.arch == 'arm64' && 'aarch64' || matrix.arch }}-w64-mingw32.static-
-        BUILD_FLAGS: ${{ matrix.configuration == 'debug' && '--debug' || '' }}
       run: |
         mkdir -p ${CCACHE_DIR}
         docker run --rm \
@@ -49,10 +64,10 @@ jobs:
           -e CCACHE_DIR=${CCACHE_DIR} \
           -e CCACHE_MAXSIZE=${CCACHE_MAXSIZE} \
           -e CROSSPREFIX=${CROSSPREFIX} \
-          -e CROSSAR=${CROSSPREFIX}ar \
+          -e CROSSAR=${CROSSAR} \
           -u $(id -u):$(id -g) \
           $DOCKER_IMAGE_NAME \
-            bash -c "ccache -z; ./build.sh -p win64-cross ${BUILD_FLAGS} && ccache -s"
+            bash -c "ccache -z; ./build.sh -p win64-cross ${XEMU_BUILD_OPTIONS} && ccache -s"
     - name: Upload build artifact
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v4
       with:


### PR DESCRIPTION
* ThinLTO with cache for fast incremental linking for macOS, Linux builds.
* llvm-mingw failing to build for Windows with LTO enabled.
   * Moved x86_64 Windows builds to GCC15 with Incremental LTO.
   * arm64 builds remain on llvm-mingw, without LTO.
 
- [x] Move to ghcr.io hosted images