### PR TITLE
ui: Disable CRT assert dialogs, log to stderr

### DIFF
--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -1339,6 +1339,8 @@ int main(int argc, char **argv)
             freopen("xemu.log", "a", stderr);
         }
     }
+
+    _set_error_mode(_OUT_TO_STDERR);
 #endif
 
     fprintf(stderr, "xemu_version: %s\n", xemu_version);


### PR DESCRIPTION
* Disables the CRT "Assertion failed!" dialog, instead just writes errors to stderr
* Terminates instead of letting the user continue with undefined state