### PR TITLE
ci: Create pre-release on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: CI
 on:
   pull_request:
   push:
-    branches:
-      - "**"
+    branches-ignore:
+      - master
     tags-ignore:
       - "v*"
 

--- a/.github/workflows/delete-prerelease.yml
+++ b/.github/workflows/delete-prerelease.yml
@@ -1,0 +1,20 @@
+name: Delete Pre-release
+
+on:
+  workflow_call:
+
+jobs:
+  delete:
+    name: Delete pre-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Delete pre-release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      run: |
+        if gh release view pre-release --json isPrerelease --jq '.isPrerelease' | grep -q true; then
+          gh release delete pre-release --yes --cleanup-tag || true
+        fi

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,16 @@
+name: Pre-release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: Pre-release
+    if: github.repository_owner == 'xemu-project'
+    uses: ./.github/workflows/release.yml
+    with:
+      ref: ${{ github.sha }}
+      tag: pre-release
+      pre-release: true

--- a/.github/workflows/release-on-dispatch.yml
+++ b/.github/workflows/release-on-dispatch.yml
@@ -38,4 +38,5 @@ jobs:
     needs: tag
     uses: ./.github/workflows/release.yml
     with:
+      ref: ${{ needs.tag.outputs.tag }}
       tag: ${{ needs.tag.outputs.tag }}

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -9,4 +9,5 @@ jobs:
     name: Release
     uses: ./.github/workflows/release.yml
     with:
+      ref: ${{ github.ref_name }}
       tag: ${{ github.ref_name }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -5,6 +5,11 @@ on:
     types: [published]
 
 jobs:
+  cleanup_prerelease:
+    name: Delete pre-release
+    if: ${{ !github.event.release.prerelease }}
+    uses: ./.github/workflows/delete-prerelease.yml
+
   update_website:
     name: Update website
     if: ${{ github.repository_owner == 'xemu-project' && !github.event.release.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,49 +3,71 @@ name: Release
 on:
   workflow_call:
     inputs:
-      tag:
-        description: "Tag to release (e.g. v1.2.3)"
+      ref:
+        description: "Git ref to build and release"
         required: true
         type: string
+      tag:
+        description: "Tag name for the release"
+        required: true
+        type: string
+      pre-release:
+        description: "Create as published pre-release instead of draft release"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
     name: Build
     uses: ./.github/workflows/build.yml
     with:
-      ref: ${{ inputs.tag }}
+      ref: ${{ inputs.ref }}
+
+  delete_prerelease:
+    name: Delete pre-release
+    needs: build
+    if: ${{ inputs.pre-release }}
+    uses: ./.github/workflows/delete-prerelease.yml
 
   release:
     name: Create release
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, delete_prerelease]
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     steps:
     - name: Clone tree
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
       with:
         fetch-depth: 0
-        ref: ${{ inputs.tag }}
+        ref: ${{ inputs.ref }}
     - name: Generate Changelog
       run: |
-        PREVIOUS_TAG=$(git describe --tags --match 'v*' --abbrev=0 HEAD^)
-        git log --pretty=format:'* %h %s' --first-parent $PREVIOUS_TAG..HEAD > CHANGELOG.md
+        if PREVIOUS_TAG=$(git describe --tags --match 'v*' --abbrev=0 HEAD^ 2>/dev/null); then
+          git log --pretty=format:'* %h %s' --first-parent $PREVIOUS_TAG..HEAD > CHANGELOG.md
+        else
+          touch CHANGELOG.md
+        fi
     - name: Download artifacts
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v4
       with:
         path: dist
         merge-multiple: true
     - name: Add transitionary package aliases
+      if: ${{ !inputs.pre-release }}
       run: |
         pushd dist
         cp xemu-${{ needs.build.outputs.pkg_version }}-windows-x86_64.zip xemu-win-x86_64-release.zip
         cp xemu-${{ needs.build.outputs.pkg_version }}-windows-arm64.zip xemu-win-aarch64-release.zip
-    - name: Create release draft
+    - name: Create release
       uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
       with:
-        name: ${{ inputs.tag }}
+        name: ${{ inputs.pre-release && 'Latest Development Build' || inputs.tag }}
         tag_name: ${{ inputs.tag }}
+        target_commitish: ${{ inputs.pre-release && inputs.ref || '' }}
         body_path: CHANGELOG.md
-        draft: true
+        draft: ${{ !inputs.pre-release }}
+        prerelease: ${{ inputs.pre-release }}
         files: |
           dist/xemu*.tar.zst
           dist/xemu*-win*.zip


### PR DESCRIPTION
For the (ideally short) time between official releases, push artifacts to a 'Latest Development Build' pre-release on GitHub.
