### PR TITLE
ci: Fix Win version.rc compilation on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           echo "pkg_version=${TAG#v}" >> $GITHUB_OUTPUT
         else
           SHORT_HASH=$(git rev-parse --short HEAD)
-          echo "pkg_version=0.0.0-unofficial-${SHORT_HASH}" >> $GITHUB_OUTPUT
+          echo "pkg_version=0.0.0-0-unofficial-${SHORT_HASH}" >> $GITHUB_OUTPUT
         fi
     - name: Create source package
       id: package


### PR DESCRIPTION
Not sure how my initial "unofficial" PR worked in my branch a week ago but it doesn't with a master sync now. 

Looks like `xemu-version.sh` ends up passing "unofficial" to `version.rc` where it's treated as an integer. This change makes it `0` instead.

We could also probably switch from using `-` separators to `_` so the `cut` fallback logic catches its own `-0`.