### PR TITLE
nv2a: Fix calculation of palette length

### DIFF
--- a/hw/xbox/nv2a/pgraph/texture.c
+++ b/hw/xbox/nv2a/pgraph/texture.c
@@ -124,7 +124,7 @@ hwaddr pgraph_get_texture_palette_phys_addr_length(PGRAPHState *pg, int texture_
     default: assert(false); break;
     }
     if (length) {
-        *length = palette_length;
+        *length = palette_length * 4;
     }
 
     hwaddr palette_dma_len;


### PR DESCRIPTION
pgraph_get_texture_palette_phys_addr_length returns the length of the palette in entries whereas the use of the returned data expects bytes. This leads to a situation where textures that are rendered without any changes to the lower palette entries will erroneously reuse stale data.

Test: https://github.com/abaire/nxdk_pgraph_tests/blob/0b1ae640fa76ecfc5b7b4f2b5f870404ed106114/src/tests/texture_palette_tests.cpp#L234
HW results: https://abaire.github.io/nxdk_pgraph_tests_golden_results/results/Texture_palette/index.html

Fixes #2646
Fixes #2403