### PR TITLE
.github: Configure issue template type property

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: Request a new feature for xemu
 labels: [enhancement]
+type: feature
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/general-issue.yml
+++ b/.github/ISSUE_TEMPLATE/general-issue.yml
@@ -1,6 +1,7 @@
 name: General Issue
 description: Report a general issue with xemu, not specific to one or more particular titles
 labels: [bug, triage]
+type: bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/title-issue.yml
+++ b/.github/ISSUE_TEMPLATE/title-issue.yml
@@ -2,6 +2,7 @@ name: Title Issue
 description: Report a specific issue with a title/game in xemu
 title: "Title Name: Short Description"
 labels: [bug, triage]
+type: bug
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
GitHub added issue "type" property [last year](https://github.blog/changelog/2025-04-09-evolving-github-issues-and-projects/) and I just recently noticed it. Configure this property in issue templates. We'll phase out enhancement/bug labels separately, once existing issues are assigned a type.

---

Edit: I reverted this change because I also just discovered this feature is not fully baked throughout GitHub ecosystem (e.g. https://github.com/cli/cli/issues/9696). Will reconsider using it later.