### PR TITLE
xemu-snapshots: fix assert

### DIFF
--- a/ui/xemu-snapshots.c
+++ b/ui/xemu-snapshots.c
@@ -169,8 +169,8 @@ static void xemu_snapshots_all_load_data(QEMUSnapshotInfo **info,
 
     bdrv_flush(bs_ro);
     bdrv_drain(bs_ro);
+    assert(bs_ro->refcnt == 1);
     bdrv_unref(bs_ro);
-    assert(bs_ro->refcnt == 0);
     if (!(*err))
         xemu_snapshots_dirty = false;
 }


### PR DESCRIPTION
`bdrv_unref(bs_ro);` frees `bs_ro` so the `assert(bs_ro->refcnt == 0);` in next line is a use after free. Move the assert before the `free`.