### PR TITLE
ui: Allow Alt to trigger RenderDoc+PGRAPH caps

### DIFF
--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -79,7 +79,7 @@ void ProcessKeyboardShortcuts(void)
     if (ImGui::IsKeyPressed(ImGuiKey_F10) && nv2a_dbg_renderdoc_available()) {
         ImGuiIO& io = ImGui::GetIO();
         int num_frames = io.KeyShift ? 5 : 1;
-        nv2a_dbg_renderdoc_capture_frames(num_frames, io.KeyCtrl);
+        nv2a_dbg_renderdoc_capture_frames(num_frames, io.KeyCtrl || io.KeyAlt);
     }
 #endif
 }


### PR DESCRIPTION
It appears that `KeyCtrl` is no longer being set for the control key on macOS. This change allows either ctrl or alt/option to trigger PGRAPH traces along with F10 RenderDoc captures.