### PR TITLE
apu: Restructure monitor sink to eliminate callbacks and extra buffer

### DIFF
--- a/hw/xbox/mcpx/apu/apu_int.h
+++ b/hw/xbox/mcpx/apu/apu_int.h
@@ -93,9 +93,9 @@ typedef struct MCPXAPUState {
     uint32_t regs[0x20000];
 
     int ep_frame_div;
-    int sleep_acc;
+    int sleep_acc_us;
     int frame_count;
-    int64_t frame_count_time;
+    int64_t frame_count_time_ms;
 
     struct {
         McpxApuDebugMonitorPoint point;

--- a/hw/xbox/mcpx/apu/apu_int.h
+++ b/hw/xbox/mcpx/apu/apu_int.h
@@ -81,6 +81,9 @@ typedef struct MCPXAPUState {
     QemuThread apu_thread;
     QemuMutex lock;
     QemuCond cond;
+    QemuCond idle_cond;
+    bool pause_requested;
+    bool is_idle;
 
     MemoryRegion *ram;
     uint8_t *ram_ptr;

--- a/hw/xbox/mcpx/apu/apu_int.h
+++ b/hw/xbox/mcpx/apu/apu_int.h
@@ -33,7 +33,6 @@
 #include "qemu/main-loop.h"
 #include "qemu/thread.h"
 #include "system/runstate.h"
-#include "qemu/fifo8.h"
 #include "ui/xemu-settings.h"
 
 #include "trace.h"
@@ -100,9 +99,7 @@ typedef struct MCPXAPUState {
 
     struct {
         McpxApuDebugMonitorPoint point;
-        int16_t frame_buf[256][2]; // 1 EP frame (0x400 bytes), 8 buffered
-        QemuSpin fifo_lock;
-        Fifo8 fifo;
+        int16_t frame_buf[256][2]; // 1 EP frame (0x400 bytes)
         SDL_AudioStream *stream;
     } monitor;
 } MCPXAPUState;

--- a/hw/xbox/mcpx/apu/apu_int.h
+++ b/hw/xbox/mcpx/apu/apu_int.h
@@ -96,6 +96,7 @@ typedef struct MCPXAPUState {
     int sleep_acc_us;
     int frame_count;
     int64_t frame_count_time_ms;
+    int64_t next_frame_time_us;
 
     struct {
         McpxApuDebugMonitorPoint point;

--- a/hw/xbox/mcpx/apu/vp/vp.c
+++ b/hw/xbox/mcpx/apu/vp/vp.c
@@ -1646,7 +1646,7 @@ static void voice_work_acquire_voice_lock_for_processing(MCPXAPUState *d, int v)
     while (is_voice_locked(d, v)) {
         /* Stall until voice is available */
         qemu_spin_unlock(&d->vp.voice_spinlocks[v]);
-        qemu_cond_wait(&d->cond, &d->lock);
+        qemu_cond_timedwait(&d->cond, &d->lock, 1);
         qemu_spin_lock(&d->vp.voice_spinlocks[v]);
     }
 }

--- a/hw/xbox/mcpx/apu/vp/vp.c
+++ b/hw/xbox/mcpx/apu/vp/vp.c
@@ -133,15 +133,17 @@ static void voice_off(MCPXAPUState *d, uint16_t v)
 static void voice_lock(MCPXAPUState *d, uint16_t v, bool lock)
 {
     assert(v < MCPX_HW_MAX_VOICES);
-    qemu_spin_lock(&d->vp.voice_spinlocks[v]);
+    qemu_mutex_lock(&d->lock);
+
     uint64_t mask = 1LL << (v % 64);
     if (lock) {
         d->vp.voice_locked[v / 64] |= mask;
     } else {
         d->vp.voice_locked[v / 64] &= ~mask;
     }
-    qemu_spin_unlock(&d->vp.voice_spinlocks[v]);
-    qemu_cond_broadcast(&d->cond);
+
+    qemu_cond_signal(&d->cond);
+    qemu_mutex_unlock(&d->lock);
 }
 
 static bool is_voice_locked(MCPXAPUState *d, uint16_t v)
@@ -1640,17 +1642,6 @@ static void *voice_worker_thread(void *arg)
     return NULL;
 }
 
-static void voice_work_acquire_voice_lock_for_processing(MCPXAPUState *d, int v)
-{
-    qemu_spin_lock(&d->vp.voice_spinlocks[v]);
-    while (is_voice_locked(d, v)) {
-        /* Stall until voice is available */
-        qemu_spin_unlock(&d->vp.voice_spinlocks[v]);
-        qemu_cond_timedwait(&d->cond, &d->lock, 1);
-        qemu_spin_lock(&d->vp.voice_spinlocks[v]);
-    }
-}
-
 static void voice_work_enqueue(MCPXAPUState *d, int v, int list)
 {
     VoiceWorkDispatch *vwd = &d->vp.voice_work_dispatch;
@@ -1660,17 +1651,6 @@ static void voice_work_enqueue(MCPXAPUState *d, int v, int list)
         .voice = v,
         .list = list,
     };
-
-    voice_work_acquire_voice_lock_for_processing(d, v);
-}
-
-static void voice_work_release_voice_locks(MCPXAPUState *d)
-{
-    VoiceWorkDispatch *vwd = &d->vp.voice_work_dispatch;
-
-    for (int i = 0; i < vwd->queue_len; i++) {
-        qemu_spin_unlock(&d->vp.voice_spinlocks[vwd->queue[i].voice]);
-    }
 }
 
 static void voice_work_schedule(MCPXAPUState *d)
@@ -1722,6 +1702,19 @@ static void voice_work_schedule(MCPXAPUState *d)
     }
 }
 
+static bool any_queued_voice_locked(MCPXAPUState *d)
+{
+    VoiceWorkDispatch *vwd = &d->vp.voice_work_dispatch;
+
+    for (int i = 0; i < vwd->queue_len; i++) {
+        if (is_voice_locked(d, vwd->queue[i].voice)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static void
 voice_work_dispatch(MCPXAPUState *d,
                     float mixbins[NUM_MIXBINS][NUM_SAMPLES_PER_FRAME])
@@ -1729,6 +1722,19 @@ voice_work_dispatch(MCPXAPUState *d,
     VoiceWorkDispatch *vwd = &d->vp.voice_work_dispatch;
 
     int64_t start_time = qemu_clock_get_us(QEMU_CLOCK_REALTIME);
+
+    while (true) {
+        if (qatomic_read(&d->pause_requested)) {
+            vwd->queue_len = 0;
+            return;
+        }
+
+        if (!any_queued_voice_locked(d)) {
+            break;
+        }
+
+        qemu_cond_timedwait(&d->cond, &d->lock, 1);
+    }
 
     qemu_mutex_lock(&vwd->lock);
 
@@ -1740,7 +1746,6 @@ voice_work_dispatch(MCPXAPUState *d,
         qemu_cond_broadcast(&vwd->work_pending);
         qemu_cond_wait(&vwd->work_finished, &vwd->lock);
         assert(!vwd->workers_pending);
-        voice_work_release_voice_locks(d);
         vwd->queue_len = 0;
 
         // Add voice contributions
@@ -1852,10 +1857,6 @@ void mcpx_apu_vp_frame(MCPXAPUState *d, float mixbins[NUM_MIXBINS][NUM_SAMPLES_P
 
 void mcpx_apu_vp_init(MCPXAPUState *d)
 {
-    for (int i = 0; i < MCPX_HW_MAX_VOICES; i++) {
-        qemu_spin_init(&d->vp.voice_spinlocks[i]);
-    }
-
     voice_work_init(d);
 }
 

--- a/hw/xbox/mcpx/apu/vp/vp.h
+++ b/hw/xbox/mcpx/apu/vp/vp.h
@@ -87,7 +87,6 @@ typedef struct {
     uint8_t submix_headroom[NUM_MIXBINS];
     float sample_buf[NUM_SAMPLES_PER_FRAME][2];
     uint64_t voice_locked[4];
-    QemuSpin voice_spinlocks[MCPX_HW_MAX_VOICES];
 
     struct {
         int current_entry;


### PR DESCRIPTION
SDL3 lets us simplify some of this code

Fixes #354