### PR TITLE
u: Fix crash in SDL_Quit

### DIFF
--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -1180,6 +1180,8 @@ static void display_finalize(void)
     }
 
     SDL_RemoveEventWatch(event_watch_callback, &scon_list[0]);
+    SDL_GL_MakeCurrent(NULL, NULL);
+    SDL_GL_DestroyContext(m_context);
     SDL_DestroyWindow(m_window);
     SDL_Quit();
 }


### PR DESCRIPTION
Xemu crashes during shutdown
```
Thread 1 received signal SIGSEGV, Segmentation fault.
0x00007ff9fb5eeb1f in WIN_GL_MakeCurrent (_this=0x84b8a0, window=0x108a1440, context=0x0) at C:/src/SDL3/src/SDL3-3.4.0/src/video/windows/SDL_windowsopengl.c:875
875         hdc = window->internal->hdc;
(gdb) bt
#0  0x00007ff9fb5eeb1f in WIN_GL_MakeCurrent (_this=0x84b8a0, window=0x108a1440, context=0x0) at C:/src/SDL3/src/SDL3-3.4.0/src/video/windows/SDL_windowsopengl.c:875
#1  0x00007ff9fb5be13a in SDL_GL_MakeCurrent_REAL (window=0x0, window@entry=0x1141b000, context=context@entry=0x0) at C:/src/SDL3/src/SDL3-3.4.0/src/video/SDL_video.c:5445
#2  0x00007ff9fb5bfdad in SDL_DestroyWindow_REAL (window=0x1141b000) at C:/src/SDL3/src/SDL3-3.4.0/src/video/SDL_video.c:4551
#3  0x00007ff9fb5c06fc in SDL_VideoQuit () at C:/src/SDL3/src/SDL3-3.4.0/src/video/SDL_video.c:4668
#4  0x00007ff9fb491a7f in SDL_QuitSubSystem_REAL (flags=flags@entry=4294967295) at C:/src/SDL3/src/SDL3-3.4.0/src/SDL.c:629
#5  0x00007ff9fb4920b5 in SDL_Quit_REAL () at C:/src/SDL3/src/SDL3-3.4.0/src/SDL.c:685
#6  0x00007ff9fb4be9cc in SDL_Quit () at C:/src/SDL3/src/SDL3-3.4.0/src/dynapi/SDL_dynapi_procs.h:725
#7  0x00007ff74007ce52 in display_finalize () at C:/src/xemu/ui/xemu.c:1186
#8  main (argc=<optimized out>, argv=<optimized out>) at C:/src/xemu/ui/xemu.c:1376
```
I fixed it.