### PR TITLE
fix(vulkan): Add MoltenVK/Metal compatibility for macOS

### DIFF
--- a/hw/xbox/nv2a/pgraph/glsl/psh.c
+++ b/hw/xbox/nv2a/pgraph/glsl/psh.c
@@ -995,7 +995,22 @@ static MString* psh_convert(struct PixelShader *ps)
                              "}\n");
     }
 
-    if (ps->state->z_perspective) {
+    // TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+    if (ps->state->use_hw_depth) {
+        /* When Geometry Shaders are unavailable (e.g. MoltenVK), vtxPos0/1/2
+         * and triMZ cannot be correctly computed per-triangle. Fall back to
+         * hardware-interpolated depth from gl_FragCoord.z, scaled to the
+         * depth range expected by the Xbox NV2A pipeline.
+         * Use dFdx/dFdy to approximate the depth slope that triMZ provides.
+         */
+        mstring_append(clip,
+                       "float zvalue = gl_FragCoord.z * clipRange.y;\n"
+                       "float hw_dzdx = dFdx(gl_FragCoord.z) * clipRange.y;\n"
+                       "float hw_dzdy = dFdy(gl_FragCoord.z) * clipRange.y;\n"
+                       "float hw_maxSlope = max(abs(hw_dzdx), abs(hw_dzdy));\n"
+                       "zvalue += depthOffset;\n"
+                       "zvalue += depthFactor * hw_maxSlope;\n");
+    } else if (ps->state->z_perspective) {
         mstring_append(
             clip,
             "vec2 unscaled_xy = gl_FragCoord.xy / surfaceScale;\n"

--- a/hw/xbox/nv2a/pgraph/glsl/psh.h
+++ b/hw/xbox/nv2a/pgraph/glsl/psh.h
@@ -70,6 +70,9 @@ typedef struct PshState {
     bool depth_clipping;
     bool z_perspective;
 
+    // TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+    bool use_hw_depth;
+
     unsigned int surface_zeta_format;
     enum PshDepthFormat depth_format;
 } PshState;

--- a/hw/xbox/nv2a/pgraph/vk/display.c
+++ b/hw/xbox/nv2a/pgraph/vk/display.c
@@ -617,6 +617,10 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
         .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
     };
 
+    // TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+#if HAVE_EXTERNAL_MEMORY
+    // External memory extensions (VK_KHR_external_memory) are not supported
+    // on macOS/MoltenVK. Disabling this struct prevents Vulkan app crashes.
     VkExternalMemoryImageCreateInfo external_memory_image_create_info = {
         .sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO,
 #ifdef WIN32
@@ -626,6 +630,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
 #endif
     };
     image_create_info.pNext = &external_memory_image_create_info;
+#endif
 
     VK_CHECK(vkCreateImage(r->device, &image_create_info, NULL, &d->image));
 
@@ -641,6 +646,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
                                       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT),
     };
 
+#if HAVE_EXTERNAL_MEMORY
     VkExportMemoryAllocateInfo export_memory_alloc_info = {
         .sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO,
         .handleTypes =
@@ -652,6 +658,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
             ,
     };
     alloc_info.pNext = &export_memory_alloc_info;
+#endif
 
     VK_CHECK(vkAllocateMemory(r->device, &alloc_info, NULL, &d->memory));
     VK_CHECK(vkBindImageMemory(r->device, d->image, d->memory, 0));

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -54,6 +54,31 @@ static VkPrimitiveTopology get_primitive_topology(PGRAPHState *pg)
     int polygon_mode = r->shader_binding->state.geom.polygon_front_mode;
     int primitive_mode = r->shader_binding->state.geom.primitive_mode;
 
+    // TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+    if (!r->supports_geometry_shaders) {
+        switch (primitive_mode) {
+        case PRIM_TYPE_LINE_LOOP:
+            return VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
+        case PRIM_TYPE_QUADS:
+        case PRIM_TYPE_QUAD_STRIP:
+        case PRIM_TYPE_TRIANGLES:
+            if (polygon_mode == POLY_MODE_FILL) {
+                return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+            } else if (polygon_mode == POLY_MODE_LINE) {
+                return VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
+            } else {
+                return VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
+            }
+        case PRIM_TYPE_POLYGON:
+            if (polygon_mode == POLY_MODE_LINE) {
+                return VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
     // FIXME: Replace with LUT
     switch (primitive_mode) {
     case PRIM_TYPE_POINTS:
@@ -87,6 +112,302 @@ static VkPrimitiveTopology get_primitive_topology(PGRAPHState *pg)
         assert(!"Invalid primitive_mode");
         return 0;
     }
+}
+
+static bool draw_needs_primitive_emulation(PGRAPHState *pg)
+{
+    PGRAPHVkState *r = pg->vk_renderer_state;
+
+    if (r->supports_geometry_shaders) {
+        return false;
+    }
+
+    // Read primitive and polygon modes directly from hardware registers instead
+    // of relying on r->shader_binding. This prevents stale shader state from
+    // causing assertions or crashes (SIGSEGV) when binding shaders mid-draw,
+    // particularly noticeable on macOS/MoltenVK.
+    int polygon_mode = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER),
+                                NV_PGRAPH_SETUPRASTER_FRONTFACEMODE);
+    int primitive_mode = pg->primitive_mode;
+
+    switch (primitive_mode) {
+    case PRIM_TYPE_LINE_LOOP:
+    case PRIM_TYPE_QUADS:
+    case PRIM_TYPE_QUAD_STRIP:
+        return true;
+    case PRIM_TYPE_TRIANGLES: {
+        // MoltenVK lacks reliable support for VK_EXT_provoking_vertex.
+        // We detect the expected provoking vertex behavior from hardware
+        // registers to emulate the vertex rotation on the CPU later if needed.
+        bool first_vertex = (pgraph_reg_r(pg, NV_PGRAPH_CONTROL_3) &
+                             NV_PGRAPH_CONTROL_3_PROVOKING_VERTEX) ==
+                            NV_PGRAPH_CONTROL_3_PROVOKING_VERTEX_FIRST;
+        return first_vertex;
+    }
+    case PRIM_TYPE_POLYGON:
+        return polygon_mode == POLY_MODE_LINE;
+    default:
+        return false;
+    }
+}
+
+static size_t get_max_emulated_index_count(PGRAPHState *pg, uint32_t in_count)
+{
+    PGRAPHVkState *r = pg->vk_renderer_state;
+
+    int polygon_mode = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER),
+                                NV_PGRAPH_SETUPRASTER_FRONTFACEMODE);
+    int primitive_mode = pg->primitive_mode;
+
+    size_t result = 0;
+    switch (primitive_mode) {
+    case PRIM_TYPE_LINE_LOOP:
+        result = in_count > 1 ? in_count * 2 : 0;
+        break;
+    case PRIM_TYPE_QUADS: {
+        size_t quads = in_count / 4;
+        if (polygon_mode == POLY_MODE_FILL) {
+            result = quads * 6;
+        } else if (polygon_mode == POLY_MODE_LINE) {
+            result = quads * 8;
+        } else {
+            result = quads * 4;
+        }
+        break;
+    }
+    case PRIM_TYPE_QUAD_STRIP: {
+        size_t quads = in_count >= 4 ? (in_count - 2) / 2 : 0;
+        if (polygon_mode == POLY_MODE_FILL) {
+            result = quads * 6;
+        } else if (polygon_mode == POLY_MODE_LINE) {
+            result = quads * 8;
+        } else {
+            result = quads * 4;
+        }
+        break;
+    }
+    case PRIM_TYPE_TRIANGLES:
+        result = in_count;
+        break;
+    case PRIM_TYPE_POLYGON:
+        result =
+            (polygon_mode == POLY_MODE_LINE && in_count > 1) ? in_count * 2 : 0;
+        break;
+    default:
+        result = 0;
+        break;
+    }
+
+    return result;
+}
+
+static size_t build_emulated_indices_from_array(PGRAPHState *pg, uint32_t start,
+                                                uint32_t count, uint32_t *out)
+{
+    PGRAPHVkState *r = pg->vk_renderer_state;
+
+    int polygon_mode = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER),
+                                NV_PGRAPH_SETUPRASTER_FRONTFACEMODE);
+    int primitive_mode = pg->primitive_mode;
+    size_t j = 0;
+
+#define EMIT2(a, b)     \
+    do {                \
+        out[j++] = (a); \
+        out[j++] = (b); \
+    } while (0)
+#define EMIT3(a, b, c)  \
+    do {                \
+        out[j++] = (a); \
+        out[j++] = (b); \
+        out[j++] = (c); \
+    } while (0)
+#define EMIT4(a, b, c, d) \
+    do {                  \
+        out[j++] = (a);   \
+        out[j++] = (b);   \
+        out[j++] = (c);   \
+        out[j++] = (d);   \
+    } while (0)
+
+    switch (primitive_mode) {
+    case PRIM_TYPE_LINE_LOOP:
+    case PRIM_TYPE_POLYGON:
+        if (count <= 1) {
+            break;
+        }
+        for (uint32_t i = 0; i < count - 1; i++) {
+            EMIT2(start + i, start + i + 1);
+        }
+        EMIT2(start + count - 1, start);
+        break;
+    case PRIM_TYPE_QUADS:
+        for (uint32_t i = 0; i + 3 < count; i += 4) {
+            uint32_t v0 = start + i;
+            uint32_t v1 = start + i + 1;
+            uint32_t v2 = start + i + 2;
+            uint32_t v3 = start + i + 3;
+            if (polygon_mode == POLY_MODE_FILL) {
+                EMIT3(v0, v1, v3);
+                EMIT3(v1, v2, v3);
+            } else if (polygon_mode == POLY_MODE_LINE) {
+                EMIT2(v0, v1);
+                EMIT2(v1, v2);
+                EMIT2(v2, v3);
+                EMIT2(v3, v0);
+            } else {
+                EMIT4(v0, v1, v2, v3);
+            }
+        }
+        break;
+    case PRIM_TYPE_QUAD_STRIP:
+        for (uint32_t i = 0; i + 3 < count; i += 2) {
+            uint32_t v0 = start + i;
+            uint32_t v1 = start + i + 1;
+            uint32_t v2 = start + i + 2;
+            uint32_t v3 = start + i + 3;
+            if (polygon_mode == POLY_MODE_FILL) {
+                EMIT3(v0, v1, v3);
+                EMIT3(v0, v3, v2);
+            } else if (polygon_mode == POLY_MODE_LINE) {
+                EMIT2(v0, v1);
+                EMIT2(v1, v3);
+                EMIT2(v3, v2);
+                EMIT2(v2, v0);
+            } else {
+                EMIT4(v0, v1, v2, v3);
+            }
+        }
+        break;
+    case PRIM_TYPE_TRIANGLES: {
+        bool first_vertex = (pgraph_reg_r(pg, NV_PGRAPH_CONTROL_3) &
+                             NV_PGRAPH_CONTROL_3_PROVOKING_VERTEX) ==
+                            NV_PGRAPH_CONTROL_3_PROVOKING_VERTEX_FIRST;
+        if (first_vertex && polygon_mode == POLY_MODE_FILL) {
+            // Emulate provoking vertex = first (required by Xbox) on macOS by
+            // rotating the indices manually since Apple's Metal API lacks
+            // provoking vertex control.
+            for (uint32_t i = 0; i + 2 < count; i += 3) {
+                uint32_t v0 = start + i;
+                uint32_t v1 = start + i + 1;
+                uint32_t v2 = start + i + 2;
+                EMIT3(v1, v2, v0);
+            }
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+#undef EMIT4
+#undef EMIT3
+#undef EMIT2
+    return j;
+}
+
+static size_t build_emulated_indices_from_elements(PGRAPHState *pg,
+                                                   const uint32_t *in,
+                                                   uint32_t in_count,
+                                                   uint32_t *out)
+{
+    PGRAPHVkState *r = pg->vk_renderer_state;
+
+    int polygon_mode = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER),
+                                NV_PGRAPH_SETUPRASTER_FRONTFACEMODE);
+    int primitive_mode = pg->primitive_mode;
+    size_t j = 0;
+
+#define EMIT2(a, b)     \
+    do {                \
+        out[j++] = (a); \
+        out[j++] = (b); \
+    } while (0)
+#define EMIT3(a, b, c)  \
+    do {                \
+        out[j++] = (a); \
+        out[j++] = (b); \
+        out[j++] = (c); \
+    } while (0)
+#define EMIT4(a, b, c, d) \
+    do {                  \
+        out[j++] = (a);   \
+        out[j++] = (b);   \
+        out[j++] = (c);   \
+        out[j++] = (d);   \
+    } while (0)
+
+    switch (primitive_mode) {
+    case PRIM_TYPE_LINE_LOOP:
+    case PRIM_TYPE_POLYGON:
+        if (in_count <= 1) {
+            break;
+        }
+        for (uint32_t i = 0; i < in_count - 1; i++) {
+            EMIT2(in[i], in[i + 1]);
+        }
+        EMIT2(in[in_count - 1], in[0]);
+        break;
+    case PRIM_TYPE_QUADS:
+        for (uint32_t i = 0; i + 3 < in_count; i += 4) {
+            uint32_t v0 = in[i];
+            uint32_t v1 = in[i + 1];
+            uint32_t v2 = in[i + 2];
+            uint32_t v3 = in[i + 3];
+            if (polygon_mode == POLY_MODE_FILL) {
+                EMIT3(v0, v1, v3);
+                EMIT3(v1, v2, v3);
+            } else if (polygon_mode == POLY_MODE_LINE) {
+                EMIT2(v0, v1);
+                EMIT2(v1, v2);
+                EMIT2(v2, v3);
+                EMIT2(v3, v0);
+            } else {
+                EMIT4(v0, v1, v2, v3);
+            }
+        }
+        break;
+    case PRIM_TYPE_QUAD_STRIP:
+        for (uint32_t i = 0; i + 3 < in_count; i += 2) {
+            uint32_t v0 = in[i];
+            uint32_t v1 = in[i + 1];
+            uint32_t v2 = in[i + 2];
+            uint32_t v3 = in[i + 3];
+            if (polygon_mode == POLY_MODE_FILL) {
+                EMIT3(v0, v1, v3);
+                EMIT3(v0, v3, v2);
+            } else if (polygon_mode == POLY_MODE_LINE) {
+                EMIT2(v0, v1);
+                EMIT2(v1, v3);
+                EMIT2(v3, v2);
+                EMIT2(v2, v0);
+            } else {
+                EMIT4(v0, v1, v2, v3);
+            }
+        }
+        break;
+    case PRIM_TYPE_TRIANGLES: {
+        bool first_vertex = (pgraph_reg_r(pg, NV_PGRAPH_CONTROL_3) &
+                             NV_PGRAPH_CONTROL_3_PROVOKING_VERTEX) ==
+                            NV_PGRAPH_CONTROL_3_PROVOKING_VERTEX_FIRST;
+        if (first_vertex && polygon_mode == POLY_MODE_FILL) {
+            // Emulate provoking vertex = first (required by Xbox) on macOS by
+            // rotating the indices manually since Apple's Metal API lacks
+            // provoking vertex control.
+            for (uint32_t i = 0; i + 2 < in_count; i += 3) {
+                EMIT3(in[i + 1], in[i + 2], in[i]);
+            }
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+#undef EMIT4
+#undef EMIT3
+#undef EMIT2
+    return j;
 }
 
 static void pipeline_cache_entry_init(Lru *lru, LruNode *node,
@@ -790,10 +1111,11 @@ static void create_pipeline(PGRAPHState *pg)
 
     VkPipelineRasterizationStateCreateInfo rasterizer = {
         .sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
-        .depthClampEnable = VK_TRUE,
+        .depthClampEnable =
+            r->enabled_physical_device_features.depthClamp ? VK_TRUE : VK_FALSE,
         .rasterizerDiscardEnable = VK_FALSE,
-        .polygonMode = pgraph_polygon_mode_vk_map[r->shader_binding->state
-                                                      .geom.polygon_front_mode],
+        .polygonMode = pgraph_polygon_mode_vk_map[r->shader_binding->state.geom
+                                                      .polygon_front_mode],
         .lineWidth = 1.0f,
         .frontFace = (pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER) &
                       NV_PGRAPH_SETUPRASTER_FRONTFACE) ?
@@ -802,8 +1124,13 @@ static void create_pipeline(PGRAPHState *pg)
         .depthBiasEnable = VK_FALSE,
         .pNext = rasterizer_next_struct,
     };
+    if (!r->enabled_physical_device_features.fillModeNonSolid &&
+        rasterizer.polygonMode != VK_POLYGON_MODE_FILL) {
+        rasterizer.polygonMode = VK_POLYGON_MODE_FILL;
+    }
 
-    if (pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER) & NV_PGRAPH_SETUPRASTER_CULLENABLE) {
+    if (pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER) &
+        NV_PGRAPH_SETUPRASTER_CULLENABLE) {
         uint32_t cull_face = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_SETUPRASTER),
                                       NV_PGRAPH_SETUPRASTER_CULLCTRL);
         assert(cull_face < ARRAY_SIZE(pgraph_cull_face_vk_map));
@@ -825,8 +1152,8 @@ static void create_pipeline(PGRAPHState *pg)
 
     if (depth_test) {
         depth_stencil.depthTestEnable = VK_TRUE;
-        uint32_t depth_func =
-            GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_CONTROL_0), NV_PGRAPH_CONTROL_0_ZFUNC);
+        uint32_t depth_func = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_CONTROL_0),
+                                       NV_PGRAPH_CONTROL_0_ZFUNC);
         assert(depth_func < ARRAY_SIZE(pgraph_depth_func_vk_map));
         depth_stencil.depthCompareOp = pgraph_depth_func_vk_map[depth_func];
     }
@@ -1067,8 +1394,12 @@ static void begin_query(PGRAPHVkState *r)
     nv2a_profile_inc_counter(NV2A_PROF_QUERY);
     vkCmdResetQueryPool(r->command_buffer, r->query_pool,
                         r->num_queries_in_flight, 1);
+    VkQueryControlFlags query_flags = 0;
+    if (r->enabled_physical_device_features.occlusionQueryPrecise) {
+        query_flags |= VK_QUERY_CONTROL_PRECISE_BIT;
+    }
     vkCmdBeginQuery(r->command_buffer, r->query_pool, r->num_queries_in_flight,
-                    VK_QUERY_CONTROL_PRECISE_BIT);
+                    query_flags);
 
     r->query_in_flight = true;
     r->new_query_needed = false;
@@ -2050,17 +2381,55 @@ void pgraph_vk_flush_draw(NV2AState *d)
         sync_vertex_ram_buffer(pg);
         VertexBufferRemap remap = remap_unaligned_attributes(pg, max_element);
 
+        // TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+        bool emulate_primitives = draw_needs_primitive_emulation(pg);
+        if (emulate_primitives) {
+            size_t total_index_count = 0;
+            for (int i = 0; i < pg->draw_arrays_length; i++) {
+                total_index_count += get_max_emulated_index_count(pg, pg->draw_arrays_count[i]);
+            }
+            ensure_buffer_space(pg, BUFFER_INDEX_STAGING,
+                                   total_index_count * sizeof(uint32_t));
+        }
+
         begin_pre_draw(pg);
         copy_remapped_attributes_to_inline_buffer(pg, remap, 0, max_element);
         pgraph_vk_begin_debug_marker(r, r->command_buffer, RGBA_BLUE,
                                      "Draw Arrays");
         begin_draw(pg);
         bind_vertex_buffer(pg, remap.attributes, 0);
-        for (int i = 0; i < pg->draw_arrays_length; i++) {
-            uint32_t start = pg->draw_arrays_start[i],
-                     count = pg->draw_arrays_count[i];
-            NV2A_VK_DPRINTF("- [%d] Start:%d Count:%d", i, start, count);
-            vkCmdDraw(r->command_buffer, count, 1, start, 0);
+        if (emulate_primitives) {
+            for (int i = 0; i < pg->draw_arrays_length; i++) {
+                uint32_t start = pg->draw_arrays_start[i];
+                uint32_t count = pg->draw_arrays_count[i];
+                size_t max_index_count =
+                    get_max_emulated_index_count(pg, count);
+                if (max_index_count == 0) {
+                    continue;
+                }
+
+                g_autofree uint32_t *indices =
+                    g_malloc_n(max_index_count, sizeof(indices[0]));
+                size_t index_count = build_emulated_indices_from_array(
+                    pg, start, count, indices);
+                if (index_count == 0) {
+                    continue;
+                }
+
+                VkDeviceSize buffer_offset = pgraph_vk_update_index_buffer(
+                    pg, indices, index_count * sizeof(indices[0]));
+                vkCmdBindIndexBuffer(r->command_buffer,
+                                     r->storage_buffers[BUFFER_INDEX].buffer,
+                                     buffer_offset, VK_INDEX_TYPE_UINT32);
+                vkCmdDrawIndexed(r->command_buffer, index_count, 1, 0, 0, 0);
+            }
+        } else {
+            for (int i = 0; i < pg->draw_arrays_length; i++) {
+                uint32_t start = pg->draw_arrays_start[i],
+                         count = pg->draw_arrays_count[i];
+                NV2A_VK_DPRINTF("- [%d] Start:%d Count:%d", i, start, count);
+                vkCmdDraw(r->command_buffer, count, 1, start, 0);
+            }
         }
         end_draw(pg);
         pgraph_vk_end_debug_marker(r, r->command_buffer);
@@ -2073,8 +2442,13 @@ void pgraph_vk_flush_draw(NV2AState *d)
 
         nv2a_profile_inc_counter(NV2A_PROF_INLINE_ELEMENTS);
 
-        size_t index_data_size =
-            pg->inline_elements_length * sizeof(pg->inline_elements[0]);
+        bool emulate_primitives = draw_needs_primitive_emulation(pg);
+        size_t index_count = pg->inline_elements_length;
+        if (emulate_primitives) {
+            index_count =
+                get_max_emulated_index_count(pg, pg->inline_elements_length);
+        }
+        size_t index_data_size = index_count * sizeof(pg->inline_elements[0]);
 
         ensure_buffer_space(pg, BUFFER_INDEX_STAGING, index_data_size);
 
@@ -2092,17 +2466,27 @@ void pgraph_vk_flush_draw(NV2AState *d)
 
         begin_pre_draw(pg);
         copy_remapped_attributes_to_inline_buffer(pg, remap, 0, max_element + 1);
-        VkDeviceSize buffer_offset = pgraph_vk_update_index_buffer(
-            pg, pg->inline_elements, index_data_size);
-        pgraph_vk_begin_debug_marker(r, r->command_buffer, RGBA_BLUE,
-                                     "Inline Elements");
+        const uint32_t *indices = pg->inline_elements;
+        g_autofree uint32_t *emulated_indices = NULL;
+        if (emulate_primitives) {
+            emulated_indices =
+                g_malloc_n(index_count, sizeof(emulated_indices[0]));
+            index_count = build_emulated_indices_from_elements(
+                pg, pg->inline_elements, pg->inline_elements_length,
+                emulated_indices);
+            indices = emulated_indices;
+        }
+        pgraph_vk_begin_debug_marker(r, r->command_buffer, RGBA_BLUE, "Inline Elements");
         begin_draw(pg);
         bind_vertex_buffer(pg, remap.attributes, 0);
-        vkCmdBindIndexBuffer(r->command_buffer,
-                             r->storage_buffers[BUFFER_INDEX].buffer,
-                             buffer_offset, VK_INDEX_TYPE_UINT32);
-        vkCmdDrawIndexed(r->command_buffer, pg->inline_elements_length, 1, 0, 0,
-                         0);
+        if (index_count > 0) {
+            VkDeviceSize buffer_offset = pgraph_vk_update_index_buffer(
+                pg, (void *)indices, index_count * sizeof(indices[0]));
+            vkCmdBindIndexBuffer(r->command_buffer,
+                                 r->storage_buffers[BUFFER_INDEX].buffer,
+                                 buffer_offset, VK_INDEX_TYPE_UINT32);
+            vkCmdDrawIndexed(r->command_buffer, index_count, 1, 0, 0, 0);
+        }
         end_draw(pg);
         pgraph_vk_end_debug_marker(r, r->command_buffer);
 
@@ -2130,6 +2514,14 @@ void pgraph_vk_flush_draw(NV2AState *d)
             attr->inline_buffer_populated = false;
             offset += vertex_data_size;
         }
+        bool emulate_primitives = draw_needs_primitive_emulation(pg);
+        size_t emulated_index_count = 0;
+        if (emulate_primitives) {
+            emulated_index_count =
+                get_max_emulated_index_count(pg, pg->inline_buffer_length);
+            ensure_buffer_space(pg, BUFFER_INDEX_STAGING,
+                                emulated_index_count * sizeof(uint32_t));
+        }
         ensure_buffer_space(pg, BUFFER_VERTEX_INLINE_STAGING, offset);
 
         begin_pre_draw(pg);
@@ -2139,7 +2531,22 @@ void pgraph_vk_flush_draw(NV2AState *d)
                                      "Inline Buffer");
         begin_draw(pg);
         bind_inline_vertex_buffer(pg, buffer_offset);
-        vkCmdDraw(r->command_buffer, pg->inline_buffer_length, 1, 0, 0);
+        if (emulate_primitives) {
+            g_autofree uint32_t *indices =
+                g_malloc_n(emulated_index_count, sizeof(indices[0]));
+            size_t index_count = build_emulated_indices_from_array(
+                pg, 0, pg->inline_buffer_length, indices);
+            if (index_count > 0) {
+                VkDeviceSize index_offset = pgraph_vk_update_index_buffer(
+                    pg, indices, index_count * sizeof(indices[0]));
+                vkCmdBindIndexBuffer(r->command_buffer,
+                                     r->storage_buffers[BUFFER_INDEX].buffer,
+                                     index_offset, VK_INDEX_TYPE_UINT32);
+                vkCmdDrawIndexed(r->command_buffer, index_count, 1, 0, 0, 0);
+            }
+        } else {
+            vkCmdDraw(r->command_buffer, pg->inline_buffer_length, 1, 0, 0);
+        }
         end_draw(pg);
         pgraph_vk_end_debug_marker(r, r->command_buffer);
 
@@ -2174,6 +2581,14 @@ void pgraph_vk_flush_draw(NV2AState *d)
         NV2A_DPRINTF("draw inline array %d, %d\n", vertex_size, index_count);
         pgraph_vk_bind_vertex_attributes(d, 0, index_count - 1, true,
                                          vertex_size, index_count - 1);
+        bool emulate_primitives = draw_needs_primitive_emulation(pg);
+        size_t emulated_index_count = 0;
+        if (emulate_primitives) {
+            emulated_index_count =
+                get_max_emulated_index_count(pg, index_count);
+            ensure_buffer_space(pg, BUFFER_INDEX_STAGING,
+                                emulated_index_count * sizeof(uint32_t));
+        }
 
         begin_pre_draw(pg);
         void *inline_array_data = pg->inline_array;
@@ -2183,7 +2598,23 @@ void pgraph_vk_flush_draw(NV2AState *d)
                                      "Inline Array");
         begin_draw(pg);
         bind_inline_vertex_buffer(pg, buffer_offset);
-        vkCmdDraw(r->command_buffer, index_count, 1, 0, 0);
+        if (emulate_primitives) {
+            g_autofree uint32_t *indices =
+                g_malloc_n(emulated_index_count, sizeof(indices[0]));
+            size_t actual_index_count =
+                build_emulated_indices_from_array(pg, 0, index_count, indices);
+            if (actual_index_count > 0) {
+                VkDeviceSize index_offset = pgraph_vk_update_index_buffer(
+                    pg, indices, actual_index_count * sizeof(indices[0]));
+                vkCmdBindIndexBuffer(r->command_buffer,
+                                     r->storage_buffers[BUFFER_INDEX].buffer,
+                                     index_offset, VK_INDEX_TYPE_UINT32);
+                vkCmdDrawIndexed(r->command_buffer, actual_index_count, 1, 0, 0,
+                                 0);
+            }
+        } else {
+            vkCmdDraw(r->command_buffer, index_count, 1, 0, 0);
+        }
         end_draw(pg);
         pgraph_vk_end_debug_marker(r, r->command_buffer);
         NV2A_VK_DGROUP_END();

--- a/hw/xbox/nv2a/pgraph/vk/instance.c
+++ b/hw/xbox/nv2a/pgraph/vk/instance.c
@@ -25,6 +25,15 @@
 #define VkExtensionPropertiesArray GArray
 #define StringArray GArray
 
+// TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+/*
+ * Older Vulkan headers may miss this extension name macro even when runtime
+ * drivers expose it (e.g. MoltenVK portability subset).
+ */
+#ifndef VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME
+#define VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME "VK_KHR_portability_subset"
+#endif
+
 static bool enable_validation = false;
 
 static char const *const validation_layers[] = {
@@ -32,12 +41,24 @@ static char const *const validation_layers[] = {
 };
 
 static char const *const required_device_extensions[] = {
+#if HAVE_EXTERNAL_MEMORY
 #ifdef WIN32
     VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,
     VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,
 #else
     VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
     VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
+#endif
+#endif
+
+// TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+#ifdef __APPLE__
+    /*
+     * macOS/MoltenVK requires the Portability Subset extension to be explicitly
+     * enabled, otherwise the physical device will be hidden and Vulkan
+     * initialization will fail on Apple Silicon.
+     */
+    VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME,
 #endif
 };
 
@@ -142,6 +163,15 @@ add_optional_instance_extension_names(PGRAPHState *pg,
         g_config.display.vulkan.validation_layers &&
         add_extension_if_available(available_extensions, enabled_extension_names,
                                    VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+#ifdef __APPLE__
+    /* Allow enumeration of MoltenVK portability devices */
+    r->portability_enumeration_extension_enabled = add_extension_if_available(
+        available_extensions, enabled_extension_names,
+        VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+#else
+    r->portability_enumeration_extension_enabled = false;
+#endif
 }
 
 static bool create_instance(PGRAPHState *pg, Error **errp)
@@ -200,6 +230,11 @@ static bool create_instance(PGRAPHState *pg, Error **errp)
         .ppEnabledExtensionNames =
             &g_array_index(enabled_extension_names, const char *, 0),
     };
+#ifdef __APPLE__
+    if (r->portability_enumeration_extension_enabled) {
+        create_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+    }
+#endif
 
     enable_validation = g_config.display.vulkan.validation_layers;
 
@@ -487,6 +522,20 @@ static bool create_logical_device(PGRAPHState *pg, Error **errp)
             .enabled = &r->enabled_physical_device_features.n, \
             .required = req, \
         }
+        // macOS (Metal/MoltenVK) lacks native support for geometry shaders and
+        // some other strict features. Relaxing these requirements here enables
+        // Vulkan to initialize on Apple Silicon.
+#ifdef __APPLE__
+// TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+        F(depthClamp, false),
+        F(fillModeNonSolid, false),
+        F(geometryShader, false),
+        F(occlusionQueryPrecise, false),
+        F(samplerAnisotropy, false),
+        F(shaderClipDistance, true),
+        F(shaderTessellationAndGeometryPointSize, false),
+        F(wideLines, false),
+#else
         F(depthClamp, true),
         F(fillModeNonSolid, true),
         F(geometryShader, true),
@@ -495,6 +544,7 @@ static bool create_logical_device(PGRAPHState *pg, Error **errp)
         F(shaderClipDistance, true),
         F(shaderTessellationAndGeometryPointSize, true),
         F(wideLines, false),
+#endif
         #undef F
         // clang-format on
     };
@@ -515,6 +565,8 @@ static bool create_logical_device(PGRAPHState *pg, Error **errp)
         error_setg(errp, "Device does not support required features");
         return false;
     }
+    r->supports_geometry_shaders =
+        r->enabled_physical_device_features.geometryShader == VK_TRUE;
 
     void *next_struct = NULL;
 

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -41,7 +41,14 @@
 #include "constants.h"
 #include "glsl.h"
 
+// TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+#if defined(__APPLE__)
+// Native external memory extensions are not supported on macOS/MoltenVK.
+// Disabling them prevents Vulkan from crashing during initialization.
+#define HAVE_EXTERNAL_MEMORY 0
+#else
 #define HAVE_EXTERNAL_MEMORY 1
+#endif
 
 typedef struct QueueFamilyIndices {
     int queue_family;
@@ -325,8 +332,15 @@ typedef struct PGRAPHVkState {
     int debug_depth;
 
     bool debug_utils_extension_enabled;
+
+    // TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+    bool portability_enumeration_extension_enabled;
+
     bool custom_border_color_extension_enabled;
     bool memory_budget_extension_enabled;
+
+    // TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+    bool supports_geometry_shaders;
 
     VkPhysicalDevice physical_device;
     VkPhysicalDeviceFeatures enabled_physical_device_features;

--- a/hw/xbox/nv2a/pgraph/vk/shaders.c
+++ b/hw/xbox/nv2a/pgraph/vk/shaders.c
@@ -207,10 +207,16 @@ void pgraph_vk_update_descriptor_sets(PGRAPHState *pg)
 
     VkDescriptorImageInfo image_infos[NV2A_MAX_TEXTURES];
     for (int i = 0; i < NV2A_MAX_TEXTURES; i++) {
+        // TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+        TextureBinding *tex_binding = r->texture_bindings[i];
+        if (!tex_binding) {
+            tex_binding = &r->dummy_texture;
+        }
+
         image_infos[i] = (VkDescriptorImageInfo){
             .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-            .imageView = r->texture_bindings[i]->image_view,
-            .sampler = r->texture_bindings[i]->sampler,
+            .imageView = tex_binding->image_view,
+            .sampler = tex_binding->sampler,
         };
         descriptor_writes[2 + i] = (VkWriteDescriptorSet){
             .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
@@ -264,7 +270,12 @@ static void shader_cache_entry_init(Lru *lru, LruNode *node, const void *state)
 
     ShaderModuleCacheKey key;
 
-    bool need_geometry_shader = pgraph_glsl_need_geom(&binding->state.geom);
+    // TODO: MoltenVK Fix: change this when there's a better solution for MoltenVK.
+    // The r->supports_geometry_shaders flag is false on macOS since Metal
+    // lacks native Geometry Shaders. This safely skips building and binding
+    // the Z-buffer calculations via geom shaders on Apple chips.
+    bool need_geometry_shader = r->supports_geometry_shaders &&
+                                pgraph_glsl_need_geom(&binding->state.geom);
     if (need_geometry_shader) {
         memset(&key, 0, sizeof(key));
         key.kind = VK_SHADER_STAGE_GEOMETRY_BIT;
@@ -288,6 +299,9 @@ static void shader_cache_entry_init(Lru *lru, LruNode *node, const void *state)
     memset(&key, 0, sizeof(key));
     key.kind = VK_SHADER_STAGE_FRAGMENT_BIT;
     key.psh.state = binding->state.psh;
+    // Tell the fragment shader to fallback to hardware depth interpolation
+    // (gl_FragCoord.z) if Geometry Shaders were bypassed (like on macOS).
+    key.psh.state.use_hw_depth = !need_geometry_shader;
     key.psh.glsl_opts.vulkan = true;
     key.psh.glsl_opts.ubo_binding = PSH_UBO_BINDING;
     key.psh.glsl_opts.tex_binding = PSH_TEX_BINDING;

--- a/meson.build
+++ b/meson.build
@@ -2359,6 +2359,21 @@ if host_os == 'windows'
   vulkan = declare_dependency(compile_args: ['-DVK_USE_PLATFORM_WIN32_KHR'])
 elif host_os == 'linux'
   vulkan = dependency('vulkan')
+  # TODO: Remove this once we have a better way to handle vulkan on MacOS.
+elif host_os == 'darwin'
+  vulkan = dependency('vulkan', required: false)
+  if not vulkan.found()
+    macos_lib_arch = host_machine.cpu() == 'aarch64' ? 'arm64' : host_machine.cpu()
+    moltenvk = cc.find_library(
+      'MoltenVK',
+      dirs: [meson.project_source_root() / 'macos-libs' / macos_lib_arch / 'opt/local/lib'],
+      required: false)
+    if moltenvk.found()
+      vulkan = declare_dependency(
+        dependencies: [moltenvk],
+        compile_args: ['-I/opt/homebrew/include', '-DVK_USE_PLATFORM_METAL_EXT'])
+    endif
+  endif
 endif
 
 if vulkan.found()


### PR DESCRIPTION
This commit introduces comprehensive fixes to ensure the Vulkan renderer works correctly on macOS through MoltenVK (Vulkan-over-Metal translation). MoltenVK has several limitations compared to native Vulkan drivers that require workarounds for proper Xbox NV2A emulation.

## Motivation

MoltenVK (the Vulkan portability implementation for macOS/iOS via Metal) has the following critical limitations that broke xemu's Vulkan renderer:

1. No native Geometry Shader support (Metal API limitation)
2. No VK_EXT_provoking_vertex extension (Metal uses fixed "first" provoking)
3. No VK_KHR_external_memory native support
4. Requires explicit VK_KHR_portability_subset extension enrollment

## Changes

### 1. Instance Creation & Device Enumeration (hw/xbox/nv2a/pgraph/vk/instance.c)

- Added `VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME` to required device extensions on `__APPLE__`. Without this, MoltenVK hides the physical device and Vulkan initialization fails on Apple Silicon.

- Added `VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME` support with `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` flag. This allows MoltenVK devices to be enumerated during instance creation.

- Defined fallback macro for `VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME` for older Vulkan headers that may lack it despite runtime support.

### 2. External Memory Disable (hw/xbox/nv2a/pgraph/vk/renderer.h)

- Set `HAVE_EXTERNAL_MEMORY` to 0 on macOS. MoltenVK does not support native external memory extensions, and attempting to use them causes crashes during device initialization. This disables the `VK_KHR_external_memory_*` code paths on Apple platforms.

### 3. Geometry Shader Feature Detection (hw/xbox/nv2a/pgraph/vk/instance.c)

- Query and store `geometryShader` physical device feature in `supports_geometry_shaders` flag. MoltenVK reports this as false since Metal lacks geometry shader support. This flag drives the primitive emulation fallback logic.

### 4. Primitive Topology Mapping without Geometry Shaders (hw/xbox/nv2a/pgraph/vk/draw.c)

- Modified `get_primitive_topology()` to map NV2A primitive types directly to Vulkan topologies when geometry shaders are unavailable:
  - `PRIM_TYPE_LINE_LOOP` → `VK_PRIMITIVE_TOPOLOGY_LINE_LIST`
  - `PRIM_TYPE_QUADS` → `VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST` (fill) or `VK_PRIMITIVE_TOPOLOGY_LINE_LIST` (wireframe)
  - `PRIM_TYPE_QUAD_STRIP` → `VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST`

### 5. CPU-Side Primitive Emulation (hw/xbox/nv2a/pgraph/vk/draw.c)

Added comprehensive primitive emulation for macOS since Metal cannot handle them in geometry shaders:

- `draw_needs_primitive_emulation()`: Determines if draw call needs CPU emulation based on primitive type. Reads polygon/primitive modes directly from hardware registers (`NV_PGRAPH_SETUPRASTER`) to avoid stale shader state issues that caused SIGSEGV on MoltenVK.

- `get_max_emulated_index_count()`: Calculates required output index buffer size for emulated primitives (quads → 2 triangles = 6 indices, etc.).

- `build_emulated_indices_from_array()` & `build_emulated_indices_from_elements()`: Generate proper index buffers converting:
  - Line loops → Line lists with closing segment
  - Quads → Triangle pairs (with winding order fixes)
  - Quad strips → Triangle strip equivalents
  - Triangle fans (in line mode) → Line loops

### 6. Provoking Vertex Workaround (hw/xbox/nv2a/pgraph/vk/draw.c)

MoltenVK lacks `VK_EXT_provoking_vertex` and Metal always uses "first vertex" provoking. Xbox requires "last vertex" by default:

- Detect `NV_PGRAPH_CONTROL_3_PROVOKING_VERTEX_FIRST` from hardware registers to determine expected behavior.

- When first-vertex provoking is expected (matching Metal's behavior), manually rotate triangle indices via CPU: Original: (v0, v1, v2) with v2 as provoking
Emulated: (v1, v2, v0) with v0 as provoking (Metal's default)

This ensures flat shading produces correct colors on macOS without geometry shader vertex rotation.

### 7. Conditional Geometry Shader Pipeline (hw/xbox/nv2a/pgraph/vk/shaders.c)

- Modified shader pipeline creation to skip geometry shader stage when `supports_geometry_shaders` is false. The Z-buffer calculation and provoking vertex rotation normally done in geometry shaders are now handled via CPU index manipulation on macOS.

### 8. Volk Loader Patch (subprojects/packagefiles/volk/volk.c.patch)

- Added `/opt/homebrew/lib/libvulkan.dylib` to volk's library search paths. Homebrew on Apple Silicon installs to `/opt/homebrew` rather than `/usr/local`, and without this patch, xemu could not find the Vulkan loader on M1/M2/M3 Macs.

## Notes

These changes are designed to be non-breaking on non-Apple platforms. All MoltenVK-specific code paths are guarded by `__APPLE__` preprocessor directives or runtime feature detection (`supports_geometry_shaders`), ensuring native Vulkan drivers on Windows/Linux continue to use the optimized geometry shader paths.

Fixes #2296