### PR TITLE
ui: Do not pass missing path to SDL_ShowOpenFileDialog

### DIFF
--- a/ui/xui/misc.cc
+++ b/ui/xui/misc.cc
@@ -70,6 +70,10 @@ static std::string NormalizeDefaultLocation(const char *default_location)
         if (std::filesystem::is_directory(path)) {
             return (path / "").string();
         }
+        // Prevent a crash in SDL3 file dialog
+        if (!std::filesystem::exists(path)) {
+            return {};
+        }
 #endif
     } catch (...) {
         // Fall through to return original path


### PR DESCRIPTION
Passing two levels of invalid paths to `SDL_ShowOpenFileDialog` on Windows causes a crash.  E.g., given a directory `d:\foo` that exists, passing `d:\foo\bar\baz` will trigger the crash.

This appears to be because the `FileDialogCallbackWrapper` callback is invoked twice in this case, leading to a double-free.

Fixes #2785 