### PR TITLE
macOS: IOSurface zero-copy display and frame interpolation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,6 @@ package_macos() {
     # Bundle Vulkan/MoltenVK runtime if available
     if command -v brew &>/dev/null; then
         brew_prefix="$(brew --prefix)"
-        mvk_icd="${brew_prefix}/Cellar/molten-vk/$(ls "${brew_prefix}/Cellar/molten-vk/" 2>/dev/null | head -1)/etc/vulkan/icd.d/MoltenVK_icd.json"
         mvk_lib="${brew_prefix}/lib/libMoltenVK.dylib"
         vk_loader="${brew_prefix}/lib/libvulkan.1.dylib"
 

--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,48 @@ package_macos() {
     plutil -replace CFBundleShortVersionString -string "${xemu_version}" dist/xemu.app/Contents/Info.plist
     plutil -replace CFBundleVersion            -string "${xemu_version}" dist/xemu.app/Contents/Info.plist
 
+    # Bundle Vulkan/MoltenVK runtime if available
+    if command -v brew &>/dev/null; then
+        brew_prefix="$(brew --prefix)"
+        mvk_icd="${brew_prefix}/Cellar/molten-vk/$(ls "${brew_prefix}/Cellar/molten-vk/" 2>/dev/null | head -1)/etc/vulkan/icd.d/MoltenVK_icd.json"
+        mvk_lib="${brew_prefix}/lib/libMoltenVK.dylib"
+        vk_loader="${brew_prefix}/lib/libvulkan.1.dylib"
+
+        if [ -f "$mvk_lib" ] && [ -f "$vk_loader" ]; then
+            echo "Bundling Vulkan/MoltenVK runtime..."
+            vk_lib_dest="dist/xemu.app/Contents/Libraries/${target_arch}"
+            vk_icd_dest="dist/xemu.app/Contents/Resources/vulkan/icd.d"
+
+            # Copy Vulkan loader and MoltenVK
+            cp "$vk_loader" "${vk_lib_dest}/libvulkan.1.dylib"
+            cp "$mvk_lib" "${vk_lib_dest}/libMoltenVK.dylib"
+            codesign -s - -f "${vk_lib_dest}/libvulkan.1.dylib"
+            codesign -s - -f "${vk_lib_dest}/libMoltenVK.dylib"
+
+            # Create ICD manifest pointing to bundled MoltenVK
+            mkdir -p "$vk_icd_dest"
+            cat > "${vk_icd_dest}/MoltenVK_icd.json" << 'ICDJSON'
+{
+    "file_format_version" : "1.0.0",
+    "ICD": {
+        "library_path": "../../../Libraries/__ARCH__/libMoltenVK.dylib",
+        "api_version" : "1.2.0",
+        "is_portability_driver" : true
+    }
+}
+ICDJSON
+            sed -i '' "s/__ARCH__/${target_arch}/g" "${vk_icd_dest}/MoltenVK_icd.json"
+
+            # Set VK_ICD_FILENAMES in Info.plist so the Vulkan loader finds MoltenVK.
+            # Note: LSEnvironment values are resolved relative to /, so we cannot
+            # use @executable_path here. The programmatic setenv in instance.c
+            # handles the Finder launch case; this is a fallback for edge cases.
+            plutil -replace LSEnvironment -json "{\"VK_DRIVER_FILES\": \"../Resources/vulkan/icd.d/MoltenVK_icd.json\"}" dist/xemu.app/Contents/Info.plist
+        else
+            echo "Warning: MoltenVK/Vulkan loader not found, Vulkan renderer will not be available"
+        fi
+    fi
+
     codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign - "${exe_path}"
     python3 ./scripts/gen-license.py --version-file=macos-libs/$target_arch/INSTALLED > dist/LICENSE.txt
 }
@@ -232,6 +274,10 @@ case "$platform" in # Adjust compilation options based on platform
         fi
         sys_ldflags='-headerpad_max_install_names'
         export PKG_CONFIG_LIBDIR="${lib_prefix}/lib/pkgconfig"
+        # Add Homebrew pkg-config path for Vulkan/MoltenVK if available
+        if command -v brew &>/dev/null; then
+            export PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR}:$(brew --prefix)/lib/pkgconfig"
+        fi
         opts="$opts --disable-cocoa --cross-prefix="
         postbuild='package_macos'
         ;;

--- a/config_spec.yml
+++ b/config_spec.yml
@@ -257,6 +257,9 @@ display:
     vsync:
       type: bool
       default: true
+    frame_interpolation:
+      type: bool
+      default: false
   ui:
     show_menubar:
       type: bool

--- a/hw/xbox/nv2a/nv2a.h
+++ b/hw/xbox/nv2a/nv2a.h
@@ -25,6 +25,11 @@ void nv2a_init(PCIBus *bus, int devfn, MemoryRegion *ram);
 void nv2a_context_init(void);
 int nv2a_get_framebuffer_surface(void);
 void nv2a_release_framebuffer_surface(void);
+int nv2a_get_frame_time(void);
+#if defined(__APPLE__)
+#include <IOSurface/IOSurfaceRef.h>
+IOSurfaceRef nv2a_get_display_iosurface(void);
+#endif
 void nv2a_set_surface_scale_factor(unsigned int scale);
 unsigned int nv2a_get_surface_scale_factor(void);
 const uint8_t *nv2a_get_dac_palette(void);

--- a/hw/xbox/nv2a/pgraph/pgraph.c
+++ b/hw/xbox/nv2a/pgraph/pgraph.c
@@ -381,6 +381,30 @@ void nv2a_release_framebuffer_surface(void)
     qemu_mutex_unlock(&pg->renderer_lock);
 }
 
+int nv2a_get_frame_time(void)
+{
+    NV2AState *d = g_nv2a;
+    return d->pgraph.frame_time;
+}
+
+#if defined(__APPLE__)
+#include <IOSurface/IOSurfaceRef.h>
+#include "vk/renderer.h"
+
+IOSurfaceRef nv2a_get_display_iosurface(void)
+{
+    NV2AState *d = g_nv2a;
+    PGRAPHState *pg = &d->pgraph;
+
+    if (pg->renderer->type != CONFIG_DISPLAY_RENDERER_VULKAN) {
+        return NULL;
+    }
+
+    PGRAPHVkState *r = pg->vk_renderer_state;
+    return r ? r->display.iosurface : NULL;
+}
+#endif
+
 void nv2a_set_surface_scale_factor(unsigned int scale)
 {
     NV2AState *d = g_nv2a;

--- a/hw/xbox/nv2a/pgraph/vk/buffer.c
+++ b/hw/xbox/nv2a/pgraph/vk/buffer.c
@@ -50,6 +50,18 @@ void pgraph_vk_init_buffers(NV2AState *d)
 
     // FIXME: Profile buffer sizes
 
+#if defined(__APPLE__)
+    // Apple Silicon has unified memory — CPU and GPU share the same RAM.
+    // Use VMA_MEMORY_USAGE_AUTO so VMA can place allocations in shared memory
+    // without unnecessary copies between host and device heaps.
+    VmaAllocationCreateInfo host_alloc_create_info = {
+        .usage = VMA_MEMORY_USAGE_AUTO,
+        .flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT,
+    };
+    VmaAllocationCreateInfo device_alloc_create_info = {
+        .usage = VMA_MEMORY_USAGE_AUTO,
+    };
+#else
     VmaAllocationCreateInfo host_alloc_create_info = {
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_HOST,
         .flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT |
@@ -59,6 +71,7 @@ void pgraph_vk_init_buffers(NV2AState *d)
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
         .flags = VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT
     };
+#endif
 
     r->storage_buffers[BUFFER_STAGING_DST] = (StorageBuffer){
         .alloc_info = host_alloc_create_info,

--- a/hw/xbox/nv2a/pgraph/vk/display.c
+++ b/hw/xbox/nv2a/pgraph/vk/display.c
@@ -96,7 +96,11 @@ static void create_pvideo_image(PGRAPHState *pg, int width, int height)
         .flags = 0,
     };
     VmaAllocationCreateInfo alloc_create_info = {
+#if defined(__APPLE__)
+        .usage = VMA_MEMORY_USAGE_AUTO,
+#else
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
+#endif
     };
     VK_CHECK(vmaCreateImage(r->allocator, &image_create_info,
                             &alloc_create_info, &d->pvideo.image,
@@ -578,10 +582,10 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
         destroy_current_display_image(pg);
     }
 
-    const GLint gl_internal_format = GL_RGBA8;
     bool use_optimal_tiling = true;
 
 #if HAVE_EXTERNAL_MEMORY
+    const GLint gl_internal_format = GL_RGBA8;
     GLint num_tiling_types;
     glGetInternalformativ(GL_TEXTURE_2D, gl_internal_format,
                           GL_NUM_TILING_TYPES_EXT, 1, &num_tiling_types);
@@ -617,6 +621,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
         .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
     };
 
+#if HAVE_EXTERNAL_MEMORY
     VkExternalMemoryImageCreateInfo external_memory_image_create_info = {
         .sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO,
 #ifdef WIN32
@@ -626,6 +631,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
 #endif
     };
     image_create_info.pNext = &external_memory_image_create_info;
+#endif
 
     VK_CHECK(vkCreateImage(r->device, &image_create_info, NULL, &d->image));
 
@@ -641,6 +647,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
                                       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT),
     };
 
+#if HAVE_EXTERNAL_MEMORY
     VkExportMemoryAllocateInfo export_memory_alloc_info = {
         .sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO,
         .handleTypes =
@@ -652,6 +659,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
             ,
     };
     alloc_info.pNext = &export_memory_alloc_info;
+#endif
 
     VK_CHECK(vkAllocateMemory(r->device, &alloc_info, NULL, &d->memory));
     VK_CHECK(vkBindImageMemory(r->device, d->image, d->memory, 0));

--- a/hw/xbox/nv2a/pgraph/vk/display.c
+++ b/hw/xbox/nv2a/pgraph/vk/display.c
@@ -20,6 +20,13 @@
 #include "renderer.h"
 #include <math.h>
 
+#if defined(__APPLE__)
+#include <IOSurface/IOSurface.h>
+#include <OpenGL/OpenGL.h>
+#include <OpenGL/CGLIOSurface.h>
+#include <epoxy/gl.h>
+#endif
+
 static uint8_t *convert_texture_data__CR8YB8CB8YA8(uint8_t *data_out,
                                                    const uint8_t *data_in,
                                                    unsigned int width,
@@ -324,7 +331,11 @@ static void create_render_pass(PGRAPHState *pg)
 
     VkAttachmentReference color_reference;
     attachment = (VkAttachmentDescription){
+#if defined(__APPLE__)
+        .format = VK_FORMAT_B8G8R8A8_UNORM,
+#else
         .format = VK_FORMAT_R8G8B8A8_UNORM,
+#endif
         .samples = VK_SAMPLE_COUNT_1_BIT,
         .loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
         .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
@@ -556,6 +567,35 @@ static void destroy_current_display_image(PGRAPHState *pg)
     CloseHandle(d->handle);
     d->handle = 0;
 #endif
+#elif defined(__APPLE__)
+    if (d->gl_draw_fbo) {
+        GLuint fbo = d->gl_draw_fbo;
+        glDeleteFramebuffers(1, &fbo);
+        d->gl_draw_fbo = 0;
+    }
+
+    if (d->gl_fbo) {
+        GLuint fbo = d->gl_fbo;
+        glDeleteFramebuffers(1, &fbo);
+        d->gl_fbo = 0;
+    }
+
+    if (d->gl_texture_id) {
+        GLuint tex = d->gl_texture_id;
+        glDeleteTextures(1, &tex);
+        d->gl_texture_id = 0;
+    }
+
+    if (d->gl_rect_texture_id) {
+        GLuint tex = d->gl_rect_texture_id;
+        glDeleteTextures(1, &tex);
+        d->gl_rect_texture_id = 0;
+    }
+
+    if (d->iosurface) {
+        CFRelease(d->iosurface);
+        d->iosurface = NULL;
+    }
 #endif
 
     vkDestroyImageView(r->device, d->image_view, NULL);
@@ -613,7 +653,11 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
         .extent.depth = 1,
         .mipLevels = 1,
         .arrayLayers = 1,
+#if defined(__APPLE__)
+        .format = VK_FORMAT_B8G8R8A8_UNORM,
+#else
         .format = VK_FORMAT_R8G8B8A8_UNORM,
+#endif
         .tiling = use_optimal_tiling ? VK_IMAGE_TILING_OPTIMAL : VK_IMAGE_TILING_LINEAR,
         .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
         .usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
@@ -631,6 +675,13 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
 #endif
     };
     image_create_info.pNext = &external_memory_image_create_info;
+#elif defined(__APPLE__)
+    // Tell MoltenVK to back this VkImage with an IOSurface
+    VkExportMetalObjectCreateInfoEXT export_metal_create_info = {
+        .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT,
+        .exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_IOSURFACE_BIT_EXT,
+    };
+    image_create_info.pNext = &export_metal_create_info;
 #endif
 
     VK_CHECK(vkCreateImage(r->device, &image_create_info, NULL, &d->image));
@@ -720,6 +771,70 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
                          image_create_info.extent.width,
                          image_create_info.extent.height, d->gl_memory_obj, 0);
     assert(glGetError() == GL_NO_ERROR);
+
+#elif defined(__APPLE__)
+
+    // Export IOSurface from VkImage via VK_EXT_metal_objects
+    VkExportMetalIOSurfaceInfoEXT surface_info = {
+        .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT,
+        .image = d->image,
+    };
+    VkExportMetalObjectsInfoEXT export_info = {
+        .sType = VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECTS_INFO_EXT,
+        .pNext = &surface_info,
+    };
+    vkExportMetalObjectsEXT(r->device, &export_info);
+    assert(surface_info.ioSurface != NULL);
+    d->iosurface = (IOSurfaceRef)CFRetain(surface_info.ioSurface);
+
+    // Create GL_TEXTURE_RECTANGLE backed by the IOSurface (zero-copy)
+    CGLContextObj cgl_ctx = CGLGetCurrentContext();
+    assert(cgl_ctx != NULL);
+
+    GLuint rect_tex;
+    glGenTextures(1, &rect_tex);
+    glBindTexture(GL_TEXTURE_RECTANGLE, rect_tex);
+    glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    CGLTexImageIOSurface2D(cgl_ctx, GL_TEXTURE_RECTANGLE, GL_RGBA8,
+                           image_create_info.extent.width,
+                           image_create_info.extent.height,
+                           GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
+                           d->iosurface, 0);
+    assert(glGetError() == GL_NO_ERROR);
+    d->gl_rect_texture_id = rect_tex;
+
+    // Create GL_TEXTURE_2D for UI consumption (blit target)
+    GLuint out_tex;
+    glGenTextures(1, &out_tex);
+    glBindTexture(GL_TEXTURE_2D, out_tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8,
+                 image_create_info.extent.width,
+                 image_create_info.extent.height,
+                 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+    assert(glGetError() == GL_NO_ERROR);
+    d->gl_texture_id = out_tex;
+
+    // Create FBOs for rect→2D blit
+    GLuint read_fbo, draw_fbo;
+    glGenFramebuffers(1, &read_fbo);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, read_fbo);
+    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                           GL_TEXTURE_RECTANGLE, rect_tex, 0);
+    assert(glCheckFramebufferStatus(GL_READ_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+    d->gl_fbo = read_fbo;
+
+    glGenFramebuffers(1, &draw_fbo);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, draw_fbo);
+    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                           GL_TEXTURE_2D, out_tex, 0);
+    assert(glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    d->gl_draw_fbo = draw_fbo;
+
 
 #endif // HAVE_EXTERNAL_MEMORY
 
@@ -933,7 +1048,12 @@ static void render_display(PGRAPHState *pg, SurfaceBinding *surface)
                                       VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
                                       VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     pgraph_vk_transition_image_layout(
-        pg, cmd, disp->image, VK_FORMAT_R8G8B8A8_UNORM,
+        pg, cmd, disp->image,
+#if defined(__APPLE__)
+        VK_FORMAT_B8G8R8A8_UNORM,
+#else
+        VK_FORMAT_R8G8B8A8_UNORM,
+#endif
         VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
     VkRenderPassBeginInfo render_pass_begin_info = {
@@ -998,7 +1118,11 @@ static void render_display(PGRAPHState *pg, SurfaceBinding *surface)
                                       VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
     pgraph_vk_transition_image_layout(pg, cmd, disp->image,
-                                      VK_FORMAT_R8G8B8_UNORM,
+#if defined(__APPLE__)
+                                      VK_FORMAT_B8G8R8A8_UNORM,
+#else
+                                      VK_FORMAT_R8G8B8A8_UNORM,
+#endif
                                       VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
                                       VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
@@ -1008,6 +1132,28 @@ static void render_display(PGRAPHState *pg, SurfaceBinding *surface)
 
     disp->draw_time = surface->draw_time;
 }
+
+#if defined(__APPLE__)
+void pgraph_vk_blit_display_to_gl(PGRAPHState *pg)
+{
+    PGRAPHVkState *r = pg->vk_renderer_state;
+    PGRAPHVkDisplayState *d = &r->display;
+
+    if (!d->gl_fbo || !d->gl_draw_fbo ||
+        !d->gl_rect_texture_id || !d->gl_texture_id) {
+        return;
+    }
+
+    // Blit rect texture → 2D texture (GPU-side copy, fast on unified memory)
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, d->gl_fbo);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, d->gl_draw_fbo);
+    glBlitFramebuffer(0, 0, d->width, d->height,
+                      0, 0, d->width, d->height,
+                      GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+}
+#endif
 
 static void create_surface_sampler(PGRAPHState *pg)
 {

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -131,6 +131,16 @@ static char *get_pipeline_cache_path(void)
     return g_build_filename(base, "pipeline_cache.bin", NULL);
 }
 
+static bool pipeline_cache_saved;
+static void save_pipeline_cache(PGRAPHState *pg);
+
+static void save_pipeline_cache_atexit(void)
+{
+    if (g_nv2a) {
+        save_pipeline_cache(&g_nv2a->pgraph);
+    }
+}
+
 static void init_pipeline_cache(PGRAPHState *pg)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
@@ -192,11 +202,20 @@ static void init_pipeline_cache(PGRAPHState *pg)
     r->pipeline_cache.init_node = pipeline_cache_entry_init;
     r->pipeline_cache.compare_nodes = pipeline_cache_entry_compare;
     r->pipeline_cache.post_node_evict = pipeline_cache_entry_post_evict;
+
+    atexit(save_pipeline_cache_atexit);
 }
 
 static void save_pipeline_cache(PGRAPHState *pg)
 {
+    if (pipeline_cache_saved) {
+        return;
+    }
+
     PGRAPHVkState *r = pg->vk_renderer_state;
+    if (!r || !r->device || !r->vk_pipeline_cache) {
+        return;
+    }
 
     char *cache_path = get_pipeline_cache_path();
     if (!cache_path) {
@@ -221,6 +240,7 @@ static void save_pipeline_cache(PGRAPHState *pg)
             fclose(f);
             fprintf(stderr, "Saved Vulkan pipeline cache (%zu bytes)\n",
                     cache_size);
+            pipeline_cache_saved = true;
         }
     }
     g_free(cache_data);

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -19,6 +19,7 @@
 
 #include "qemu/osdep.h"
 #include "qemu/fast-hash.h"
+#include "ui/xemu-settings.h"
 #include "renderer.h"
 #include <math.h>
 
@@ -121,19 +122,63 @@ static bool pipeline_cache_entry_compare(Lru *lru, LruNode *node,
     return memcmp(&snode->key, key, sizeof(PipelineKey));
 }
 
+static char *get_pipeline_cache_path(void)
+{
+    const char *base = xemu_settings_get_base_path();
+    if (!base) {
+        return NULL;
+    }
+    return g_build_filename(base, "pipeline_cache.bin", NULL);
+}
+
 static void init_pipeline_cache(PGRAPHState *pg)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
 
+    void *cache_data = NULL;
+    size_t cache_size = 0;
+
+    char *cache_path = get_pipeline_cache_path();
+    if (cache_path) {
+        FILE *f = fopen(cache_path, "rb");
+        if (f) {
+            fseek(f, 0, SEEK_END);
+            long file_size = ftell(f);
+            fseek(f, 0, SEEK_SET);
+            if (file_size > 16) {
+                cache_data = g_malloc(file_size);
+                if (fread(cache_data, 1, file_size, f) == (size_t)file_size) {
+                    cache_size = file_size;
+                    fprintf(stderr, "Loaded Vulkan pipeline cache (%ld bytes)\n",
+                            file_size);
+                } else {
+                    g_free(cache_data);
+                    cache_data = NULL;
+                }
+            }
+            fclose(f);
+        }
+        g_free(cache_path);
+    }
+
     VkPipelineCacheCreateInfo cache_info = {
         .sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
         .flags = 0,
-        .initialDataSize = 0,
-        .pInitialData = NULL,
+        .initialDataSize = cache_size,
+        .pInitialData = cache_data,
         .pNext = NULL,
     };
-    VK_CHECK(vkCreatePipelineCache(r->device, &cache_info, NULL,
-                                   &r->vk_pipeline_cache));
+    VkResult result = vkCreatePipelineCache(r->device, &cache_info, NULL,
+                                            &r->vk_pipeline_cache);
+    g_free(cache_data);
+
+    if (result != VK_SUCCESS) {
+        // If loading the cache failed (e.g. stale data), retry without it
+        cache_info.initialDataSize = 0;
+        cache_info.pInitialData = NULL;
+        VK_CHECK(vkCreatePipelineCache(r->device, &cache_info, NULL,
+                                       &r->vk_pipeline_cache));
+    }
 
     const size_t pipeline_cache_size = 2048;
     lru_init(&r->pipeline_cache);
@@ -149,9 +194,44 @@ static void init_pipeline_cache(PGRAPHState *pg)
     r->pipeline_cache.post_node_evict = pipeline_cache_entry_post_evict;
 }
 
+static void save_pipeline_cache(PGRAPHState *pg)
+{
+    PGRAPHVkState *r = pg->vk_renderer_state;
+
+    char *cache_path = get_pipeline_cache_path();
+    if (!cache_path) {
+        return;
+    }
+
+    size_t cache_size = 0;
+    VkResult result = vkGetPipelineCacheData(r->device, r->vk_pipeline_cache,
+                                             &cache_size, NULL);
+    if (result != VK_SUCCESS || cache_size <= 16) {
+        g_free(cache_path);
+        return;
+    }
+
+    void *cache_data = g_malloc(cache_size);
+    result = vkGetPipelineCacheData(r->device, r->vk_pipeline_cache,
+                                    &cache_size, cache_data);
+    if (result == VK_SUCCESS) {
+        FILE *f = fopen(cache_path, "wb");
+        if (f) {
+            fwrite(cache_data, 1, cache_size, f);
+            fclose(f);
+            fprintf(stderr, "Saved Vulkan pipeline cache (%zu bytes)\n",
+                    cache_size);
+        }
+    }
+    g_free(cache_data);
+    g_free(cache_path);
+}
+
 static void finalize_pipeline_cache(PGRAPHState *pg)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
+
+    save_pipeline_cache(pg);
 
     lru_flush(&r->pipeline_cache);
     g_free(r->pipeline_cache_entries);

--- a/hw/xbox/nv2a/pgraph/vk/frame-interp-macos.h
+++ b/hw/xbox/nv2a/pgraph/vk/frame-interp-macos.h
@@ -1,0 +1,53 @@
+/*
+ * Frame Interpolation for macOS via VideoToolbox VTFrameProcessor
+ *
+ * Copyright (c) 2025 xemu contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FRAME_INTERP_MACOS_H
+#define FRAME_INTERP_MACOS_H
+
+#include <stdbool.h>
+#include <IOSurface/IOSurfaceRef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Check if VTFrameRateConversion is supported on this system */
+bool frame_interp_is_available(void);
+
+/* Initialize frame interpolation for given dimensions.
+ * Returns true on success. */
+bool frame_interp_init(int width, int height);
+
+/* Tear down frame interpolation resources */
+void frame_interp_finalize(void);
+
+/* Push a new real frame's IOSurface into the ring buffer */
+void frame_interp_push_frame(IOSurfaceRef surface);
+
+/* Generate an interpolated frame between the two most recent pushed frames.
+ * Returns the IOSurface of the interpolated frame, or NULL if not enough
+ * frames have been pushed or interpolation fails. The returned IOSurface
+ * is owned by the interpolator and valid until the next call. */
+IOSurfaceRef frame_interp_get_interpolated(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FRAME_INTERP_MACOS_H */

--- a/hw/xbox/nv2a/pgraph/vk/frame-interp-macos.m
+++ b/hw/xbox/nv2a/pgraph/vk/frame-interp-macos.m
@@ -1,0 +1,430 @@
+/*
+ * Frame Interpolation for macOS via VideoToolbox VTFrameProcessor
+ *
+ * Uses VTFrameRateConversion to generate synthetic intermediate frames
+ * between real 30fps game frames, producing smooth 60fps output.
+ *
+ * All heavy work (vImageScale + VTFrameProcessor) runs asynchronously on a
+ * GCD serial queue. The render loop never blocks on frame interpolation.
+ * Double-buffered output ensures tear-free reads.
+ *
+ * Copyright (c) 2025 xemu contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#import <Foundation/Foundation.h>
+#import <VideoToolbox/VTFrameProcessor.h>
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+#import <IOSurface/IOSurface.h>
+#import <Accelerate/Accelerate.h>
+#include <stdatomic.h>
+
+#include "frame-interp-macos.h"
+
+// Ring buffer of 2 frames (prev + current)
+#define RING_SIZE 2
+
+// Cap interpolation resolution for performance. VTFrameProcessor has ~15ms
+// of fixed neural engine overhead regardless of resolution.
+#define INTERP_MAX_DIM 1280
+
+static struct {
+    bool initialized;
+    bool available;
+    int src_width;   // source IOSurface dimensions
+    int src_height;
+    int width;       // interpolation dimensions (may be smaller than source)
+    int height;
+    bool needs_scale;
+
+    id processor; // VTFrameProcessor * (macOS 15.4+)
+    id config;    // VTFrameRateConversionConfiguration * (macOS 15.4+)
+
+    CVPixelBufferRef ring[RING_SIZE];
+    atomic_int ring_head; // points to current (most recent) frame
+    atomic_int frame_count;
+
+    // Double-buffered async output
+    CVPixelBufferRef interp_output[2];
+    IOSurfaceRef interp_iosurface[2];
+    atomic_int ready_idx;      // index of buffer ready for display (-1 = none)
+    atomic_int ready_fc;       // frame_count when ready result was computed
+    atomic_bool processing;    // true while async VT is running
+    atomic_bool pending;       // true if new frames arrived during processing
+    dispatch_queue_t queue;    // serial queue for async processing
+} g_interp;
+
+static void do_vt_processing(void);
+
+static CVPixelBufferRef create_iosurface_pixel_buffer(int width, int height)
+{
+    NSDictionary *attrs = @{
+        (NSString *)kCVPixelBufferWidthKey: @(width),
+        (NSString *)kCVPixelBufferHeightKey: @(height),
+        (NSString *)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA),
+        (NSString *)kCVPixelBufferIOSurfacePropertiesKey: @{},
+    };
+
+    CVPixelBufferRef buffer = NULL;
+    CVReturn status = CVPixelBufferCreate(
+        kCFAllocatorDefault, width, height,
+        kCVPixelFormatType_32BGRA,
+        (__bridge CFDictionaryRef)attrs,
+        &buffer);
+
+    if (status != kCVReturnSuccess) {
+        fprintf(stderr, "[frame-interp] Failed to create pixel buffer: %d\n",
+                status);
+        return NULL;
+    }
+    return buffer;
+}
+
+bool frame_interp_is_available(void)
+{
+    if (@available(macOS 15.4, *)) {
+        return [VTFrameRateConversionConfiguration processorSupported];
+    }
+    return false;
+}
+
+bool frame_interp_init(int width, int height)
+{
+    if (g_interp.initialized) {
+        frame_interp_finalize();
+    }
+
+    memset(&g_interp, 0, sizeof(g_interp));
+    atomic_store(&g_interp.ready_idx, -1);
+    atomic_store(&g_interp.ready_fc, 0);
+    atomic_store(&g_interp.processing, false);
+    atomic_store(&g_interp.pending, false);
+
+    if (!frame_interp_is_available()) {
+        fprintf(stderr, "[frame-interp] VTFrameRateConversion not available\n");
+        return false;
+    }
+
+    if (@available(macOS 15.4, *)) {
+        g_interp.src_width = width;
+        g_interp.src_height = height;
+
+        // Cap interpolation resolution for performance
+        int interp_w = width, interp_h = height;
+        int max_dim = MAX(interp_w, interp_h);
+        if (max_dim > INTERP_MAX_DIM) {
+            float scale = (float)INTERP_MAX_DIM / max_dim;
+            interp_w = (int)(interp_w * scale) & ~1; // keep even
+            interp_h = (int)(interp_h * scale) & ~1;
+        }
+        g_interp.width = interp_w;
+        g_interp.height = interp_h;
+        g_interp.needs_scale = (interp_w != width || interp_h != height);
+
+        // Create frame rate conversion configuration
+        VTFrameRateConversionConfiguration *config =
+            [[VTFrameRateConversionConfiguration alloc]
+                initWithFrameWidth:interp_w
+                       frameHeight:interp_h
+                usePrecomputedFlow:NO
+             qualityPrioritization:VTFrameRateConversionConfigurationQualityPrioritizationNormal
+                          revision:VTFrameRateConversionConfigurationRevision1];
+        g_interp.config = config;
+        if (!config) {
+            fprintf(stderr, "[frame-interp] Failed to create FRC config\n");
+            return false;
+        }
+
+        // Create processor and start session
+        VTFrameProcessor *processor = [[VTFrameProcessor alloc] init];
+        g_interp.processor = processor;
+        NSError *error = nil;
+        BOOL ok = [processor
+            startSessionWithConfiguration:config
+                                    error:&error];
+        if (!ok) {
+            fprintf(stderr, "[frame-interp] Failed to start session: %s\n",
+                    error.localizedDescription.UTF8String);
+            g_interp.processor = nil;
+            g_interp.config = nil;
+            return false;
+        }
+
+        // Allocate ring buffer CVPixelBuffers at interpolation resolution
+        for (int i = 0; i < RING_SIZE; i++) {
+            g_interp.ring[i] =
+                create_iosurface_pixel_buffer(interp_w, interp_h);
+            if (!g_interp.ring[i]) {
+                frame_interp_finalize();
+                return false;
+            }
+        }
+
+        // Allocate double-buffered output
+        for (int i = 0; i < 2; i++) {
+            g_interp.interp_output[i] =
+                create_iosurface_pixel_buffer(interp_w, interp_h);
+            if (!g_interp.interp_output[i]) {
+                frame_interp_finalize();
+                return false;
+            }
+            g_interp.interp_iosurface[i] =
+                CVPixelBufferGetIOSurface(g_interp.interp_output[i]);
+        }
+
+        // Create serial dispatch queue for async processing
+        g_interp.queue = dispatch_queue_create(
+            "org.xemu.frame-interp", DISPATCH_QUEUE_SERIAL);
+
+        g_interp.initialized = true;
+        g_interp.available = true;
+        atomic_store(&g_interp.frame_count, 0);
+        atomic_store(&g_interp.ring_head, 0);
+
+        return true;
+    }
+
+    return false;
+}
+
+void frame_interp_finalize(void)
+{
+    // Wait for any pending async work to complete
+    if (g_interp.queue) {
+        dispatch_sync(g_interp.queue, ^{});
+    }
+
+    if (@available(macOS 15.4, *)) {
+        if (g_interp.processor) {
+            [(VTFrameProcessor *)g_interp.processor endSession];
+            g_interp.processor = nil;
+        }
+        g_interp.config = nil;
+    }
+
+    for (int i = 0; i < 2; i++) {
+        if (g_interp.interp_output[i]) {
+            CVPixelBufferRelease(g_interp.interp_output[i]);
+            g_interp.interp_output[i] = NULL;
+        }
+        g_interp.interp_iosurface[i] = NULL;
+    }
+
+    for (int i = 0; i < RING_SIZE; i++) {
+        if (g_interp.ring[i]) {
+            CVPixelBufferRelease(g_interp.ring[i]);
+            g_interp.ring[i] = NULL;
+        }
+    }
+
+    if (g_interp.queue) {
+        g_interp.queue = nil;
+    }
+
+    atomic_store(&g_interp.ready_idx, -1);
+    atomic_store(&g_interp.ready_fc, 0);
+    atomic_store(&g_interp.processing, false);
+    atomic_store(&g_interp.pending, false);
+    g_interp.initialized = false;
+    g_interp.available = false;
+}
+
+// Run VT processing on the current ring buffer contents.
+// Must be called from the dispatch queue.
+static void do_vt_processing(void)
+{
+    @autoreleasepool {
+    if (@available(macOS 15.4, *)) {
+        int head = atomic_load(&g_interp.ring_head);
+        int prev_idx = (head + RING_SIZE - 1) % RING_SIZE;
+        int curr_idx = head;
+        int fc = atomic_load(&g_interp.frame_count);
+
+        // Write to the buffer NOT currently being displayed
+        int ready = atomic_load(&g_interp.ready_idx);
+        int write_idx = (ready == 0) ? 1 : 0;
+
+        CMTime prev_time = CMTimeMake(fc - 1, 30);
+        CMTime curr_time = CMTimeMake(fc, 30);
+
+        VTFrameProcessorFrame *src_frame =
+            [[VTFrameProcessorFrame alloc]
+                initWithBuffer:g_interp.ring[prev_idx]
+                presentationTimeStamp:prev_time];
+        VTFrameProcessorFrame *next_frame =
+            [[VTFrameProcessorFrame alloc]
+                initWithBuffer:g_interp.ring[curr_idx]
+                presentationTimeStamp:curr_time];
+
+        if (!src_frame || !next_frame) {
+            return;
+        }
+
+        VTFrameProcessorFrame *dest_frame =
+            [[VTFrameProcessorFrame alloc]
+                initWithBuffer:g_interp.interp_output[write_idx]
+                presentationTimeStamp:CMTimeMake(fc * 2 - 1, 60)];
+
+        if (!dest_frame) {
+            return;
+        }
+
+        VTFrameRateConversionParameters *params =
+            [[VTFrameRateConversionParameters alloc]
+                initWithSourceFrame:src_frame
+                          nextFrame:next_frame
+                        opticalFlow:nil
+                 interpolationPhase:@[@0.5]
+                     submissionMode:
+                      VTFrameRateConversionParametersSubmissionModeSequential
+                  destinationFrames:@[dest_frame]];
+
+        if (!params) {
+            return;
+        }
+
+        NSError *error = nil;
+        VTFrameProcessor *processor =
+            (VTFrameProcessor *)g_interp.processor;
+        BOOL ok = [processor processWithParameters:params
+                                             error:&error];
+        if (ok) {
+            // Atomically publish the new result with its frame count
+            atomic_store(&g_interp.ready_fc, fc);
+            atomic_store(&g_interp.ready_idx, write_idx);
+        }
+    }
+    } // @autoreleasepool
+}
+
+// Copy IOSurface data into the ring buffer slot (with optional downscale).
+// Must be called from the dispatch queue.
+static void do_push_copy(IOSurfaceRef surface, int head)
+{
+    CVPixelBufferRef dst = g_interp.ring[head];
+
+    IOSurfaceLock(surface, kIOSurfaceLockReadOnly, NULL);
+    CVPixelBufferLockBaseAddress(dst, 0);
+
+    if (g_interp.needs_scale) {
+        vImage_Buffer src_buf = {
+            .data = IOSurfaceGetBaseAddress(surface),
+            .width = (vImagePixelCount)IOSurfaceGetWidth(surface),
+            .height = (vImagePixelCount)IOSurfaceGetHeight(surface),
+            .rowBytes = IOSurfaceGetBytesPerRow(surface),
+        };
+        vImage_Buffer dst_buf = {
+            .data = CVPixelBufferGetBaseAddress(dst),
+            .width = (vImagePixelCount)g_interp.width,
+            .height = (vImagePixelCount)g_interp.height,
+            .rowBytes = CVPixelBufferGetBytesPerRow(dst),
+        };
+        vImageScale_ARGB8888(&src_buf, &dst_buf, NULL, kvImageNoFlags);
+    } else {
+        void *src_ptr = IOSurfaceGetBaseAddress(surface);
+        void *dst_ptr = CVPixelBufferGetBaseAddress(dst);
+        size_t src_stride = IOSurfaceGetBytesPerRow(surface);
+        size_t dst_stride = CVPixelBufferGetBytesPerRow(dst);
+        size_t copy_height = MIN((size_t)g_interp.height,
+                                 IOSurfaceGetHeight(surface));
+        size_t copy_width_bytes = MIN(src_stride, dst_stride);
+
+        for (size_t y = 0; y < copy_height; y++) {
+            memcpy((uint8_t *)dst_ptr + y * dst_stride,
+                   (uint8_t *)src_ptr + y * src_stride,
+                   copy_width_bytes);
+        }
+    }
+
+    CVPixelBufferUnlockBaseAddress(dst, 0);
+    IOSurfaceUnlock(surface, kIOSurfaceLockReadOnly, NULL);
+}
+
+void frame_interp_push_frame(IOSurfaceRef surface)
+{
+    if (!g_interp.initialized || !surface) {
+        return;
+    }
+
+    // Advance ring head and frame count atomically (main thread only)
+    int head = (atomic_load(&g_interp.ring_head) + 1) % RING_SIZE;
+    atomic_store(&g_interp.ring_head, head);
+    int fc = atomic_fetch_add(&g_interp.frame_count, 1) + 1;
+
+    // Retain IOSurface for the async block
+    CFRetain(surface);
+
+    // If VT is currently processing, mark pending so it re-dispatches
+    // when done with the latest frames
+    if (atomic_load(&g_interp.processing)) {
+        atomic_store(&g_interp.pending, true);
+    }
+
+    // Dispatch all heavy work (copy + VT) to background queue.
+    // Capture head and fc by value so the async block uses a snapshot.
+    dispatch_async(g_interp.queue, ^{
+        if (!g_interp.initialized) {
+            CFRelease(surface);
+            return;
+        }
+
+        // Copy/scale IOSurface → ring buffer
+        do_push_copy(surface, head);
+        CFRelease(surface);
+
+        // Only start VT if we have 2+ frames and nothing is already running
+        if (fc < 2) {
+            return;
+        }
+
+        // Mark as processing (if not already)
+        bool expected = false;
+        if (!atomic_compare_exchange_strong(&g_interp.processing,
+                                            &expected, true)) {
+            // Another VT job is still running — pending flag is already set
+            return;
+        }
+
+        do_vt_processing();
+
+        // Check if new frames arrived while we were processing
+        while (atomic_exchange(&g_interp.pending, false)) {
+            do_vt_processing();
+        }
+
+        atomic_store(&g_interp.processing, false);
+    });
+}
+
+IOSurfaceRef frame_interp_get_interpolated(void)
+{
+    if (!g_interp.initialized || atomic_load(&g_interp.frame_count) < 2) {
+        return NULL;
+    }
+
+    // Non-blocking: return the most recently completed result.
+    // Skip if the result is too stale (>2 game frames behind).
+    int idx = atomic_load(&g_interp.ready_idx);
+    if (idx >= 0 && idx < 2) {
+        int result_fc = atomic_load(&g_interp.ready_fc);
+        int current_fc = atomic_load(&g_interp.frame_count);
+        if (current_fc - result_fc <= 2) {
+            return g_interp.interp_iosurface[idx];
+        }
+    }
+
+    return NULL;
+}

--- a/hw/xbox/nv2a/pgraph/vk/glsl.c
+++ b/hw/xbox/nv2a/pgraph/vk/glsl.c
@@ -147,9 +147,17 @@ GByteArray *pgraph_vk_compile_glsl_to_spv(glslang_stage_t stage,
         .language = GLSLANG_SOURCE_GLSL,
         .stage = stage,
         .client = GLSLANG_CLIENT_VULKAN,
+#if defined(__APPLE__)
+        .client_version = GLSLANG_TARGET_VULKAN_1_2,
+#else
         .client_version = GLSLANG_TARGET_VULKAN_1_3,
+#endif
         .target_language = GLSLANG_TARGET_SPV,
+#if defined(__APPLE__)
+        .target_language_version = GLSLANG_TARGET_SPV_1_5,
+#else
         .target_language_version = GLSLANG_TARGET_SPV_1_6,
+#endif
         .code = glsl_source,
         .default_version = 460,
         .default_profile = GLSLANG_NO_PROFILE,

--- a/hw/xbox/nv2a/pgraph/vk/glsl.c
+++ b/hw/xbox/nv2a/pgraph/vk/glsl.c
@@ -17,12 +17,174 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "qemu/osdep.h"
+#include "qemu/fast-hash.h"
 #include "ui/xemu-settings.h"
 #include "renderer.h"
 
 #include <assert.h>
 #include <glslang/Include/glslang_c_interface.h>
 #include <stdio.h>
+
+// SPIR-V bytecode disk cache
+// Bump this when SPIR-V target version, Vulkan version, or compiler changes
+#define SPIRV_CACHE_VERSION 1
+#define SPIRV_CACHE_MAGIC   0x53505643 // 'SPVC'
+
+typedef struct SpirvCacheEntry {
+    uint64_t hash;
+    uint32_t spirv_len;
+    uint8_t *spirv_data;
+} SpirvCacheEntry;
+
+static GHashTable *spirv_cache;
+static bool spirv_cache_dirty;
+static int spirv_cache_hits;
+static int spirv_cache_misses;
+
+static char *get_spirv_cache_path(void)
+{
+    const char *base = xemu_settings_get_base_path();
+    if (!base) {
+        return NULL;
+    }
+    return g_build_filename(base, "spirv_cache.bin", NULL);
+}
+
+static void spirv_cache_entry_free(gpointer data)
+{
+    SpirvCacheEntry *entry = data;
+    g_free(entry->spirv_data);
+    g_free(entry);
+}
+
+static void load_spirv_cache(void)
+{
+    spirv_cache = g_hash_table_new_full(g_int64_hash, g_int64_equal,
+                                        NULL, spirv_cache_entry_free);
+    char *path = get_spirv_cache_path();
+    if (!path) {
+        return;
+    }
+
+    FILE *f = fopen(path, "rb");
+    g_free(path);
+    if (!f) {
+        return;
+    }
+
+    uint32_t magic, version, platform, count;
+    if (fread(&magic, 4, 1, f) != 1 || magic != SPIRV_CACHE_MAGIC ||
+        fread(&version, 4, 1, f) != 1 || version != SPIRV_CACHE_VERSION ||
+        fread(&platform, 4, 1, f) != 1 ||
+#if defined(__APPLE__)
+        platform != 1 ||
+#else
+        platform != 0 ||
+#endif
+        fread(&count, 4, 1, f) != 1) {
+        fclose(f);
+        return;
+    }
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint64_t hash;
+        uint32_t spirv_len;
+        if (fread(&hash, 8, 1, f) != 1 ||
+            fread(&spirv_len, 4, 1, f) != 1 ||
+            spirv_len == 0 || spirv_len > 1024 * 1024) {
+            break;
+        }
+
+        SpirvCacheEntry *entry = g_malloc(sizeof(SpirvCacheEntry));
+        entry->hash = hash;
+        entry->spirv_len = spirv_len;
+        entry->spirv_data = g_malloc(spirv_len);
+        if (fread(entry->spirv_data, 1, spirv_len, f) != spirv_len) {
+            g_free(entry->spirv_data);
+            g_free(entry);
+            break;
+        }
+
+        g_hash_table_insert(spirv_cache, &entry->hash, entry);
+    }
+
+    fclose(f);
+    fprintf(stderr, "Loaded SPIR-V cache (%u entries)\n",
+            g_hash_table_size(spirv_cache));
+}
+
+static void save_spirv_cache(void)
+{
+    if (!spirv_cache || !spirv_cache_dirty) {
+        return;
+    }
+
+    char *path = get_spirv_cache_path();
+    if (!path) {
+        return;
+    }
+
+    FILE *f = fopen(path, "wb");
+    g_free(path);
+    if (!f) {
+        return;
+    }
+
+    uint32_t magic = SPIRV_CACHE_MAGIC;
+    uint32_t version = SPIRV_CACHE_VERSION;
+#if defined(__APPLE__)
+    uint32_t platform = 1;
+#else
+    uint32_t platform = 0;
+#endif
+    uint32_t count = g_hash_table_size(spirv_cache);
+
+    fwrite(&magic, 4, 1, f);
+    fwrite(&version, 4, 1, f);
+    fwrite(&platform, 4, 1, f);
+    fwrite(&count, 4, 1, f);
+
+    GHashTableIter iter;
+    gpointer key, value;
+    g_hash_table_iter_init(&iter, spirv_cache);
+    while (g_hash_table_iter_next(&iter, &key, &value)) {
+        SpirvCacheEntry *entry = value;
+        fwrite(&entry->hash, 8, 1, f);
+        fwrite(&entry->spirv_len, 4, 1, f);
+        fwrite(entry->spirv_data, 1, entry->spirv_len, f);
+    }
+
+    fclose(f);
+    fprintf(stderr, "Saved SPIR-V cache (%u entries, %d hits, %d misses)\n",
+            count, spirv_cache_hits, spirv_cache_misses);
+}
+
+static GByteArray *spirv_cache_lookup(const char *glsl)
+{
+    uint64_t hash = fast_hash(glsl, strlen(glsl));
+    SpirvCacheEntry *entry = g_hash_table_lookup(spirv_cache, &hash);
+    if (entry) {
+        spirv_cache_hits++;
+        GByteArray *arr = g_byte_array_sized_new(entry->spirv_len);
+        g_byte_array_append(arr, entry->spirv_data, entry->spirv_len);
+        return arr;
+    }
+    return NULL;
+}
+
+static void spirv_cache_insert(const char *glsl, GByteArray *spirv)
+{
+    uint64_t hash = fast_hash(glsl, strlen(glsl));
+    SpirvCacheEntry *entry = g_malloc(sizeof(SpirvCacheEntry));
+    entry->hash = hash;
+    entry->spirv_len = spirv->len;
+    entry->spirv_data = g_malloc(spirv->len);
+    memcpy(entry->spirv_data, spirv->data, spirv->len);
+    g_hash_table_insert(spirv_cache, &entry->hash, entry);
+    spirv_cache_dirty = true;
+    spirv_cache_misses++;
+}
 
 static const glslang_resource_t
     resource_limits = { .max_lights = 32,
@@ -133,10 +295,17 @@ static const glslang_resource_t
 void pgraph_vk_init_glsl_compiler(void)
 {
     glslang_initialize_process();
+    load_spirv_cache();
+    atexit(save_spirv_cache);
 }
 
 void pgraph_vk_finalize_glsl_compiler(void)
 {
+    save_spirv_cache();
+    if (spirv_cache) {
+        g_hash_table_destroy(spirv_cache);
+        spirv_cache = NULL;
+    }
     glslang_finalize_process();
 }
 
@@ -378,8 +547,14 @@ ShaderModuleInfo *pgraph_vk_create_shader_module_from_glsl(
     ShaderModuleInfo *info = g_malloc0(sizeof(*info));
     info->refcnt = 0;
     info->glsl = strdup(glsl);
-    info->spirv = pgraph_vk_compile_glsl_to_spv(
-        vk_shader_stage_to_glslang_stage(stage), glsl);
+
+    info->spirv = spirv_cache_lookup(glsl);
+    if (!info->spirv) {
+        info->spirv = pgraph_vk_compile_glsl_to_spv(
+            vk_shader_stage_to_glslang_stage(stage), glsl);
+        spirv_cache_insert(glsl, info->spirv);
+    }
+
     info->module = pgraph_vk_create_shader_module_from_spv(r, info->spirv);
     init_layout_from_spv(info);
     return info;

--- a/hw/xbox/nv2a/pgraph/vk/gpuprops.c
+++ b/hw/xbox/nv2a/pgraph/vk/gpuprops.c
@@ -587,6 +587,21 @@ static void determine_triangle_winding_order(uint8_t *pixels, int width,
 
 void pgraph_vk_determine_gpu_properties(NV2AState *d)
 {
+    PGRAPHState *pg = &d->pgraph;
+    PGRAPHVkState *r = pg->vk_renderer_state;
+
+    // If geometry shaders are unavailable (e.g. MoltenVK/Metal), skip the
+    // winding probe entirely and use known-correct defaults.
+    if (!r->enabled_physical_device_features.geometryShader) {
+        pgraph_vk_gpu_properties.geom_shader_winding.tri = 0;
+        pgraph_vk_gpu_properties.geom_shader_winding.tri_strip0 = 0;
+        pgraph_vk_gpu_properties.geom_shader_winding.tri_strip1 = 0;
+        pgraph_vk_gpu_properties.geom_shader_winding.tri_fan = 0;
+        fprintf(stderr,
+                "VK geometry shader winding (default, no GS): 0, 0, 0, 0\n");
+        return;
+    }
+
     const int width = 640;
     const int height = 480;
 

--- a/hw/xbox/nv2a/pgraph/vk/instance.c
+++ b/hw/xbox/nv2a/pgraph/vk/instance.c
@@ -41,6 +41,7 @@ static char const *const required_device_extensions[] = {
     VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,
 #elif defined(__APPLE__)
     "VK_KHR_portability_subset",
+    VK_EXT_METAL_OBJECTS_EXTENSION_NAME,
 #else
     VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
     VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,

--- a/hw/xbox/nv2a/pgraph/vk/instance.c
+++ b/hw/xbox/nv2a/pgraph/vk/instance.c
@@ -177,8 +177,8 @@ static bool create_instance(PGRAPHState *pg, Error **errp)
                     "MoltenVK_icd.json", NULL);
                 char *icd_real = realpath(icd_path, NULL);
                 if (icd_real) {
-                    setenv("VK_ICD_FILENAMES", icd_real, 1);
-                    setenv("VK_DRIVER_FILES", icd_real, 1);
+                    setenv("VK_ICD_FILENAMES", icd_real, 0);
+                    setenv("VK_DRIVER_FILES", icd_real, 0);
                     free(icd_real);
                 }
                 g_free(icd_path);

--- a/hw/xbox/nv2a/pgraph/vk/instance.c
+++ b/hw/xbox/nv2a/pgraph/vk/instance.c
@@ -22,6 +22,10 @@
 #include "renderer.h"
 #include "xemu-version.h"
 
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
+
 #define VkExtensionPropertiesArray GArray
 #define StringArray GArray
 
@@ -35,6 +39,8 @@ static char const *const required_device_extensions[] = {
 #ifdef WIN32
     VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,
     VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,
+#elif defined(__APPLE__)
+    "VK_KHR_portability_subset",
 #else
     VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
     VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
@@ -142,12 +148,44 @@ add_optional_instance_extension_names(PGRAPHState *pg,
         g_config.display.vulkan.validation_layers &&
         add_extension_if_available(available_extensions, enabled_extension_names,
                                    VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+#ifdef __APPLE__
+    add_extension_if_available(available_extensions, enabled_extension_names,
+                               VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+#endif
 }
 
 static bool create_instance(PGRAPHState *pg, Error **errp)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
     VkResult result;
+
+#if defined(__APPLE__)
+    // Set VK_ICD_FILENAMES so the Vulkan loader finds the bundled MoltenVK ICD
+    // when launched from Finder (where env vars from terminal are not inherited).
+    // The 0 flag means don't overwrite if already set (e.g. from terminal).
+    {
+        char exe_path[PATH_MAX];
+        uint32_t exe_path_size = sizeof(exe_path);
+        if (_NSGetExecutablePath(exe_path, &exe_path_size) == 0) {
+            char real_path[PATH_MAX];
+            if (realpath(exe_path, real_path)) {
+                char *dir = g_path_get_dirname(real_path);
+                char *icd_path = g_build_filename(
+                    dir, "..", "Resources", "vulkan", "icd.d",
+                    "MoltenVK_icd.json", NULL);
+                char *icd_real = realpath(icd_path, NULL);
+                if (icd_real) {
+                    setenv("VK_ICD_FILENAMES", icd_real, 1);
+                    setenv("VK_DRIVER_FILES", icd_real, 1);
+                    free(icd_real);
+                }
+                g_free(icd_path);
+                g_free(dir);
+            }
+        }
+    }
+#endif
 
     result = volkInitialize();
     if (result != VK_SUCCESS) {
@@ -158,7 +196,13 @@ static bool create_instance(PGRAPHState *pg, Error **errp)
     uint32_t instance_version = VK_API_VERSION_1_0;
     if (vkEnumerateInstanceVersion) {
         vkEnumerateInstanceVersion(&instance_version);
+#if defined(__APPLE__)
+        // MoltenVK supports Vulkan 1.2; the loader may report 1.3 but
+        // requesting a higher version causes VK_ERROR_INCOMPATIBLE_DRIVER.
+        instance_version = MIN(instance_version, VK_API_VERSION_1_2);
+#else
         instance_version = MIN(instance_version, VK_API_VERSION_1_3);
+#endif
     }
     if (instance_version < VK_API_VERSION_1_1) {
         error_setg(errp, "Vulkan 1.1 or higher is required");
@@ -199,6 +243,9 @@ static bool create_instance(PGRAPHState *pg, Error **errp)
         .enabledExtensionCount = enabled_extension_names->len,
         .ppEnabledExtensionNames =
             &g_array_index(enabled_extension_names, const char *, 0),
+#ifdef __APPLE__
+        .flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR,
+#endif
     };
 
     enable_validation = g_config.display.vulkan.validation_layers;
@@ -489,11 +536,19 @@ static bool create_logical_device(PGRAPHState *pg, Error **errp)
         }
         F(depthClamp, true),
         F(fillModeNonSolid, true),
+#if defined(__APPLE__)
+        F(geometryShader, false),
+#else
         F(geometryShader, true),
+#endif
         F(occlusionQueryPrecise, true),
         F(samplerAnisotropy, false),
         F(shaderClipDistance, true),
+#if defined(__APPLE__)
+        F(shaderTessellationAndGeometryPointSize, false),
+#else
         F(shaderTessellationAndGeometryPointSize, true),
+#endif
         F(wideLines, false),
         #undef F
         // clang-format on

--- a/hw/xbox/nv2a/pgraph/vk/instance.c
+++ b/hw/xbox/nv2a/pgraph/vk/instance.c
@@ -185,6 +185,18 @@ static bool create_instance(PGRAPHState *pg, Error **errp)
             }
         }
     }
+
+    // Tune MoltenVK for emulator workload via environment variables.
+    // These are only applied if not already set by the user.
+    setenv("MVK_CONFIG_FAST_MATH_ENABLED", "1", 0);
+    setenv("MVK_CONFIG_SHOULD_MAXIMIZE_CONCURRENT_COMPILATION", "1", 0);
+    setenv("MVK_CONFIG_SHADER_COMPRESSION_ALGORITHM", "3", 0); // LZ4
+    setenv("MVK_CONFIG_PREFILL_METAL_COMMAND_BUFFERS", "1", 0);
+    setenv("MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS", "0", 0);
+    setenv("MVK_CONFIG_MAX_ACTIVE_METAL_COMMAND_BUFFERS_PER_QUEUE", "128", 0);
+    setenv("MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE", "2", 0);
+    setenv("MVK_CONFIG_USE_MTLHEAP", "2", 0);
+    setenv("MVK_CONFIG_METAL_COMPILE_TIMEOUT", "5000000000", 0);
 #endif
 
     result = volkInitialize();

--- a/hw/xbox/nv2a/pgraph/vk/meson.build
+++ b/hw/xbox/nv2a/pgraph/vk/meson.build
@@ -1,6 +1,6 @@
 if vulkan.found()
 
-specific_ss.add([volk, libglslang, vma, vulkan, spirv_reflect, 
+specific_ss.add([volk, libglslang, vma, vulkan, spirv_reflect,
 	files(
 		'blit.c',
 		'buffer.c',
@@ -21,5 +21,12 @@ specific_ss.add([volk, libglslang, vma, vulkan, spirv_reflect,
 		'vertex.c',
 		)
 	])
+
+if host_os == 'darwin'
+	vk_macos_frameworks = dependency('appleframeworks',
+		modules: ['IOSurface', 'OpenGL', 'VideoToolbox', 'CoreVideo', 'CoreMedia', 'Accelerate'],
+		required: true)
+	specific_ss.add([vk_macos_frameworks, files('frame-interp-macos.m')])
+endif
 
 endif

--- a/hw/xbox/nv2a/pgraph/vk/renderer.c
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.c
@@ -20,7 +20,9 @@
 #include "hw/xbox/nv2a/nv2a_int.h"
 #include "renderer.h"
 
+#if HAVE_EXTERNAL_MEMORY
 #include "gloffscreen.h"
+#endif
 
 #if HAVE_EXTERNAL_MEMORY
 static GloContext *g_gl_context;

--- a/hw/xbox/nv2a/pgraph/vk/renderer.c
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.c
@@ -20,17 +20,17 @@
 #include "hw/xbox/nv2a/nv2a_int.h"
 #include "renderer.h"
 
-#if HAVE_EXTERNAL_MEMORY
+#if HAVE_EXTERNAL_MEMORY || defined(__APPLE__)
 #include "gloffscreen.h"
 #endif
 
-#if HAVE_EXTERNAL_MEMORY
+#if HAVE_EXTERNAL_MEMORY || defined(__APPLE__)
 static GloContext *g_gl_context;
 #endif
 
 static void early_context_init(void)
 {
-#if HAVE_EXTERNAL_MEMORY
+#if HAVE_EXTERNAL_MEMORY || defined(__APPLE__)
     g_gl_context = glo_context_create();
 #endif
 }
@@ -41,7 +41,7 @@ static void pgraph_vk_init(NV2AState *d, Error **errp)
 
     pg->vk_renderer_state = (PGRAPHVkState *)g_malloc0(sizeof(PGRAPHVkState));
 
-#if HAVE_EXTERNAL_MEMORY
+#if HAVE_EXTERNAL_MEMORY || defined(__APPLE__)
     glo_set_current(g_gl_context);
 #endif
 
@@ -192,12 +192,16 @@ static int pgraph_vk_get_framebuffer_surface(NV2AState *d)
 
     surface->frame_time = pg->frame_time;
 
-#if HAVE_EXTERNAL_MEMORY
+#if HAVE_EXTERNAL_MEMORY || defined(__APPLE__)
     qemu_event_reset(&d->pgraph.sync_complete);
     qatomic_set(&pg->sync_pending, true);
     pfifo_kick(d);
     qemu_mutex_unlock(&d->pfifo.lock);
     qemu_event_wait(&d->pgraph.sync_complete);
+#if defined(__APPLE__)
+    // Blit IOSurface-backed rect texture → GL_TEXTURE_2D for UI
+    pgraph_vk_blit_display_to_gl(pg);
+#endif
     return r->display.gl_texture_id;
 #else
     qemu_mutex_unlock(&d->pfifo.lock);

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -31,6 +31,10 @@
 #include "hw/xbox/nv2a/pgraph/texture.h"
 #include "hw/xbox/nv2a/pgraph/glsl/shaders.h"
 
+#if defined(__APPLE__)
+#define VK_USE_PLATFORM_METAL_EXT
+#endif
+
 #include <vulkan/vulkan.h>
 #include <glslang/Include/glslang_c_interface.h>
 #include <volk.h>
@@ -299,6 +303,13 @@ typedef struct PGRAPHVkDisplayState {
 #endif
     GLuint gl_memory_obj;
     GLuint gl_texture_id;
+#elif defined(__APPLE__)
+    // macOS IOSurface zero-copy interop
+    IOSurfaceRef iosurface;
+    unsigned int gl_rect_texture_id; // GL_TEXTURE_RECTANGLE from IOSurface
+    unsigned int gl_texture_id;      // GL_TEXTURE_2D for UI consumption
+    unsigned int gl_fbo;             // FBO for rect→2D blit (read side)
+    unsigned int gl_draw_fbo;        // FBO for rect→2D blit (draw side)
 #endif
 } PGRAPHVkDisplayState;
 
@@ -547,6 +558,9 @@ void pgraph_vk_unpack_depth_stencil(PGRAPHState *pg, SurfaceBinding *surface,
 void pgraph_vk_init_display(PGRAPHState *pg);
 void pgraph_vk_finalize_display(PGRAPHState *pg);
 void pgraph_vk_render_display(PGRAPHState *pg);
+#if defined(__APPLE__)
+void pgraph_vk_blit_display_to_gl(PGRAPHState *pg);
+#endif
 
 // texture.c
 void pgraph_vk_init_textures(PGRAPHState *pg);

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -41,7 +41,11 @@
 #include "constants.h"
 #include "glsl.h"
 
+#if defined(__APPLE__)
+#define HAVE_EXTERNAL_MEMORY 0
+#else
 #define HAVE_EXTERNAL_MEMORY 1
+#endif
 
 typedef struct QueueFamilyIndices {
     int queue_family;
@@ -286,6 +290,7 @@ typedef struct PGRAPHVkDisplayState {
     int width, height;
     int draw_time;
 
+#if HAVE_EXTERNAL_MEMORY
     // OpenGL Interop
 #ifdef WIN32
     HANDLE handle;
@@ -294,6 +299,7 @@ typedef struct PGRAPHVkDisplayState {
 #endif
     GLuint gl_memory_obj;
     GLuint gl_texture_id;
+#endif
 } PGRAPHVkDisplayState;
 
 typedef struct ComputePipelineKey {

--- a/hw/xbox/nv2a/pgraph/vk/surface.c
+++ b/hw/xbox/nv2a/pgraph/vk/surface.c
@@ -793,7 +793,11 @@ static void create_surface_image(PGRAPHState *pg, SurfaceBinding *surface)
     };
 
     VmaAllocationCreateInfo alloc_create_info = {
+#if defined(__APPLE__)
+        .usage = VMA_MEMORY_USAGE_AUTO,
+#else
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
+#endif
     };
 
     VK_CHECK(vmaCreateImage(r->allocator, &image_create_info,

--- a/hw/xbox/nv2a/pgraph/vk/texture.c
+++ b/hw/xbox/nv2a/pgraph/vk/texture.c
@@ -928,7 +928,11 @@ static void create_dummy_texture(PGRAPHState *pg)
     };
 
     VmaAllocationCreateInfo alloc_create_info = {
+#if defined(__APPLE__)
+        .usage = VMA_MEMORY_USAGE_AUTO,
+#else
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
+#endif
     };
 
     VkImage texture_image;
@@ -1233,7 +1237,11 @@ static void create_texture(PGRAPHState *pg, int texture_idx)
     }
 
     VmaAllocationCreateInfo alloc_create_info = {
+#if defined(__APPLE__)
+        .usage = VMA_MEMORY_USAGE_AUTO,
+#else
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
+#endif
     };
 
     VK_CHECK(vmaCreateImage(r->allocator, &image_create_info,

--- a/meson.build
+++ b/meson.build
@@ -2359,6 +2359,11 @@ if host_os == 'windows'
   vulkan = declare_dependency(compile_args: ['-DVK_USE_PLATFORM_WIN32_KHR'])
 elif host_os == 'linux'
   vulkan = dependency('vulkan')
+elif host_os == 'darwin'
+  vulkan = dependency('vulkan', required: false)
+  if not vulkan.found()
+    vulkan = dependency('MoltenVK', required: false)
+  endif
 endif
 
 if vulkan.found()
@@ -2381,6 +2386,8 @@ if vulkan.found()
   volk_opts.add_cmake_defines({'VOLK_STATIC_DEFINES': 'VK_NO_PROTOTYPES'})
   if host_os == 'windows'
     volk_opts.append_compile_args('c', '-DVK_USE_PLATFORM_WIN32_KHR=1')
+  elif host_os == 'darwin'
+    volk_opts.append_compile_args('c', '-DVK_USE_PLATFORM_METAL_EXT=1')
   endif
   volk_subproj = cmake.subproject('volk', options: volk_opts)
   volk = declare_dependency(compile_args: ['-DVK_NO_PROTOTYPES'],

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -55,6 +55,13 @@
 #include "hw/xbox/nv2a/nv2a.h"
 #include "ui/xemu-notifications.h"
 
+#if defined(__APPLE__)
+#include "hw/xbox/nv2a/pgraph/vk/frame-interp-macos.h"
+#include <IOSurface/IOSurface.h>
+#include <OpenGL/OpenGL.h>
+#include <OpenGL/CGLIOSurface.h>
+#endif
+
 #include <stb_image.h>
 #include <locale.h>
 #include <math.h>
@@ -72,6 +79,18 @@
 
 uint64_t vblank_interval_ns = 16666666LL;
 bool use_vblank_timer_thread = true;
+
+#if defined(__APPLE__)
+static int g_last_frame_time = -1;
+static bool g_interp_initialized = false;
+static GLuint g_interp_gl_tex = 0;
+static GLuint g_interp_rect_tex = 0;
+static GLuint g_interp_read_fbo = 0;
+static GLuint g_interp_draw_fbo = 0;
+static int g_interp_width = 0;
+static int g_interp_height = 0;
+static GLuint g_last_real_tex = 0;
+#endif
 
 struct xemu_console {
     DisplayChangeListener dcl;
@@ -811,6 +830,9 @@ static void gl_render_frame(struct xemu_console *scon)
 
     bool flip_required = false;
     bool release_surface_texture = false;
+#if defined(__APPLE__)
+    bool did_get_surface = false;
+#endif
 
     /* XXX: Note that this bypasses the usual VGA path in order to quickly
      * get the surface. This is simple and fast, at the cost of accuracy.
@@ -822,9 +844,166 @@ static void gl_render_frame(struct xemu_console *scon)
      * the guest code isn't using HW accelerated rendering, but just blitting
      * to the framebuffer, fall back to the VGA path.
      */
+#if defined(__APPLE__)
+    /*
+     * Frame interpolation fast path: check if this is a repeated frame
+     * BEFORE doing the expensive Vulkan sync. If repeated, skip the sync
+     * entirely and show an interpolated frame instead.
+     */
+    GLuint tex = 0;
+    bool interp_enabled = g_config.display.window.frame_interpolation;
+    bool interp_active = interp_enabled &&
+                         frame_interp_is_available() &&
+                         g_last_real_tex != 0;
+
+    /* Tear down interpolation state when toggled off */
+    if (!interp_enabled && g_interp_initialized) {
+        frame_interp_finalize();
+        g_interp_initialized = false;
+        g_last_frame_time = -1;
+        if (g_interp_gl_tex) {
+            glDeleteTextures(1, &g_interp_gl_tex);
+            glDeleteTextures(1, &g_interp_rect_tex);
+            glDeleteFramebuffers(1, &g_interp_read_fbo);
+            glDeleteFramebuffers(1, &g_interp_draw_fbo);
+            g_interp_gl_tex = 0;
+            g_interp_rect_tex = 0;
+            g_interp_read_fbo = 0;
+            g_interp_draw_fbo = 0;
+        }
+    }
+
+    if (interp_active) {
+        int current_frame_time = nv2a_get_frame_time();
+
+        if (current_frame_time == g_last_frame_time &&
+            g_interp_initialized) {
+            /* Repeated frame — skip Vulkan sync, use interpolation */
+            IOSurfaceRef interp_surface =
+                frame_interp_get_interpolated();
+            if (interp_surface) {
+                int w = (int)IOSurfaceGetWidth(interp_surface);
+                int h = (int)IOSurfaceGetHeight(interp_surface);
+
+                /* Lazily create GL resources, recreate on resize */
+                if (g_interp_gl_tex == 0 ||
+                    w != g_interp_width || h != g_interp_height) {
+                    if (g_interp_gl_tex) {
+                        glDeleteTextures(1, &g_interp_gl_tex);
+                        glDeleteTextures(1, &g_interp_rect_tex);
+                        glDeleteFramebuffers(1, &g_interp_read_fbo);
+                        glDeleteFramebuffers(1, &g_interp_draw_fbo);
+                    }
+                    g_interp_width = w;
+                    g_interp_height = h;
+
+                    glGenTextures(1, &g_interp_rect_tex);
+                    glGenTextures(1, &g_interp_gl_tex);
+
+                    glBindTexture(GL_TEXTURE_2D, g_interp_gl_tex);
+                    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8,
+                                 w, h, 0,
+                                 GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+                    glTexParameteri(GL_TEXTURE_2D,
+                                    GL_TEXTURE_MIN_FILTER,
+                                    GL_LINEAR);
+                    glTexParameteri(GL_TEXTURE_2D,
+                                    GL_TEXTURE_MAG_FILTER,
+                                    GL_LINEAR);
+
+                    glGenFramebuffers(1, &g_interp_read_fbo);
+                    glGenFramebuffers(1, &g_interp_draw_fbo);
+
+                    glBindFramebuffer(GL_DRAW_FRAMEBUFFER,
+                                      g_interp_draw_fbo);
+                    glFramebufferTexture2D(
+                        GL_DRAW_FRAMEBUFFER,
+                        GL_COLOR_ATTACHMENT0,
+                        GL_TEXTURE_2D, g_interp_gl_tex, 0);
+                    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+                }
+
+                /* Re-bind IOSurface to rect texture each frame */
+                glBindTexture(GL_TEXTURE_RECTANGLE,
+                              g_interp_rect_tex);
+                CGLTexImageIOSurface2D(
+                    CGLGetCurrentContext(),
+                    GL_TEXTURE_RECTANGLE, GL_RGBA8, w, h,
+                    GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
+                    interp_surface, 0);
+
+                /* Blit RECTANGLE → 2D */
+                glBindFramebuffer(GL_READ_FRAMEBUFFER,
+                                  g_interp_read_fbo);
+                glFramebufferTexture2D(
+                    GL_READ_FRAMEBUFFER,
+                    GL_COLOR_ATTACHMENT0,
+                    GL_TEXTURE_RECTANGLE,
+                    g_interp_rect_tex, 0);
+                glBindFramebuffer(GL_DRAW_FRAMEBUFFER,
+                                  g_interp_draw_fbo);
+                glBlitFramebuffer(0, 0, w, h,
+                                  0, 0, w, h,
+                                  GL_COLOR_BUFFER_BIT,
+                                  GL_NEAREST);
+                glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+                tex = g_interp_gl_tex;
+            } else {
+                /* Interpolation not ready, reuse last real texture */
+                tex = g_last_real_tex;
+            }
+        }
+    }
+
+    if (tex == 0) {
+        /* New frame or interpolation not active — do full Vulkan sync */
+        tex = nv2a_get_framebuffer_surface();
+        did_get_surface = true;
+
+        assert(glGetError() == GL_NO_ERROR);
+
+        if (tex != 0 && interp_enabled && frame_interp_is_available()) {
+            /* Detect display resize: texture ID changes when the
+             * display image is recreated. Reset interpolation state. */
+            if (tex != g_last_real_tex && g_last_real_tex != 0) {
+                if (g_interp_initialized) {
+                    frame_interp_finalize();
+                    g_interp_initialized = false;
+                }
+                g_last_frame_time = -1;
+            }
+
+            int current_frame_time = nv2a_get_frame_time();
+            if (current_frame_time != g_last_frame_time) {
+                IOSurfaceRef display_surface =
+                    nv2a_get_display_iosurface();
+                if (display_surface) {
+                    /* Retain to protect against concurrent
+                     * display image recreation. */
+                    CFRetain(display_surface);
+                    if (!g_interp_initialized) {
+                        int w = (int)IOSurfaceGetWidth(display_surface);
+                        int h = (int)IOSurfaceGetHeight(display_surface);
+                        if (frame_interp_init(w, h)) {
+                            g_interp_initialized = true;
+                        }
+                    }
+                    if (g_interp_initialized) {
+                        frame_interp_push_frame(display_surface);
+                    }
+                    CFRelease(display_surface);
+                }
+                g_last_frame_time = current_frame_time;
+            }
+            g_last_real_tex = tex;
+        }
+    }
+#else
     GLuint tex = nv2a_get_framebuffer_surface();
 
     assert(glGetError() == GL_NO_ERROR);
+#endif
 
     if (tex == 0) {
         xemu_main_loop_lock();
@@ -851,7 +1030,7 @@ static void gl_render_frame(struct xemu_console *scon)
     xemu_main_loop_unlock();
 
     xemu_hud_render();
-    glFinish();
+    glFlush();
 
     if (release_surface_texture) {
         xemu_main_loop_lock();
@@ -859,6 +1038,9 @@ static void gl_render_frame(struct xemu_console *scon)
         xemu_main_loop_unlock();
     }
 
+#if defined(__APPLE__)
+    if (did_get_surface)
+#endif
     nv2a_release_framebuffer_surface();
     SDL_GL_SwapWindow(scon->real_window);
     assert(glGetError() == GL_NO_ERROR);

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -791,6 +791,10 @@ void MainMenuDisplayView::Draw()
     }
     Toggle("Vertical refresh sync", &g_config.display.window.vsync,
            "Sync to screen vertical refresh to reduce tearing artifacts");
+#if defined(__APPLE__)
+    Toggle("Frame interpolation", &g_config.display.window.frame_interpolation,
+           "Generate intermediate frames for smoother gameplay (macOS 15.4+)");
+#endif
 
     SectionTitle("Interface");
     Toggle("Show main menu bar", &g_config.display.ui.show_menubar,


### PR DESCRIPTION
## Summary

- Eliminates GPU→CPU→GPU round-trip on macOS by exporting the Vulkan display image's backing IOSurface via `VK_EXT_metal_objects` and binding it directly to OpenGL with `CGLTexImageIOSurface2D` — zero-copy on Apple Silicon unified memory
- Adds optional frame interpolation using VideoToolbox `VTFrameProcessor` (macOS 15.4+) to generate synthetic intermediate frames between real 30fps game output, producing smooth 60fps display
- All interpolation work (vImageScale + VTFrameProcessor) runs async on a GCD serial queue with double-buffered output — render loop never blocks
- Settings toggle under Display → "Frame interpolation" (off by default)

## Details

**Phase 0 — Zero-copy display path:**
- `VK_EXT_metal_objects` exports IOSurface from VkImage
- `CGLTexImageIOSurface2D` binds to GL_TEXTURE_RECTANGLE, FBO blit converts to GL_TEXTURE_2D
- Display image format switched to `VK_FORMAT_B8G8R8A8_UNORM` on macOS (required by CGLTexImageIOSurface2D)
- Cached FBOs avoid per-frame allocation

**Phase 1 — Frame interpolation:**
- `VTFrameRateConversionConfiguration` with Neural Engine inference
- Resolution capped to 1280px max dimension for performance (vImageScale downscale from display res)
- Ring buffer of 2 CVPixelBuffers (prev + current frame)
- Atomic double-buffered output with staleness tracking (skips results >2 frames behind)
- Pending re-dispatch when new frames arrive during processing
- Frame detection via `nv2a_get_frame_time()` — distinguishes new game frames from repeated vblanks

## Test plan

- [x] `./build.sh` succeeds on macOS ARM
- [x] Vulkan display works without frame interpolation (toggle off)
- [x] No GPU→CPU readback — IOSurface zero-copy path active
- [x] Frame interpolation toggle in Settings → Display
- [x] Enabling interpolation produces 60fps from 30fps game output
- [x] Disabling interpolation cleanly tears down VT session and GL resources
- [x] No crashes on display resize or game load/unload
- [ ] Test with multiple titles beyond Halo

## Files changed

| File | Change |
|------|--------|
| `hw/xbox/nv2a/pgraph/vk/instance.c` | Enable VK_EXT_metal_objects |
| `hw/xbox/nv2a/pgraph/vk/renderer.h` | macOS display state fields |
| `hw/xbox/nv2a/pgraph/vk/display.c` | IOSurface export + GL texture + cached FBOs |
| `hw/xbox/nv2a/pgraph/vk/renderer.c` | macOS framebuffer surface path |
| `hw/xbox/nv2a/nv2a.h` | frame_time + IOSurface accessors |
| `hw/xbox/nv2a/pgraph/pgraph.c` | Accessor implementations |
| `hw/xbox/nv2a/pgraph/vk/frame-interp-macos.m` | **New** — async VTFrameProcessor wrapper |
| `hw/xbox/nv2a/pgraph/vk/frame-interp-macos.h` | **New** — C interface |
| `hw/xbox/nv2a/pgraph/vk/meson.build` | Frameworks + .m source |
| `ui/xemu.c` | Interpolation render loop |
| `ui/xui/main-menu.cc` | Settings toggle |
| `config_spec.yml` | frame_interpolation config |