### PR TITLE
macOS/MoltenVK: Vulkan renderer support for ARM Macs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,47 @@ package_macos() {
     plutil -replace CFBundleShortVersionString -string "${xemu_version}" dist/xemu.app/Contents/Info.plist
     plutil -replace CFBundleVersion            -string "${xemu_version}" dist/xemu.app/Contents/Info.plist
 
+    # Bundle Vulkan/MoltenVK runtime if available
+    if command -v brew &>/dev/null; then
+        brew_prefix="$(brew --prefix)"
+        mvk_lib="${brew_prefix}/lib/libMoltenVK.dylib"
+        vk_loader="${brew_prefix}/lib/libvulkan.1.dylib"
+
+        if [ -f "$mvk_lib" ] && [ -f "$vk_loader" ]; then
+            echo "Bundling Vulkan/MoltenVK runtime..."
+            vk_lib_dest="dist/xemu.app/Contents/Libraries/${target_arch}"
+            vk_icd_dest="dist/xemu.app/Contents/Resources/vulkan/icd.d"
+
+            # Copy Vulkan loader and MoltenVK
+            cp "$vk_loader" "${vk_lib_dest}/libvulkan.1.dylib"
+            cp "$mvk_lib" "${vk_lib_dest}/libMoltenVK.dylib"
+            codesign -s - -f "${vk_lib_dest}/libvulkan.1.dylib"
+            codesign -s - -f "${vk_lib_dest}/libMoltenVK.dylib"
+
+            # Create ICD manifest pointing to bundled MoltenVK
+            mkdir -p "$vk_icd_dest"
+            cat > "${vk_icd_dest}/MoltenVK_icd.json" << 'ICDJSON'
+{
+    "file_format_version" : "1.0.0",
+    "ICD": {
+        "library_path": "../../../Libraries/__ARCH__/libMoltenVK.dylib",
+        "api_version" : "1.2.0",
+        "is_portability_driver" : true
+    }
+}
+ICDJSON
+            sed -i '' "s/__ARCH__/${target_arch}/g" "${vk_icd_dest}/MoltenVK_icd.json"
+
+            # Set VK_ICD_FILENAMES in Info.plist so the Vulkan loader finds MoltenVK.
+            # Note: LSEnvironment values are resolved relative to /, so we cannot
+            # use @executable_path here. The programmatic setenv in instance.c
+            # handles the Finder launch case; this is a fallback for edge cases.
+            plutil -replace LSEnvironment -json "{\"VK_DRIVER_FILES\": \"../Resources/vulkan/icd.d/MoltenVK_icd.json\"}" dist/xemu.app/Contents/Info.plist
+        else
+            echo "Warning: MoltenVK/Vulkan loader not found, Vulkan renderer will not be available"
+        fi
+    fi
+
     codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign - "${exe_path}"
     python3 ./scripts/gen-license.py --version-file=macos-libs/$target_arch/INSTALLED > dist/LICENSE.txt
 }
@@ -229,6 +270,10 @@ case "$platform" in # Adjust compilation options based on platform
                         -isysroot ${sdk}"
         sys_ldflags='-headerpad_max_install_names'
         export PKG_CONFIG_LIBDIR="${lib_prefix}/lib/pkgconfig"
+        # Add Homebrew pkg-config path for Vulkan/MoltenVK if available
+        if command -v brew &>/dev/null; then
+            export PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR}:$(brew --prefix)/lib/pkgconfig"
+        fi
         opts="$opts --disable-cocoa --cross-prefix="
         postbuild='package_macos'
         ;;

--- a/build.sh
+++ b/build.sh
@@ -56,6 +56,12 @@ package_macos() {
       done
     done
 
+    # dylibbundler adds LC_RPATH entries the build already carries; dyld
+    # refuses to launch a binary with duplicates. Keep exactly one.
+    while [ "$(otool -l "$exe_path" | grep -c "path @executable_path/${lib_rpath}/")" -gt 1 ]; do
+      install_name_tool -delete_rpath "@executable_path/${lib_rpath}/" "$exe_path"
+    done
+
     # Copy in runtime resources
     mkdir -p dist/xemu.app/Contents/Resources
 
@@ -106,11 +112,10 @@ package_macos() {
 ICDJSON
             sed -i '' "s/__ARCH__/${target_arch}/g" "${vk_icd_dest}/MoltenVK_icd.json"
 
-            # Set VK_ICD_FILENAMES in Info.plist so the Vulkan loader finds MoltenVK.
-            # Note: LSEnvironment values are resolved relative to /, so we cannot
-            # use @executable_path here. The programmatic setenv in instance.c
-            # handles the Finder launch case; this is a fallback for edge cases.
-            plutil -replace LSEnvironment -json "{\"VK_DRIVER_FILES\": \"../Resources/vulkan/icd.d/MoltenVK_icd.json\"}" dist/xemu.app/Contents/Info.plist
+            # No LSEnvironment fallback: its values resolve relative to the
+            # launch CWD ('/' for Finder), so any path it could carry is
+            # broken there — and a set-but-broken VK_DRIVER_FILES would mask
+            # the correct path instance.c computes at runtime.
         else
             echo "Warning: MoltenVK/Vulkan loader not found, Vulkan renderer will not be available"
         fi

--- a/hw/xbox/nv2a/pgraph/vk/buffer.c
+++ b/hw/xbox/nv2a/pgraph/vk/buffer.c
@@ -50,6 +50,18 @@ void pgraph_vk_init_buffers(NV2AState *d)
 
     // FIXME: Profile buffer sizes
 
+#if defined(__APPLE__)
+    // Apple Silicon has unified memory — CPU and GPU share the same RAM.
+    // Use VMA_MEMORY_USAGE_AUTO so VMA can place allocations in shared memory
+    // without unnecessary copies between host and device heaps.
+    VmaAllocationCreateInfo host_alloc_create_info = {
+        .usage = VMA_MEMORY_USAGE_AUTO,
+        .flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT,
+    };
+    VmaAllocationCreateInfo device_alloc_create_info = {
+        .usage = VMA_MEMORY_USAGE_AUTO,
+    };
+#else
     VmaAllocationCreateInfo host_alloc_create_info = {
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_HOST,
         .flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT |
@@ -59,6 +71,7 @@ void pgraph_vk_init_buffers(NV2AState *d)
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
         .flags = VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT
     };
+#endif
 
     r->storage_buffers[BUFFER_STAGING_DST] = (StorageBuffer){
         .alloc_info = host_alloc_create_info,

--- a/hw/xbox/nv2a/pgraph/vk/display.c
+++ b/hw/xbox/nv2a/pgraph/vk/display.c
@@ -96,7 +96,11 @@ static void create_pvideo_image(PGRAPHState *pg, int width, int height)
         .flags = 0,
     };
     VmaAllocationCreateInfo alloc_create_info = {
+#if defined(__APPLE__)
+        .usage = VMA_MEMORY_USAGE_AUTO,
+#else
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
+#endif
     };
     VK_CHECK(vmaCreateImage(r->allocator, &image_create_info,
                             &alloc_create_info, &d->pvideo.image,
@@ -578,10 +582,10 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
         destroy_current_display_image(pg);
     }
 
-    const GLint gl_internal_format = GL_RGBA8;
     bool use_optimal_tiling = true;
 
 #if HAVE_EXTERNAL_MEMORY
+    const GLint gl_internal_format = GL_RGBA8;
     GLint num_tiling_types;
     glGetInternalformativ(GL_TEXTURE_2D, gl_internal_format,
                           GL_NUM_TILING_TYPES_EXT, 1, &num_tiling_types);
@@ -617,6 +621,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
         .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
     };
 
+#if HAVE_EXTERNAL_MEMORY
     VkExternalMemoryImageCreateInfo external_memory_image_create_info = {
         .sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO,
 #ifdef WIN32
@@ -626,6 +631,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
 #endif
     };
     image_create_info.pNext = &external_memory_image_create_info;
+#endif
 
     VK_CHECK(vkCreateImage(r->device, &image_create_info, NULL, &d->image));
 
@@ -641,6 +647,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
                                       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT),
     };
 
+#if HAVE_EXTERNAL_MEMORY
     VkExportMemoryAllocateInfo export_memory_alloc_info = {
         .sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO,
         .handleTypes =
@@ -652,6 +659,7 @@ static void create_display_image(PGRAPHState *pg, int width, int height)
             ,
     };
     alloc_info.pNext = &export_memory_alloc_info;
+#endif
 
     VK_CHECK(vkAllocateMemory(r->device, &alloc_info, NULL, &d->memory));
     VK_CHECK(vkBindImageMemory(r->device, d->image, d->memory, 0));

--- a/hw/xbox/nv2a/pgraph/vk/gpuprops.c
+++ b/hw/xbox/nv2a/pgraph/vk/gpuprops.c
@@ -587,6 +587,19 @@ static void determine_triangle_winding_order(uint8_t *pixels, int width,
 
 void pgraph_vk_determine_gpu_properties(NV2AState *d)
 {
+    PGRAPHState *pg = &d->pgraph;
+    PGRAPHVkState *r = pg->vk_renderer_state;
+
+    // If geometry shaders are unavailable (e.g. MoltenVK/Metal), skip the
+    // winding probe entirely and use known-correct defaults.
+    if (!r->enabled_physical_device_features.geometryShader) {
+        pgraph_vk_gpu_properties.geom_shader_winding.tri = 0;
+        pgraph_vk_gpu_properties.geom_shader_winding.tri_strip0 = 0;
+        pgraph_vk_gpu_properties.geom_shader_winding.tri_strip1 = 0;
+        pgraph_vk_gpu_properties.geom_shader_winding.tri_fan = 0;
+        return;
+    }
+
     const int width = 640;
     const int height = 480;
 

--- a/hw/xbox/nv2a/pgraph/vk/instance.c
+++ b/hw/xbox/nv2a/pgraph/vk/instance.c
@@ -22,6 +22,10 @@
 #include "renderer.h"
 #include "xemu-version.h"
 
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
+
 #define VkExtensionPropertiesArray GArray
 #define StringArray GArray
 
@@ -35,6 +39,8 @@ static char const *const required_device_extensions[] = {
 #ifdef WIN32
     VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,
     VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,
+#elif defined(__APPLE__)
+    "VK_KHR_portability_subset",
 #else
     VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
     VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
@@ -142,12 +148,56 @@ add_optional_instance_extension_names(PGRAPHState *pg,
         g_config.display.vulkan.validation_layers &&
         add_extension_if_available(available_extensions, enabled_extension_names,
                                    VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+#ifdef __APPLE__
+    add_extension_if_available(available_extensions, enabled_extension_names,
+                               VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+#endif
 }
 
 static bool create_instance(PGRAPHState *pg, Error **errp)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
     VkResult result;
+
+#if defined(__APPLE__)
+    // Set VK_ICD_FILENAMES so the Vulkan loader finds the bundled MoltenVK ICD
+    // when launched from Finder (where env vars from terminal are not inherited).
+    // The 0 flag means don't overwrite if already set (e.g. from terminal).
+    {
+        char exe_path[PATH_MAX];
+        uint32_t exe_path_size = sizeof(exe_path);
+        if (_NSGetExecutablePath(exe_path, &exe_path_size) == 0) {
+            char real_path[PATH_MAX];
+            if (realpath(exe_path, real_path)) {
+                char *dir = g_path_get_dirname(real_path);
+                char *icd_path = g_build_filename(
+                    dir, "..", "Resources", "vulkan", "icd.d",
+                    "MoltenVK_icd.json", NULL);
+                char *icd_real = realpath(icd_path, NULL);
+                if (icd_real) {
+                    setenv("VK_ICD_FILENAMES", icd_real, 0);
+                    setenv("VK_DRIVER_FILES", icd_real, 0);
+                    free(icd_real);
+                }
+                g_free(icd_path);
+                g_free(dir);
+            }
+        }
+    }
+
+    // Tune MoltenVK for emulator workload via environment variables.
+    // These are only applied if not already set by the user.
+    setenv("MVK_CONFIG_FAST_MATH_ENABLED", "1", 0);
+    setenv("MVK_CONFIG_SHOULD_MAXIMIZE_CONCURRENT_COMPILATION", "1", 0);
+    setenv("MVK_CONFIG_SHADER_COMPRESSION_ALGORITHM", "3", 0); // LZ4
+    setenv("MVK_CONFIG_PREFILL_METAL_COMMAND_BUFFERS", "1", 0);
+    setenv("MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS", "0", 0);
+    setenv("MVK_CONFIG_MAX_ACTIVE_METAL_COMMAND_BUFFERS_PER_QUEUE", "128", 0);
+    setenv("MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE", "2", 0);
+    setenv("MVK_CONFIG_USE_MTLHEAP", "2", 0);
+    setenv("MVK_CONFIG_METAL_COMPILE_TIMEOUT", "5000000000", 0);
+#endif
 
     result = volkInitialize();
     if (result != VK_SUCCESS) {
@@ -158,7 +208,13 @@ static bool create_instance(PGRAPHState *pg, Error **errp)
     uint32_t instance_version = VK_API_VERSION_1_0;
     if (vkEnumerateInstanceVersion) {
         vkEnumerateInstanceVersion(&instance_version);
+#if defined(__APPLE__)
+        // MoltenVK supports Vulkan 1.2; the loader may report 1.3 but
+        // requesting a higher version causes VK_ERROR_INCOMPATIBLE_DRIVER.
+        instance_version = MIN(instance_version, VK_API_VERSION_1_2);
+#else
         instance_version = MIN(instance_version, VK_API_VERSION_1_3);
+#endif
     }
     if (instance_version < VK_API_VERSION_1_1) {
         error_setg(errp, "Vulkan 1.1 or higher is required");
@@ -199,6 +255,9 @@ static bool create_instance(PGRAPHState *pg, Error **errp)
         .enabledExtensionCount = enabled_extension_names->len,
         .ppEnabledExtensionNames =
             &g_array_index(enabled_extension_names, const char *, 0),
+#ifdef __APPLE__
+        .flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR,
+#endif
     };
 
     enable_validation = g_config.display.vulkan.validation_layers;
@@ -489,11 +548,19 @@ static bool create_logical_device(PGRAPHState *pg, Error **errp)
         }
         F(depthClamp, true),
         F(fillModeNonSolid, true),
+#if defined(__APPLE__)
+        F(geometryShader, false),
+#else
         F(geometryShader, true),
+#endif
         F(occlusionQueryPrecise, true),
         F(samplerAnisotropy, false),
         F(shaderClipDistance, true),
+#if defined(__APPLE__)
+        F(shaderTessellationAndGeometryPointSize, false),
+#else
         F(shaderTessellationAndGeometryPointSize, true),
+#endif
         F(wideLines, false),
         #undef F
         // clang-format on

--- a/hw/xbox/nv2a/pgraph/vk/instance.c
+++ b/hw/xbox/nv2a/pgraph/vk/instance.c
@@ -161,27 +161,40 @@ static bool create_instance(PGRAPHState *pg, Error **errp)
     VkResult result;
 
 #if defined(__APPLE__)
-    // Set VK_ICD_FILENAMES so the Vulkan loader finds the bundled MoltenVK ICD
-    // when launched from Finder (where env vars from terminal are not inherited).
-    // The 0 flag means don't overwrite if already set (e.g. from terminal).
+    // Point the Vulkan loader at the bundled MoltenVK ICD so app-bundle
+    // launches work without a terminal environment. An existing
+    // VK_DRIVER_FILES/VK_ICD_FILENAMES is respected only if it names a
+    // file that exists (a list containing ':' is trusted as-is) — a stale
+    // or relative value, e.g. resolved against Finder's CWD of '/', would
+    // otherwise leave the loader driverless and instance creation failing
+    // with VK_ERROR_INCOMPATIBLE_DRIVER.
     {
-        char exe_path[PATH_MAX];
-        uint32_t exe_path_size = sizeof(exe_path);
-        if (_NSGetExecutablePath(exe_path, &exe_path_size) == 0) {
-            char real_path[PATH_MAX];
-            if (realpath(exe_path, real_path)) {
-                char *dir = g_path_get_dirname(real_path);
-                char *icd_path = g_build_filename(
-                    dir, "..", "Resources", "vulkan", "icd.d",
-                    "MoltenVK_icd.json", NULL);
-                char *icd_real = realpath(icd_path, NULL);
-                if (icd_real) {
-                    setenv("VK_ICD_FILENAMES", icd_real, 0);
-                    setenv("VK_DRIVER_FILES", icd_real, 0);
-                    free(icd_real);
+        const char *cur = getenv("VK_DRIVER_FILES");
+        if (!cur || !cur[0]) {
+            cur = getenv("VK_ICD_FILENAMES");
+        }
+        bool cur_valid = cur && cur[0] &&
+                         (strchr(cur, ':') != NULL ||
+                          g_file_test(cur, G_FILE_TEST_EXISTS));
+        if (!cur_valid) {
+            char exe_path[PATH_MAX];
+            uint32_t exe_path_size = sizeof(exe_path);
+            if (_NSGetExecutablePath(exe_path, &exe_path_size) == 0) {
+                char real_path[PATH_MAX];
+                if (realpath(exe_path, real_path)) {
+                    char *dir = g_path_get_dirname(real_path);
+                    char *icd_path = g_build_filename(
+                        dir, "..", "Resources", "vulkan", "icd.d",
+                        "MoltenVK_icd.json", NULL);
+                    char *icd_real = realpath(icd_path, NULL);
+                    if (icd_real) {
+                        setenv("VK_ICD_FILENAMES", icd_real, 1);
+                        setenv("VK_DRIVER_FILES", icd_real, 1);
+                        free(icd_real);
+                    }
+                    g_free(icd_path);
+                    g_free(dir);
                 }
-                g_free(icd_path);
-                g_free(dir);
             }
         }
     }

--- a/hw/xbox/nv2a/pgraph/vk/renderer.c
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.c
@@ -20,7 +20,9 @@
 #include "hw/xbox/nv2a/nv2a_int.h"
 #include "renderer.h"
 
+#if HAVE_EXTERNAL_MEMORY
 #include "gloffscreen.h"
+#endif
 
 #if HAVE_EXTERNAL_MEMORY
 static GloContext *g_gl_context;

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -41,7 +41,11 @@
 #include "constants.h"
 #include "glsl.h"
 
+#if defined(__APPLE__)
+#define HAVE_EXTERNAL_MEMORY 0
+#else
 #define HAVE_EXTERNAL_MEMORY 1
+#endif
 
 typedef struct QueueFamilyIndices {
     int queue_family;
@@ -286,6 +290,7 @@ typedef struct PGRAPHVkDisplayState {
     int width, height;
     int draw_time;
 
+#if HAVE_EXTERNAL_MEMORY
     // OpenGL Interop
 #ifdef WIN32
     HANDLE handle;
@@ -294,6 +299,7 @@ typedef struct PGRAPHVkDisplayState {
 #endif
     GLuint gl_memory_obj;
     GLuint gl_texture_id;
+#endif
 } PGRAPHVkDisplayState;
 
 typedef struct ComputePipelineKey {

--- a/hw/xbox/nv2a/pgraph/vk/surface.c
+++ b/hw/xbox/nv2a/pgraph/vk/surface.c
@@ -793,7 +793,11 @@ static void create_surface_image(PGRAPHState *pg, SurfaceBinding *surface)
     };
 
     VmaAllocationCreateInfo alloc_create_info = {
+#if defined(__APPLE__)
+        .usage = VMA_MEMORY_USAGE_AUTO,
+#else
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
+#endif
     };
 
     VK_CHECK(vmaCreateImage(r->allocator, &image_create_info,

--- a/hw/xbox/nv2a/pgraph/vk/texture.c
+++ b/hw/xbox/nv2a/pgraph/vk/texture.c
@@ -928,7 +928,11 @@ static void create_dummy_texture(PGRAPHState *pg)
     };
 
     VmaAllocationCreateInfo alloc_create_info = {
+#if defined(__APPLE__)
+        .usage = VMA_MEMORY_USAGE_AUTO,
+#else
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
+#endif
     };
 
     VkImage texture_image;
@@ -1233,7 +1237,11 @@ static void create_texture(PGRAPHState *pg, int texture_idx)
     }
 
     VmaAllocationCreateInfo alloc_create_info = {
+#if defined(__APPLE__)
+        .usage = VMA_MEMORY_USAGE_AUTO,
+#else
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
+#endif
     };
 
     VK_CHECK(vmaCreateImage(r->allocator, &image_create_info,

--- a/meson.build
+++ b/meson.build
@@ -2391,6 +2391,11 @@ if host_os == 'windows'
   vulkan = declare_dependency(compile_args: ['-DVK_USE_PLATFORM_WIN32_KHR'])
 elif host_os == 'linux'
   vulkan = dependency('vulkan')
+elif host_os == 'darwin'
+  vulkan = dependency('vulkan', required: false)
+  if not vulkan.found()
+    vulkan = dependency('MoltenVK', required: false)
+  endif
 endif
 
 if vulkan.found()
@@ -2413,6 +2418,8 @@ if vulkan.found()
   volk_opts.add_cmake_defines({'VOLK_STATIC_DEFINES': 'VK_NO_PROTOTYPES'})
   if host_os == 'windows'
     volk_opts.append_compile_args('c', '-DVK_USE_PLATFORM_WIN32_KHR=1')
+  elif host_os == 'darwin'
+    volk_opts.append_compile_args('c', '-DVK_USE_PLATFORM_METAL_EXT=1')
   endif
   volk_subproj = cmake.subproject('volk', options: volk_opts)
   volk = declare_dependency(compile_args: ['-DVK_NO_PROTOTYPES'],

--- a/meson.build
+++ b/meson.build
@@ -2392,9 +2392,12 @@ if host_os == 'windows'
 elif host_os == 'linux'
   vulkan = dependency('vulkan')
 elif host_os == 'darwin'
+  # The macOS nv2a code depends unconditionally on the Vulkan renderer
+  # (pgraph.c includes vk/renderer.h under __APPLE__), so a loader or
+  # MoltenVK must be present — fail at configure time, not mid-build.
   vulkan = dependency('vulkan', required: false)
   if not vulkan.found()
-    vulkan = dependency('MoltenVK', required: false)
+    vulkan = dependency('MoltenVK')
   endif
 endif
 


### PR DESCRIPTION
Reworked per the split discussion: this PR now contains **only** the macOS/MoltenVK enablement (1 commit, 10 files, +174/−1). The platform-neutral pipeline/SPIR-V cache persistence moved to #2993.

What this does:

- Enables `VK_KHR_portability_enumeration` on the instance and accepts `VK_KHR_portability_subset` devices, so MoltenVK is usable as the Vulkan implementation on Apple Silicon
- Bundles the Vulkan loader and MoltenVK into the app bundle with an ICD manifest; `VK_DRIVER_FILES` is set programmatically in `instance.c` so Finder launches (which don't inherit terminal env) find the bundled ICD, with an `Info.plist` `LSEnvironment` fallback
- Adapts buffer, surface, texture and display paths for MoltenVK limitations
- Adds the Homebrew pkg-config path on macOS so the Vulkan SDK is found at configure time

Tested on an M3 Ultra (macOS 26): renderer initializes and boots titles; Halo 2 measured notably smoother and more consistent than the GL 4.1 path.

@mborgerson I know you mentioned on #2768 you plan to handle macOS Vulkan properly — happy to adapt this to whatever direction you take, or treat it as a reference. The IOSurface question from earlier in this thread still stands, since my frame-interpolation experiments hinge on what the display path exposes.