### PR TITLE
Handle render target reinterpretation based on memory footprint (fixes part of MM3 scaling issue) for OpenGL

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/surface.c
+++ b/hw/xbox/nv2a/pgraph/gl/surface.c
@@ -354,9 +354,7 @@ bool pgraph_gl_check_surface_to_texture_compatibility(
 {
     // FIXME: Better checks/handling on formats and surface-texture compat
 
-    if ((!surface->swizzle && surface->pitch != shape->pitch) ||
-        surface->width != shape->width ||
-        surface->height != shape->height) {
+    if (!surface->swizzle && surface->pitch != shape->pitch) {
         return false;
     }
 
@@ -375,6 +373,11 @@ bool pgraph_gl_check_surface_to_texture_compatibility(
 
     if (shape->levels > 1) {
         // FIXME: Support rendering surface to mip levels
+        return false;
+    }
+
+    if (surface->width != shape->width ||
+        surface->height != shape->height) {
         return false;
     }
 

--- a/hw/xbox/nv2a/pgraph/gl/surface.c
+++ b/hw/xbox/nv2a/pgraph/gl/surface.c
@@ -361,11 +361,6 @@ bool pgraph_gl_check_surface_to_texture_compatibility(
     int surface_fmt = surface->shape.color_format;
     int texture_fmt = shape->color_format;
 
-    if (!surface->color) {
-        // FIXME: Support zeta to color
-        return false;
-    }
-
     if (shape->cubemap) {
         // FIXME: Support rendering surface to cubemap face
         return false;
@@ -378,6 +373,11 @@ bool pgraph_gl_check_surface_to_texture_compatibility(
 
     if (surface->width != shape->width ||
         surface->height != shape->height) {
+        return false;
+    }
+
+    if (!surface->color) {
+        // FIXME: Support zeta to color
         return false;
     }
 

--- a/hw/xbox/nv2a/pgraph/gl/surface.c
+++ b/hw/xbox/nv2a/pgraph/gl/surface.c
@@ -359,7 +359,14 @@ bool pgraph_gl_check_surface_to_texture_compatibility(
     }
 
     int surface_fmt = surface->shape.color_format;
+    int surface_zeta_fmt = surface->shape.zeta_format;
+    int surface_zeta_z_format = surface->shape.z_format;
     int texture_fmt = shape->color_format;
+
+    assert(texture_fmt < ARRAY_SIZE(kelvin_color_format_gl_map));
+
+    const ColorFormatInfo *texture_fmt_info =
+        &kelvin_color_format_gl_map[texture_fmt];
 
     if (shape->cubemap) {
         // FIXME: Support rendering surface to cubemap face
@@ -373,6 +380,23 @@ bool pgraph_gl_check_surface_to_texture_compatibility(
 
     if (surface->width != shape->width ||
         surface->height != shape->height) {
+
+        if (surface->width * surface->height * surface->fmt.bytes_per_pixel ==
+            shape->width * shape->height * texture_fmt_info->bytes_per_pixel)
+        {
+            if (!surface->color && !surface_zeta_z_format) {
+                switch (surface_zeta_fmt) {
+                case NV097_SET_SURFACE_FORMAT_ZETA_Z24S8: switch (texture_fmt) {
+                    case NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_Y16: return true;
+                    default: break;
+                    }
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+
         return false;
     }
 


### PR DESCRIPTION
## Description

This PR addresses part of the scaling issue (#1771) observed in Midtown Madness 3 by improving how render target to texture reinterpretation is handled in the OpenGL backend.

## Background

In Midtown Madness 3, a depth-stencil render surface is reused as a texture with a different format and resolution, while still sharing the same underlying memory footprint.

Previously, this case was not handled correctly, since the tracking logic only considered matching dimensions and formats.

## Change

In the OpenGL backend, when there is a mismatch in width/height between the render surface and the texture, an additional check is introduced:

- If both surfaces have an identical memory footprint (width × height × bytes_per_pixel)
- And the formats fall into a compatible category (currently restricted to the validated case)

then the conversion / reinterpretation path is allowed.

At the moment, this is intentionally limited to the specific case that could be validated:

- Integer / fixed-point depth-stencil surface
- Reinterpreted as a 16-bit integer texture

This restriction is deliberate to keep the change as safe as possible and avoid unintended side effects in untested scenarios. The condition could be generalized further in the future if needed.

## Validation

Using RenderDoc, it can be observed that:

- The depth-stencil buffer is correctly reinterpreted as a texture
- The texture is used in the post-processing pass
- The texture reflects the configured scaling

This confirms that the underlying issue with render target tracking and reinterpretation is resolved for this case.

## Result

With this change:

- The scaling of the depth-stencil texture works correctly
- Visual artifacts are still present in general; however, they disappear at specific scaling factors (e.g. 5×), confirming that the change is taking effect
- This indicates that a separate issue related to texture coordinate handling still remains

## Scope / Limitations
- This change only affects the OpenGL backend
- The Vulkan backend does not currently support this behavior and will require a separate implementation
- This PR addresses part 1 of the issue #1771
   - Render target reinterpretation / scaling is fixed
   - A remaining issue related to texture coordinate handling under scaling still exists

The remaining issue will be addressed separately.
