### PR TITLE
nv2a/vk: Skip finish stall when no reports are pending

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/reports.c
+++ b/hw/xbox/nv2a/pgraph/vk/reports.c
@@ -153,7 +153,8 @@ void pgraph_vk_process_pending_reports(NV2AState *d)
     uint32_t *dma_get = &d->pfifo.regs[NV_PFIFO_CACHE1_DMA_GET];
     uint32_t *dma_put = &d->pfifo.regs[NV_PFIFO_CACHE1_DMA_PUT];
 
-    if (*dma_get == *dma_put && r->in_command_buffer) {
+    if (*dma_get == *dma_put && r->in_command_buffer &&
+        !QSIMPLEQ_EMPTY(&r->report_queue)) {
         pgraph_vk_finish(pg, VK_FINISH_REASON_STALLED);
     }
 }


### PR DESCRIPTION
Titles that do not saturate the pfifo queue (e.g., https://github.com/abaire/nxdk_framerate_test, Jet Set Radio Future during the "press start" screen) may end up calling pgraph_process_pending_reports many times per frame. On Windows, each call to `pgraph_vk_finish` may take 250 microseconds or more, so these can quickly cause a 60 fps target to be missed. This change elides the finish call unless there is a pending zpass report.

Possibly contributes to the issues reported in #2790 but does not fully resolve them.