### PR TITLE
Let SMC handle actual tray eject/load

### DIFF
--- a/hw/xbox/smbus.h
+++ b/hw/xbox/smbus.h
@@ -36,6 +36,7 @@ void xbox_smc_append_avpack_hint(Error **errp);
 void xbox_smc_append_smc_version_hint(Error **errp);
 void xbox_smc_power_button(void);
 void xbox_smc_eject_button(void);
+void xbox_smc_tray_eject(uint8_t val);
 void xbox_smc_update_tray_state(void);
 
 #endif

--- a/hw/xbox/smbus_xbox_smc.c
+++ b/hw/xbox/smbus_xbox_smc.c
@@ -152,7 +152,7 @@ static int smc_write_data(SMBusDevice *dev, uint8_t *buf, uint8_t len)
                                        &error);
         } else {
             xemu_settings_set_string(&g_config.sys.files.dvd_path, "");
-            qmp_eject(true, "ide0-cd1", false, NULL, true, false, &error)
+            qmp_eject(true, "ide0-cd1", false, NULL, true, false, &error);
         }
         xbox_smc_update_tray_state();
         break;
@@ -370,10 +370,12 @@ void xbox_smc_eject_button(void)
 void xbox_smc_tray_eject(uint8_t val)
 {
     Object *obj = object_resolve_path_type("", TYPE_XBOX_SMC, NULL);
-    uint8_t buf[2];
-    buf[0] = 0x0c;
-    buf[1] = val;
-    smc_write_data(obj, buf, 2);
+    if (obj) {
+        uint8_t buf[2];
+        buf[0] = 0x0c;
+        buf[1] = val;
+        smc_write_data(obj, buf, 2);
+    }
 }
 
 // FIXME: Ideally this would be called on a tray state change callback (see

--- a/hw/xbox/smbus_xbox_smc.c
+++ b/hw/xbox/smbus_xbox_smc.c
@@ -31,6 +31,8 @@
 #include "hw/i2c/smbus_slave.h"
 #include "qemu/config-file.h"
 #include "qapi/error.h"
+#include "qapi/qapi-commands-block.h"
+#include "ui/xemu-settings.h"
 #include "system/block-backend.h"
 #include "system/blockdev.h"
 #include "system/system.h"
@@ -117,6 +119,7 @@ static void smc_quick_cmd(SMBusDevice *dev, uint8_t read)
 
 static int smc_write_data(SMBusDevice *dev, uint8_t *buf, uint8_t len)
 {
+    Error *error = NULL;
     SMBusSMCDevice *smc = XBOX_SMC(dev);
 
     smc->cmd = buf[0];
@@ -144,16 +147,14 @@ static int smc_write_data(SMBusDevice *dev, uint8_t *buf, uint8_t len)
         break;
 
     case SMC_REG_TRAYEJECT:
-        Error *error = NULL;
         if (buf[0]) {
             const char *path = g_config.sys.files.dvd_path;
             qmp_blockdev_change_medium("ide0-cd1", NULL, path, "raw", false, false,
                                         false, 0, &error);                                       
         } else {
             xemu_settings_set_string(&g_config.sys.files.dvd_path, "");
-            qmp_eject(true, "ide0-cd1", false, NULL, true, false, &error);
+            qmp_eject("ide0-cd1", NULL, true, false, &error);
         }
-        error_free(error);
         xbox_smc_update_tray_state();
         break;
 
@@ -176,6 +177,8 @@ static int smc_write_data(SMBusDevice *dev, uint8_t *buf, uint8_t len)
         break;
     }
 
+    error_free(error);
+    
     return 0;
 }
 
@@ -371,10 +374,9 @@ void xbox_smc_tray_eject(uint8_t val)
 {
     Object *obj = object_resolve_path_type("", TYPE_XBOX_SMC, NULL);
     if (obj) {
-        uint8_t buf[2];
-        buf[0] = 0x0c;
-        buf[1] = val;
-        smc_write_data(obj, buf, 2);
+        SMBusSMCDevice *smc = XBOX_SMC(obj);
+        uint8_t buf[2] = { 0x0c, val };
+        smc_write_data(&smc->smbusdev, buf, 2);
     }
 }
 

--- a/hw/xbox/smbus_xbox_smc.c
+++ b/hw/xbox/smbus_xbox_smc.c
@@ -92,8 +92,10 @@
 #define SMC_REG_RESETONEJECT        0x19
 #define SMC_REG_INTEN               0x1a
 #define SMC_REG_SCRATCH             0x1b
-#define     SMC_REG_SCRATCH_SHORT_ANIMATION 0x04
-
+#define     SMC_REG_SCRATCH_EJECT_AFTER_BOOT 0x01
+#define     SMC_REG_SCRATCH_ERROR_AFTER_BOOT 0x02
+#define     SMC_REG_SCRATCH_SHORT_ANIMATION  0x04
+#define     SMC_REG_SCRATCH_FORCE_DASH_BOOT  0x08
 #define SMC_VERSION_LENGTH 3
 
 typedef struct SMBusSMCDevice {
@@ -115,6 +117,7 @@ static void smc_quick_cmd(SMBusDevice *dev, uint8_t read)
 
 static int smc_write_data(SMBusDevice *dev, uint8_t *buf, uint8_t len)
 {
+    Error *error = NULL;
     SMBusSMCDevice *smc = XBOX_SMC(dev);
 
     smc->cmd = buf[0];
@@ -139,6 +142,19 @@ static int smc_write_data(SMBusDevice *dev, uint8_t *buf, uint8_t len)
         } else if (buf[0] & SMC_REG_POWER_SHUTDOWN) {
             qemu_system_shutdown_request(SHUTDOWN_CAUSE_GUEST_SHUTDOWN);
         }
+        break;
+
+    case SMC_REG_TRAYEJECT:
+        if (buf[0]) {
+            const char *path = g_config.sys.files.dvd_path;
+            qmp_blockdev_change_medium(true, "ide0-cd1", false, NULL, path,
+                                       false, "", false, false, false, 0,
+                                       &error);
+        } else {
+            xemu_settings_set_string(&g_config.sys.files.dvd_path, "");
+            qmp_eject(true, "ide0-cd1", false, NULL, true, false, &error)
+        }
+        xbox_smc_update_tray_state();
         break;
 
     case SMC_REG_ERROR_WRITE:
@@ -265,8 +281,12 @@ static void smbus_smc_realize(DeviceState *dev, Error **errp)
     smc->cmd = 0;
     smc->error_reg = 0;
 
+    if (object_property_get_bool(qdev_get_machine(), "eject-after-boot", NULL)) {
+        smc->scratch_reg |= SMC_REG_SCRATCH_EJECT_AFTER_BOOT;
+    }
+
     if (object_property_get_bool(qdev_get_machine(), "short-animation", NULL)) {
-        smc->scratch_reg = SMC_REG_SCRATCH_SHORT_ANIMATION;
+        smc->scratch_reg |= SMC_REG_SCRATCH_SHORT_ANIMATION;
     }
 
     avpack = object_property_get_str(qdev_get_machine(), "avpack", NULL);
@@ -345,6 +365,15 @@ void xbox_smc_eject_button(void)
     SMBusSMCDevice *smc = XBOX_SMC(obj);
     smc->intstatus_reg |= SMC_REG_INTSTATUS_EJECT_BUTTON;
     xbox_assert_extsmi();
+}
+
+void xbox_smc_tray_eject(uint8_t val)
+{
+    Object *obj = object_resolve_path_type("", TYPE_XBOX_SMC, NULL);
+    uint8_t buf[2];
+    buf[0] = 0x0c;
+    buf[1] = val;
+    smc_write_data(obj, buf, 2);
 }
 
 // FIXME: Ideally this would be called on a tray state change callback (see

--- a/hw/xbox/smbus_xbox_smc.c
+++ b/hw/xbox/smbus_xbox_smc.c
@@ -117,7 +117,6 @@ static void smc_quick_cmd(SMBusDevice *dev, uint8_t read)
 
 static int smc_write_data(SMBusDevice *dev, uint8_t *buf, uint8_t len)
 {
-    Error *error = NULL;
     SMBusSMCDevice *smc = XBOX_SMC(dev);
 
     smc->cmd = buf[0];
@@ -145,6 +144,7 @@ static int smc_write_data(SMBusDevice *dev, uint8_t *buf, uint8_t len)
         break;
 
     case SMC_REG_TRAYEJECT:
+        Error *error = NULL;
         if (buf[0]) {
             const char *path = g_config.sys.files.dvd_path;
             qmp_blockdev_change_medium(true, "ide0-cd1", false, NULL, path,
@@ -154,6 +154,7 @@ static int smc_write_data(SMBusDevice *dev, uint8_t *buf, uint8_t len)
             xemu_settings_set_string(&g_config.sys.files.dvd_path, "");
             qmp_eject(true, "ide0-cd1", false, NULL, true, false, &error);
         }
+        error_free(error);
         xbox_smc_update_tray_state();
         break;
 

--- a/hw/xbox/smbus_xbox_smc.c
+++ b/hw/xbox/smbus_xbox_smc.c
@@ -147,9 +147,8 @@ static int smc_write_data(SMBusDevice *dev, uint8_t *buf, uint8_t len)
         Error *error = NULL;
         if (buf[0]) {
             const char *path = g_config.sys.files.dvd_path;
-            qmp_blockdev_change_medium(true, "ide0-cd1", false, NULL, path,
-                                       false, "", false, false, false, 0,
-                                       &error);
+            qmp_blockdev_change_medium("ide0-cd1", NULL, path, "raw", false, false,
+                                        false, 0, &error);                                       
         } else {
             xemu_settings_set_string(&g_config.sys.files.dvd_path, "");
             qmp_eject(true, "ide0-cd1", false, NULL, true, false, &error);

--- a/hw/xbox/xbox.c
+++ b/hw/xbox/xbox.c
@@ -507,10 +507,10 @@ static void xbox_machine_options(MachineClass *m)
         "Set the encoder presented to the OS: conexant (default), focus, "
         "xcalibur");
 
-    object_property_add_bool(oc, "eject-after-boot",
+    object_class_property_add_bool(oc, "eject-after-boot",
                              machine_get_eject_after_boot,
                              machine_set_eject_after_boot);
-    object_property_set_description(oc, "eject-after-boot",
+    object_class_property_set_description(oc, "eject-after-boot",
                                     "Eject disc tray after boot");        
 }
 

--- a/hw/xbox/xbox.c
+++ b/hw/xbox/xbox.c
@@ -396,6 +396,18 @@ static bool machine_get_short_animation(Object *obj, Error **errp)
     return ms->short_animation;
 }
 
+static void machine_set_eject_after_boot(Object *obj, bool value, Error **errp)
+{
+    XboxMachineState *ms = XBOX_MACHINE(obj);
+    ms->eject_after_boot = value;
+}
+
+static bool machine_get_eject_after_boot(Object *obj, Error **errp)
+{
+    XboxMachineState *ms = XBOX_MACHINE(obj);
+    return ms->eject_after_boot;
+}
+
 static char *machine_get_smc_version(Object *obj, Error **errp)
 {
     XboxMachineState *ms = XBOX_MACHINE(obj);
@@ -494,6 +506,12 @@ static void xbox_machine_options(MachineClass *m)
         oc, "video-encoder",
         "Set the encoder presented to the OS: conexant (default), focus, "
         "xcalibur");
+
+    object_property_add_bool(oc, "eject-after-boot",
+                             machine_get_eject_after_boot,
+                             machine_set_eject_after_boot);
+    object_property_set_description(oc, "eject-after-boot",
+                                    "Eject disc tray after boot");        
 }
 
 static inline void xbox_machine_initfn(Object *obj)
@@ -502,6 +520,7 @@ static inline void xbox_machine_initfn(Object *obj)
     object_property_set_bool(obj, "short-animation", false, &error_fatal);
     object_property_set_str(obj, "smc-version", "P01", &error_fatal);
     object_property_set_str(obj, "video-encoder", "conexant", &error_fatal);
+    object_property_set_bool(obj, "eject-after-boot", false, &error_fatal);
 }
 
 static void xbox_machine_class_init(ObjectClass *oc, const void *data)

--- a/hw/xbox/xbox.h
+++ b/hw/xbox/xbox.h
@@ -45,6 +45,7 @@ typedef struct XboxMachineState {
     char *bootrom;
     char *avpack;
     bool short_animation;
+    bool eject_after_boot;
     char *smc_version;
     char *video_encoder;
 } XboxMachineState;

--- a/system/vl.c
+++ b/system/vl.c
@@ -3018,7 +3018,7 @@ void qemu_init(int argc, char **argv)
 
     bool eject_after_boot = false;
     for (int i = 1; i < argc; i++) {
-        if (argv[i] && strcmp(argv[i], "-eject_after_boot")==0) {
+        if (argv[i] && strcmp(argv[i], "-eject_after_boot") == 0) {
             argv[i] = NULL;
             eject_after_boot = true;
             break;

--- a/system/vl.c
+++ b/system/vl.c
@@ -3016,9 +3016,19 @@ void qemu_init(int argc, char **argv)
         "none",
     }[g_config.sys.avpack];
 
-    fake_argv[fake_argc++] = g_strdup_printf("xbox%s%s%s,avpack=%s",
+    bool eject_after_boot = false;
+    for (int i = 1; i < argc; i++) {
+        if (argv[i] && strcmp(argv[i], "-eject_after_boot")==0) {
+            argv[i] = NULL;
+            eject_after_boot = true;
+            break;
+        }
+    }    
+
+    fake_argv[fake_argc++] = g_strdup_printf("xbox%s%s%s%s,avpack=%s",
         (bootrom_arg != NULL) ? bootrom_arg : "",
         g_config.general.skip_boot_anim ? ",short-animation=on" : "",
+        eject_after_boot ? ",eject-after-boot=on" : "",
         ",kernel-irqchip=off",
         avpack_str
         );

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -1380,23 +1380,26 @@ int main(int argc, char **argv)
 
 void xemu_eject_disc(Error **errp)
 {
-    Error *error = NULL;
+    // Error *error = NULL;
 
     xbox_smc_eject_button();
-    xemu_settings_set_string(&g_config.sys.files.dvd_path, "");
+    // xemu_settings_set_string(&g_config.sys.files.dvd_path, "");
 
-    // Xbox software may request that the drive open, but do it now anyway
-    qmp_eject("ide0-cd1", NULL, true, false, &error);
-    if (error) {
-        error_propagate(errp, error);
-    }
+    // // Xbox software may request that the drive open, but do it now anyway
+    // qmp_eject("ide0-cd1", NULL, true, false, &error);
+    // if (error) {
+    //     error_propagate(errp, error);
+    // }
 
-    xbox_smc_update_tray_state();
+    // xbox_smc_update_tray_state();
 }
 
 void xemu_load_disc(const char *path, Error **errp)
 {
-    Error *error = NULL;
+    xemu_settings_set_string(&g_config.sys.files.dvd_path, path);
+    xbox_smc_tray_eject(1); // issue smc tray load command
+
+    /*Error *error = NULL;
 
     // Ensure an eject sequence is always triggered so Xbox software reloads
     xbox_smc_eject_button();
@@ -1410,5 +1413,5 @@ void xemu_load_disc(const char *path, Error **errp)
         xemu_settings_set_string(&g_config.sys.files.dvd_path, path);
     }
 
-    xbox_smc_update_tray_state();
+    xbox_smc_update_tray_state();*/
 }

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -1380,38 +1380,11 @@ int main(int argc, char **argv)
 
 void xemu_eject_disc(Error **errp)
 {
-    // Error *error = NULL;
-
     xbox_smc_eject_button();
-    // xemu_settings_set_string(&g_config.sys.files.dvd_path, "");
-
-    // // Xbox software may request that the drive open, but do it now anyway
-    // qmp_eject("ide0-cd1", NULL, true, false, &error);
-    // if (error) {
-    //     error_propagate(errp, error);
-    // }
-
-    // xbox_smc_update_tray_state();
 }
 
 void xemu_load_disc(const char *path, Error **errp)
 {
     xemu_settings_set_string(&g_config.sys.files.dvd_path, path);
     xbox_smc_tray_eject(1); // issue smc tray load command
-
-    /*Error *error = NULL;
-
-    // Ensure an eject sequence is always triggered so Xbox software reloads
-    xbox_smc_eject_button();
-    xemu_settings_set_string(&g_config.sys.files.dvd_path, "");
-
-    qmp_blockdev_change_medium("ide0-cd1", NULL, path, "raw", false, false,
-                               false, 0, &error);
-    if (error) {
-        error_propagate(errp, error);
-    } else {
-        xemu_settings_set_string(&g_config.sys.files.dvd_path, path);
-    }
-
-    xbox_smc_update_tray_state();*/
 }


### PR DESCRIPTION
This is a remake of #1564

hw/xbox/smc: Centralize disc tray control and fix scratch register handling

Route Xemu UI disc eject/load commands through the emulated SMC's `SMC_REG_TRAYEJECT` register. This improves emulation accuracy by ensuring the SMC's state is always synchronized with disc operations, mimicking how a real Xbox interacts with its hardware.

Add a new machine property `eject-after-boot` and corresponding command-line option `-eject_after_boot` to set the SMC's scratch register flag `SMC_REG_SCRATCH_EJECT_AFTER_BOOT`.

Correctly use bitwise OR assignment (`|=`) when setting SMC scratch register flags (like `SMC_REG_SCRATCH_SHORT_ANIMATION`) to avoid unintentionally overwriting other flags.

Fixes #1563