### PR TITLE
nv2a/vk: Fix blurry 2D/UI rendering at internal resolutions > 1x

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/surface.c
+++ b/hw/xbox/nv2a/pgraph/vk/surface.c
@@ -252,7 +252,7 @@ static void download_surface_to_buffer(NV2AState *d, SurfaceBinding *surface,
                        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                        surface->image_scratch,
                        surface->image_scratch_current_layout, 1, &blit_region,
-                       surface->color ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
+                       VK_FILTER_NEAREST);
 
         pgraph_vk_transition_image_layout(pg, cmd, surface->image_scratch,
                                           surface->host_fmt.vk_format,

--- a/hw/xbox/nv2a/pgraph/vk/surface.c
+++ b/hw/xbox/nv2a/pgraph/vk/surface.c
@@ -1236,7 +1236,7 @@ void pgraph_vk_upload_surface_data(NV2AState *d, SurfaceBinding *surface,
         vkCmdBlitImage(cmd, surface->image_scratch,
                        surface->image_scratch_current_layout, surface->image,
                        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blitRegion,
-                       surface->color ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
+                       VK_FILTER_NEAREST);
     } else {
         // Note: We should be able to vkCmdCopyBufferToImage directly into
         // surface->image, but there is an apparent AMD Windows driver


### PR DESCRIPTION
I believe this is a bug introduced when the Vulkan renderer was initially added. Please let me know if the PR format is not acceptable.

When the CPU writes directly to a surface in VRAM, `pgraph_vk_upload_surface_data()` is called to sync that data to the GPU.

At internal resolutions above 1x, upscaling is done via `vkCmdBlitImage`. Color surfaces were explicitly using `VK_FILTER_LINEAR` for this blit. AFAIK linear filtering will ultimately introduce blur, and I'm not sure that's something you want for upscaling? Maybe I'm naive here but I don't see why we can't simply simply replicate pixels, (which is also what the GL renderer does via `surface_copy_expand()`, so hopefully fairly safe to do?). This fix switches the blit to `VK_FILTER_NEAREST` unconditionally.

In practice this affects content that writes its framebuffer from the CPU. I haven't found a ton of good repro scenarios for this just yet; mainly the XDK dashboard is _very_ obvious but I'll try to find a different example.. I suspect some game menus and other applications may that use CPU-rendered content. Pure 3D rendering is unaffected as it never goes through this path.

Edit: I've decided to change the downscale path to work the same way.

---

Also as an aside out of curiosity:

The downscale / download path at [line 251](https://github.com/xemu-project/xemu/blob/e72e76bd1f12ce45c6c63b4196c6918ea2cc705d/hw/xbox/nv2a/pgraph/vk/surface.c#L251-L256) has the same `surface->color ? VK_FILTER_LINEAR : VK_FILTER_NEAREST` logic:

```c
        vkCmdBlitImage(cmd, surface->image,
                       VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                       surface->image_scratch,
                       surface->image_scratch_current_layout, 1, &blit_region,
                       surface->color ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
```

Wouldn't the CPU expect accurate pixels from a rendered framebuffer in this case; not blended values? If this is also a bug I can include this in the PR or create a separate one if you like. I'm genuinely not sure about the downscaling part as it's a bit over my head.
