### PR TITLE
Enable x86-64-v3 optimizations for release builds

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -47,6 +47,7 @@ jobs:
             -Db_lto_mode=thin
             -Db_thinlto_cache=true
             -Db_thinlto_cache_dir="$LTO_CACHE_DIR"
+            -Dx86_version=3
           )
           mkdir -p ${LTO_CACHE_DIR}
         fi

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -66,6 +66,7 @@ jobs:
             -Db_lto_mode=thin
             -Db_thinlto_cache=true
             -Db_thinlto_cache_dir="$LTO_CACHE_DIR"
+            -Dx86_version=3
           )
           mkdir -p ${LTO_CACHE_DIR}
         fi

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -60,6 +60,7 @@ jobs:
           opts=(
             --extra-cflags="-flto-incremental=${LTO_CACHE_DIR} -flto-partition=cache"
             -Db_lto=true
+            -Dx86_version=3
           )
           mkdir -p ${LTO_CACHE_DIR}
         elif [[ "${{ matrix.arch }}" == "arm64" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -227,9 +227,6 @@ case "$platform" in # Adjust compilation options based on platform
         export LDFLAGS="${LDFLAGS} \
                         -arch ${target_arch} \
                         -isysroot ${sdk}"
-        if [ "$target_arch" == "x86_64" ]; then
-            sys_cflags='-march=ivybridge'
-        fi
         sys_ldflags='-headerpad_max_install_names'
         export PKG_CONFIG_LIBDIR="${lib_prefix}/lib/pkgconfig"
         opts="$opts --disable-cocoa --cross-prefix="

--- a/meson.build
+++ b/meson.build
@@ -450,7 +450,16 @@ if host_arch in ['i386', 'x86_64']
     qemu_isa_flags += cc.get_supported_arguments('-mneeded')
   endif
   if get_option('x86_version') >= '3'
-    qemu_isa_flags += ['-mmovbe', '-mabm', '-mbmi', '-mbmi2', '-mfma', '-mf16c']
+    qemu_isa_flags += ['-mmovbe', '-mlzcnt', '-mbmi', '-mbmi2', '-mfma', '-mf16c']
+    # The Win64 ABI only guarantees 16-byte stack alignment and its SEH unwind
+    # format cannot express realignment beyond that, but GCC's autovectorizer
+    # emits 32-byte-aligned spills (vmovdqa) for 256-bit ymm registers under
+    # -mavx2, which then fault at runtime. Cap autovectorization at 128-bit on
+    # Windows to avoid the crash while keeping the rest of the v3 ISA (FMA,
+    # BMI2, LZCNT, MOVBE, VEX-encoded 128-bit ops).
+    if host_os == 'windows'
+      qemu_isa_flags += cc.get_supported_arguments('-mprefer-vector-width=128')
+    endif
   endif
 
   # add required vector instruction set (each level implies those below)
@@ -3327,7 +3336,7 @@ if have_cpuid_h
 else
   have_avx2 = false
   have_avx512bw = false
-  if get_option('x86_version') >= '3'
+  if get_option('x86_version') >= '3' and host_arch in ['i386', 'x86_64']
     error('Cannot enable AVX optimizations due to missing cpuid.h')
   endif
 endif


### PR DESCRIPTION
Enables x86-64-v3 optimization for release builds (with some compatibility fixes). Thanks to @GXTX for championing the change.

Supersedes:
* #2871
* #1557 

Fixes #1485
Fixes #1492