### PR TITLE
nv2a: defer PGRAPH IRQ raise from the pfifo thread to a bottom half (fixes random load-time hang)

### DIFF
--- a/hw/xbox/nv2a/pgraph/pgraph.c
+++ b/hw/xbox/nv2a/pgraph/pgraph.c
@@ -177,6 +177,23 @@ void pgraph_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
     qemu_mutex_unlock(&d->pfifo.lock);
 }
 
+static void pgraph_update_irq_bh(void *opaque)
+{
+    NV2AState *d = opaque;
+    nv2a_update_irq(d);
+}
+
+/* Raising a PGRAPH interrupt needs the BQL, but taking the BQL from the
+ * pfifo thread can deadlock: a BQL holder may itself be blocked waiting on
+ * this very thread. For example, IDE DMA loading game data into RAM that
+ * overlaps a GPU-watched range holds the BQL and waits for the
+ * memory-access-callback flush that only the pfifo thread performs. Defer
+ * the IRQ raise to a main-loop bottom half, which runs with the BQL held. */
+static void pgraph_schedule_irq_update(NV2AState *d)
+{
+    aio_bh_schedule_oneshot(qemu_get_aio_context(), pgraph_update_irq_bh, d);
+}
+
 void pgraph_context_switch(NV2AState *d, unsigned int channel_id)
 {
     PGRAPHState *pg = &d->pgraph;
@@ -198,12 +215,8 @@ void pgraph_context_switch(NV2AState *d, unsigned int channel_id)
                             NV_PGRAPH_DEBUG_3_HW_CONTEXT_SWITCH));
 
         pg->waiting_for_context_switch = true;
-        qemu_mutex_unlock(&pg->lock);
-        bql_lock();
         pg->pending_interrupts |= NV_PGRAPH_INTR_CONTEXT_SWITCH;
-        nv2a_update_irq(d);
-        bql_unlock();
-        qemu_mutex_lock(&pg->lock);
+        pgraph_schedule_irq_update(d);
     }
 }
 
@@ -849,11 +862,7 @@ DEF_METHOD(NV097, NO_OPERATION)
     pg->pending_interrupts |= NV_PGRAPH_INTR_ERROR;
     pg->waiting_for_nop = true;
 
-    qemu_mutex_unlock(&pg->lock);
-    bql_lock();
-    nv2a_update_irq(d);
-    bql_unlock();
-    qemu_mutex_lock(&pg->lock);
+    pgraph_schedule_irq_update(d);
 }
 
 DEF_METHOD(NV097, WAIT_FOR_IDLE)


### PR DESCRIPTION
Taking the BQL from the pfifo thread (NO_OPERATION and context-switch interrupt raising) can deadlock: a BQL holder may itself be blocked waiting on the pfifo thread.

**Concrete scenario, captured with gdb on Windows:** IDE DMA loading game data into RAM that overlaps a GPU-watched range holds the BQL inside the block-layer completion callback and waits in `mem_check_access_callback_ramaddr` for the flush that only the pfifo thread performs — while the pfifo thread sits in `bql_lock()` inside the `NO_OPERATION` handler. Both threads wait on each other forever and the emulator hard-freezes.

Thread stacks at the moment of the hang:
- pfifo thread: `qemu_mutex_lock(bql)` ← `pgraph_NV097_NO_OPERATION_handler` ← `pgraph_method` ← `pfifo_run_pusher`
- BQL holder: `qemu_event_wait` ← `mem_check_access_callback_ramaddr` ← `flatview_write` ← `pci_dma_read` ← `bmdma_rw_buf` ← `ide_atapi_cmd_read_dma_cb` ← `blk_aio_complete`

Observed in the wild as a long-standing random hang when starting games; with Silent Scope Complete it reproduces every few boots during the disc-heavy loading phase.

**Fix:** schedule the `nv2a_update_irq()` call on a main-loop bottom half (which runs with the BQL already held) instead of acquiring the BQL from the pfifo thread. `pending_interrupts` is set before scheduling, and `nv2a_update_irq()` recomputes from pending & enabled, so the deferral is safe and idempotent.
