### PR TITLE
nv2a: consume INLINE_ARRAY vertex data in bulk

### DIFF
--- a/hw/xbox/nv2a/pgraph/pgraph.c
+++ b/hw/xbox/nv2a/pgraph/pgraph.c
@@ -2753,11 +2753,28 @@ DEF_METHOD(NV097, DRAW_ARRAYS)
     pg->draw_arrays_prevent_connect = false;
 }
 
-DEF_METHOD_NON_INC(NV097, INLINE_ARRAY)
+/* Defined without the NON_INC wrapper on purpose: bulk vertex data would
+ * otherwise pay a dispatch-loop iteration per word. Consume the whole run
+ * at once instead. */
+DEF_METHOD(NV097, INLINE_ARRAY)
 {
     pgraph_check_within_begin_end_block(pg);
     assert(pg->inline_array_length < NV2A_MAX_BATCH_LENGTH);
-    pg->inline_array[pg->inline_array_length++] = parameter;
+
+    if (inc) {
+        pg->inline_array[pg->inline_array_length++] = parameter;
+        return;
+    }
+
+    size_t count = MIN(num_words_available,
+                       (size_t)NV2A_MAX_BATCH_LENGTH -
+                           (size_t)pg->inline_array_length);
+    for (size_t i = 0; i < count; i++) {
+        pg->inline_array[pg->inline_array_length + i] =
+            ldl_le_p(parameters + i);
+    }
+    pg->inline_array_length += count;
+    *num_words_consumed = count;
 }
 
 DEF_METHOD_INC(NV097, SET_EYE_VECTOR)


### PR DESCRIPTION
`NV097_INLINE_ARRAY` was defined through the NON_INC wrapper, which invokes the handler once per pushbuffer word: bulk geometry paid a dispatch-loop iteration (plus the method logging hook) for every single 32-bit word.

This PR defines the handler directly and lets it consume the whole run of available words at once, reporting the amount through `*num_words_consumed` — the same batching other handlers already use. The unusual `inc` case keeps the previous word-at-a-time behavior.

Draw-call-heavy titles that submit geometry inline benefit substantially. Measured with Silent Scope Complete (~5000 inline-array draws per frame): several milliseconds per frame less method-processing time on the pfifo thread. This was part of a series of local fixes that took the game from ~15 fps to its full frame-rate cap on the same machine (Intel iGPU laptop).
