### PR TITLE
Lightgun support with per-device pointer input (Raw Input / evdev)

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -55,6 +55,44 @@ input:
   auto_bind:
     type: bool
     default: true
+  # Keep mouse clicks away from UI shortcuts while using a mouse/lightgun
+  disable_dblclick_fullscreen:
+    type: bool
+    default: false
+  disable_rclick_menu:
+    type: bool
+    default: false
+  # Lightgun aim feel: smoothing tames hand/camera jitter (0 = raw),
+  # sensitivity scales aim range around the screen center (1.0 = 1:1)
+  lightgun_smoothing:
+    type: number
+    default: 0.2
+  lightgun_sensitivity:
+    type: number
+    default: 1.0
+  # Optional custom bindings for lightgun ports. Empty = default mouse
+  # mapping (LEFT=trigger/A, RIGHT=B, MIDDLE=Start, X1=Back, X2=X).
+  # Formats: "mouse:<hash>:<left|right|middle|x1|x2>",
+  # "mouse:<hash>:k<input-event code>" (raw device key, e.g. Linux guns)
+  # or "key:<SDL key name>"
+  lightgun_mapping:
+    trigger: string
+    b: string
+    x: string
+    start: string
+    back: string
+    dpad_up: string
+    dpad_down: string
+    dpad_left: string
+    dpad_right: string
+    y: string
+    white: string
+    black: string
+    lstick: string
+    rstick: string
+    ltrig: string
+    rtrig: string
+    guide: string
   # Deprecated: use 'enable_rumble' on the controller mapping settings instead
   allow_vibration:
     type: bool

--- a/hw/xbox/meson.build
+++ b/hw/xbox/meson.build
@@ -16,6 +16,7 @@ specific_ss.add(files(
 	'xid.c',
 	'xblc.c',
 	'xid-gamepad.c',
+	'xid-lightgun.c',
 	))
 subdir('nv2a')
 subdir('mcpx')

--- a/hw/xbox/xid-lightgun.c
+++ b/hw/xbox/xid-lightgun.c
@@ -1,0 +1,369 @@
+/*
+ * QEMU USB XID Lightgun (EMS TopGun II)
+ *
+ * Copyright (c) 2013 espes
+ * Copyright (c) 2017 Jannik Vogel
+ * Copyright (c) 2018-2021 Matt Borgerson
+ *
+ * Emulates an EMS TopGun II lightgun. On the Xbox this device enumerates
+ * as a standard XID gamepad with device subtype 0x50 (lightgun). The
+ * aiming position is reported through the left thumbstick axes and games
+ * detect whether the gun points at the screen through bit 0x2000 of
+ * wButtons (XINPUT_LIGHTGUN_ONSCREEN).
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "xid.h"
+
+// #define DEBUG_XID
+#ifdef DEBUG_XID
+#define DPRINTF printf
+#else
+#define DPRINTF(...)
+#endif
+
+#define USB_VENDOR_EMS 0x0b9a
+#define USB_PRODUCT_TOPGUN_II 0x016b
+
+#define GAMEPAD_IN_ENDPOINT_ID 0x02
+#define GAMEPAD_OUT_ENDPOINT_ID 0x02
+
+typedef struct USBXIDLightgunState {
+    USBXIDGamepadState xid;
+    // Calibration offsets, set by the game through
+    // XInputSetLightgunCalibration -> HID SET_REPORT (see Cxbx-Reloaded
+    // g_devs[].info.ligthgun offsets)
+    int16_t offset_x, offset_y;
+    int16_t offset_upp_x, offset_upp_y;
+} USBXIDLightgunState;
+
+// Wire format of the calibration report sent by XInputSetLightgunCalibration
+typedef struct XIDLightgunCalibrationReport {
+    uint8_t bReportId;
+    uint8_t bLength;
+    int16_t wCenterX;
+    int16_t wCenterY;
+    int16_t wUpperLeftX;
+    int16_t wUpperLeftY;
+} QEMU_PACKED XIDLightgunCalibrationReport;
+
+#define USB_XID_LIGHTGUN(obj) \
+    OBJECT_CHECK(USBXIDLightgunState, (obj), TYPE_USB_XID_LIGHTGUN)
+
+static const USBDescStrings desc_strings_lightgun = {
+    [STR_MANUFACTURER] = "EMS",
+    [STR_PRODUCT]      = "TopGun II",
+    [STR_SERIALNUMBER] = "1",
+};
+
+static const USBDescIface desc_iface_xbox_lightgun = {
+    .bInterfaceNumber = 0,
+    .bNumEndpoints = 2,
+    .bInterfaceClass = USB_CLASS_XID,
+    .bInterfaceSubClass = 0x42,
+    .bInterfaceProtocol = 0x00,
+    .eps =
+        (USBDescEndpoint[]){
+            {
+                .bEndpointAddress = USB_DIR_IN | GAMEPAD_IN_ENDPOINT_ID,
+                .bmAttributes = USB_ENDPOINT_XFER_INT,
+                .wMaxPacketSize = 0x20,
+                .bInterval = 4,
+            },
+            {
+                .bEndpointAddress = USB_DIR_OUT | GAMEPAD_OUT_ENDPOINT_ID,
+                .bmAttributes = USB_ENDPOINT_XFER_INT,
+                .wMaxPacketSize = 0x20,
+                .bInterval = 4,
+            },
+        },
+};
+
+static const USBDescDevice desc_device_xbox_lightgun = {
+    .bcdUSB = 0x0110,
+    .bMaxPacketSize0 = 0x40,
+    .bNumConfigurations = 1,
+    .confs =
+        (USBDescConfig[]){
+            {
+                .bNumInterfaces = 1,
+                .bConfigurationValue = 1,
+                .bmAttributes = USB_CFG_ATT_ONE,
+                .bMaxPower = 50,
+                .nif = 1,
+                .ifs = &desc_iface_xbox_lightgun,
+            },
+        },
+};
+
+static const USBDesc desc_xbox_lightgun = {
+    .id = {
+        .idVendor          = USB_VENDOR_EMS,
+        .idProduct         = USB_PRODUCT_TOPGUN_II,
+        .bcdDevice         = 0x0457,
+        .iManufacturer     = STR_MANUFACTURER,
+        .iProduct          = STR_PRODUCT,
+        .iSerialNumber     = STR_SERIALNUMBER,
+    },
+    .full = &desc_device_xbox_lightgun,
+    .str  = desc_strings_lightgun,
+};
+
+static const XIDDesc desc_xid_xbox_lightgun = {
+    .bLength = 0x10,
+    .bDescriptorType = USB_DT_XID,
+    .bcdXid = 0x100,
+    .bType = XID_DEVICETYPE_GAMEPAD,
+    .bSubType = XID_DEVICESUBTYPE_LIGHTGUN,
+    .bMaxInputReportSize = 20,
+    .bMaxOutputReportSize = 6,
+    .wAlternateProductIds = { 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF },
+};
+
+static void update_input_lightgun(USBXIDLightgunState *lg)
+{
+    USBXIDGamepadState *s = &lg->xid;
+
+    if (xemu_input_get_test_mode()) {
+        // Don't report changes if we are testing the controller while running
+        return;
+    }
+
+    update_input(s);
+
+    ControllerState *state = xemu_input_get_bound(s->device_index);
+    assert(state);
+    if (state->buttons & CONTROLLER_BUTTON_LIGHTGUN_ONSCREEN) {
+        s->in_state.wButtons |= XID_LIGHTGUN_ONSCREEN;
+    }
+
+    // Apply the game-supplied calibration the same way Cxbx-Reloaded does:
+    // positions beyond half range use the upper-left offsets
+    int16_t x = s->in_state.sThumbLX;
+    int16_t y = s->in_state.sThumbLY;
+    s->in_state.sThumbLX =
+        x + ((abs(x) > 16383) ? lg->offset_upp_x : lg->offset_x);
+    s->in_state.sThumbLY =
+        y + ((abs(y) > 16383) ? lg->offset_upp_y : lg->offset_y);
+}
+
+static void usb_xid_lightgun_set_calibration(
+    USBXIDLightgunState *lg, const XIDLightgunCalibrationReport *report)
+{
+    lg->offset_x = le16_to_cpu(report->wCenterX);
+    lg->offset_y = le16_to_cpu(report->wCenterY);
+    lg->offset_upp_x = le16_to_cpu(report->wUpperLeftX);
+    lg->offset_upp_y = le16_to_cpu(report->wUpperLeftY);
+    DPRINTF("xid lightgun calibration: center %d,%d upper-left %d,%d\n",
+            lg->offset_x, lg->offset_y, lg->offset_upp_x, lg->offset_upp_y);
+}
+
+// Unlike the gamepad control handler, this never asserts on unexpected
+// requests: lightgun games send requests (e.g. calibration) that the
+// generic handler does not know about, and guest behavior must not be able
+// to abort the emulator. Unknown requests are stalled like real hardware.
+static void usb_xid_lightgun_handle_control(USBDevice *dev, USBPacket *p,
+                                            int request, int value, int index,
+                                            int length, uint8_t *data)
+{
+    USBXIDLightgunState *lg = USB_XID_LIGHTGUN(dev);
+    USBXIDGamepadState *s = &lg->xid;
+
+    DPRINTF("xid lightgun handle_control 0x%x 0x%x\n", request, value);
+
+    int ret =
+        usb_desc_handle_control(dev, p, request, value, index, length, data);
+    if (ret >= 0) {
+        return;
+    }
+
+    switch (request) {
+    /* HID requests */
+    case ClassInterfaceRequest | HID_GET_REPORT:
+        if (value == 0x0100 && length <= s->in_state.bLength) { /* input */
+            update_input_lightgun(lg);
+            memcpy(data, &s->in_state, s->in_state.bLength);
+            p->actual_length = length;
+        } else {
+            p->status = USB_RET_STALL;
+        }
+        break;
+    case ClassInterfaceOutRequest | HID_SET_REPORT:
+        if (length == sizeof(XIDLightgunCalibrationReport)) {
+            // XInputSetLightgunCalibration
+            XIDLightgunCalibrationReport report;
+            memcpy(&report, data, sizeof(report));
+            usb_xid_lightgun_set_calibration(lg, &report);
+            p->actual_length = length;
+        } else if (value == 0x0200 && length == s->out_state.length) {
+            /* output (rumble; not present on a real gun, accept anyway) */
+            memcpy(&s->out_state, data, sizeof(s->out_state));
+            update_output(s);
+            p->actual_length = length;
+        } else {
+            p->status = USB_RET_STALL;
+        }
+        break;
+    /* XID requests */
+    case VendorInterfaceRequest | USB_REQ_GET_DESCRIPTOR:
+        if (value == 0x4200 && s->xid_desc->bLength <= length) {
+            memcpy(data, s->xid_desc, s->xid_desc->bLength);
+            p->actual_length = s->xid_desc->bLength;
+        } else {
+            p->status = USB_RET_STALL;
+        }
+        break;
+    case VendorInterfaceRequest | XID_GET_CAPABILITIES:
+        if (value == 0x0100) {
+            if (length > s->in_state_capabilities.bLength) {
+                length = s->in_state_capabilities.bLength;
+            }
+            memcpy(data, &s->in_state_capabilities, length);
+            p->actual_length = length;
+        } else if (value == 0x0200) {
+            if (length > s->out_state_capabilities.length) {
+                length = s->out_state_capabilities.length;
+            }
+            memcpy(data, &s->out_state_capabilities, length);
+            p->actual_length = length;
+        } else {
+            p->status = USB_RET_STALL;
+        }
+        break;
+    default:
+        DPRINTF("xid lightgun stalled on request 0x%x value 0x%x\n", request,
+                value);
+        p->status = USB_RET_STALL;
+        break;
+    }
+}
+
+static void usb_xid_lightgun_handle_data(USBDevice *dev, USBPacket *p)
+{
+    USBXIDLightgunState *lg = USB_XID_LIGHTGUN(dev);
+    USBXIDGamepadState *s = &lg->xid;
+
+    DPRINTF("xid handle_lightgun_data 0x%x %d 0x%zx\n", p->pid, p->ep->nr,
+            p->iov.size);
+
+    switch (p->pid) {
+    case USB_TOKEN_IN:
+        if (p->ep->nr == GAMEPAD_IN_ENDPOINT_ID) {
+            update_input_lightgun(lg);
+            usb_packet_copy(p, &s->in_state, s->in_state.bLength);
+        } else {
+            p->status = USB_RET_STALL;
+        }
+        break;
+    case USB_TOKEN_OUT:
+        if (p->ep->nr == GAMEPAD_OUT_ENDPOINT_ID) {
+            if (p->iov.size == sizeof(XIDLightgunCalibrationReport)) {
+                // Calibration may also arrive over the interrupt pipe
+                XIDLightgunCalibrationReport report;
+                usb_packet_copy(p, &report, sizeof(report));
+                usb_xid_lightgun_set_calibration(lg, &report);
+            } else if (p->iov.size == s->out_state.length) {
+                usb_packet_copy(p, &s->out_state, s->out_state.length);
+                update_output(s);
+            } else {
+                p->status = USB_RET_STALL;
+            }
+        } else {
+            p->status = USB_RET_STALL;
+        }
+        break;
+    default:
+        p->status = USB_RET_STALL;
+        break;
+    }
+}
+
+static void usb_xbox_lightgun_realize(USBDevice *dev, Error **errp)
+{
+    USBXIDLightgunState *lg = USB_XID_LIGHTGUN(dev);
+    USBXIDGamepadState *s = &lg->xid;
+    usb_desc_create_serial(dev);
+    usb_desc_init(dev);
+    s->intr = usb_ep_get(dev, USB_TOKEN_IN, 2);
+
+    s->in_state.bLength = sizeof(s->in_state);
+    s->in_state.bReportId = 0;
+
+    s->out_state.length = sizeof(s->out_state);
+    s->out_state.report_id = 0;
+
+    s->xid_desc = &desc_xid_xbox_lightgun;
+
+    memset(&s->in_state_capabilities, 0xFF, sizeof(s->in_state_capabilities));
+    s->in_state_capabilities.bLength = sizeof(s->in_state_capabilities);
+    s->in_state_capabilities.bReportId = 0;
+
+    memset(&s->out_state_capabilities, 0xFF,
+           sizeof(s->out_state_capabilities));
+    s->out_state_capabilities.length = sizeof(s->out_state_capabilities);
+    s->out_state_capabilities.report_id = 0;
+}
+
+static const Property xid_lightgun_properties[] = {
+    DEFINE_PROP_UINT8("index", USBXIDLightgunState, xid.device_index, 0),
+};
+
+static const VMStateDescription vmstate_usb_xbox_lightgun = {
+    .name = TYPE_USB_XID_LIGHTGUN,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]){ VMSTATE_USB_DEVICE(xid.dev,
+                                                   USBXIDLightgunState),
+                                VMSTATE_INT16(offset_x, USBXIDLightgunState),
+                                VMSTATE_INT16(offset_y, USBXIDLightgunState),
+                                VMSTATE_INT16(offset_upp_x,
+                                              USBXIDLightgunState),
+                                VMSTATE_INT16(offset_upp_y,
+                                              USBXIDLightgunState),
+                                VMSTATE_END_OF_LIST() },
+};
+
+static void usb_xbox_lightgun_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    USBDeviceClass *uc = USB_DEVICE_CLASS(klass);
+
+    uc->product_desc = "EMS TopGun II Lightgun";
+    uc->usb_desc = &desc_xbox_lightgun;
+    uc->realize = usb_xbox_lightgun_realize;
+    uc->unrealize = usb_xbox_gamepad_unrealize;
+    uc->handle_reset = usb_xid_handle_reset;
+    uc->handle_control = usb_xid_lightgun_handle_control;
+    uc->handle_data = usb_xid_lightgun_handle_data;
+    uc->handle_attach = usb_desc_attach;
+    set_bit(DEVICE_CATEGORY_INPUT, dc->categories);
+    dc->vmsd = &vmstate_usb_xbox_lightgun;
+    device_class_set_props(dc, xid_lightgun_properties);
+    dc->desc = "EMS TopGun II Lightgun";
+}
+
+static const TypeInfo usb_xbox_lightgun_info = {
+    .name = TYPE_USB_XID_LIGHTGUN,
+    .parent = TYPE_USB_DEVICE,
+    .instance_size = sizeof(USBXIDLightgunState),
+    .class_init = usb_xbox_lightgun_class_init,
+};
+
+static void usb_xid_lightgun_register_types(void)
+{
+    type_register_static(&usb_xbox_lightgun_info);
+}
+
+type_init(usb_xid_lightgun_register_types)

--- a/hw/xbox/xid.h
+++ b/hw/xbox/xid.h
@@ -51,9 +51,15 @@
 
 #define XID_DEVICESUBTYPE_GAMEPAD 0x01
 #define XID_DEVICESUBTYPE_GAMEPAD_S 0x02
+#define XID_DEVICESUBTYPE_LIGHTGUN 0x50
+
+// Set in wButtons of the input report while the lightgun points at the
+// screen (XINPUT_LIGHTGUN_ONSCREEN in the XDK)
+#define XID_LIGHTGUN_ONSCREEN 0x2000
 
 #define TYPE_USB_XID_GAMEPAD "usb-xbox-gamepad"
 #define TYPE_USB_XID_GAMEPAD_S "usb-xbox-gamepad-s"
+#define TYPE_USB_XID_LIGHTGUN "usb-xbox-lightgun"
 
 #define GAMEPAD_A 0
 #define GAMEPAD_B 1

--- a/ui/meson.build
+++ b/ui/meson.build
@@ -22,6 +22,8 @@ subdir('thirdparty')
 xemu_ss = ss.source_set()
 xemu_ss.add(files(
   'xemu-input.c',
+  'xemu-rawinput.c',
+  'xemu-evdev.c',
   'xemu-monitor.c',
   'xemu-net.c',
   'xemu-settings.cc',

--- a/ui/xemu-evdev.c
+++ b/ui/xemu-evdev.c
@@ -1,0 +1,468 @@
+/*
+ * xemu evdev mouse/lightgun support (Linux)
+ *
+ * Enumerates pointer devices individually through the Linux evdev interface
+ * so that multiple pointing devices (e.g. Sinden Lightguns, which appear as
+ * absolute mice) can be told apart and bound to different controller ports.
+ *
+ * This is the Linux counterpart of the Windows Raw Input backend
+ * (xemu-rawinput.c): it implements the same xemu_rawinput_* entry points
+ * and reuses the INPUT_DEVICE_RAWINPUT_MOUSE controller type, so the rest
+ * of the input stack, the settings UI and the emulated lightgun device all
+ * work unchanged.
+ *
+ * Frontends such as Batocera/EmulationStation decide which gun belongs to
+ * which player: their launcher writes the device path into xemu.toml, e.g.
+ *
+ *   [input.bindings]
+ *   port1 = 'evdev:/dev/input/event5'
+ *   port1_driver = 'lightgun'
+ *
+ * (see the "evdev:" alias matching in
+ * xemu_input_get_controller_default_bind_port). Manual desktop use keeps
+ * working too: devices get a stable "mouse:xxxxxxxx" pseudo-GUID hashed
+ * from their physical topology path, exactly like on Windows.
+ *
+ * Note: reading /dev/input/event* requires root or membership in the
+ * "input" group. Batocera runs emulators as root, so this only matters on
+ * regular desktop distributions.
+ *
+ * Copyright (C) 2026 xemu contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "qemu/osdep.h"
+
+#include "xemu-rawinput.h"
+#include "xemu-input.h"
+#include "xemu-notifications.h"
+#include "xemu-settings.h"
+
+#ifdef __linux__
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <math.h>
+#include <sys/inotify.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <linux/input.h>
+#include <SDL3/SDL.h>
+
+// #define DEBUG_EVDEV
+#ifdef DEBUG_EVDEV
+#define DPRINTF(fmt, ...) fprintf(stderr, fmt, ##__VA_ARGS__)
+#else
+#define DPRINTF(fmt, ...) do {} while (0)
+#endif
+
+static SDL_Window *g_window;
+static int g_inotify_fd = -1;
+static bool g_initialized;
+
+// Shared aim/mapping logic (also used by the Windows Raw Input backend)
+#include "xemu-pointer-aim.c.inc"
+
+#define EV_BITS_PER_LONG (sizeof(unsigned long) * 8)
+#define EV_NLONGS(x) (((x) + EV_BITS_PER_LONG - 1) / EV_BITS_PER_LONG)
+
+static bool ev_test_bit(unsigned int bit, const unsigned long *bits)
+{
+    return (bits[bit / EV_BITS_PER_LONG] >>
+            (bit % EV_BITS_PER_LONG)) & 1;
+}
+
+// Per-device data, hung off ControllerState.rawinput_handle
+typedef struct EvdevMouse {
+    int fd;
+    bool has_abs; // absolute pointer (lightgun/touch); else relative mouse
+    struct input_absinfo abs_x, abs_y;
+    int32_t raw_x, raw_y; // last absolute position, device units
+    float rel_x, rel_y;   // accumulated position for relative mice, px
+    // Full key/button state of the device. Guns expose their extra
+    // buttons as keyboard keys (Sinden D-pad = arrow keys) or low BTN_*
+    // codes that X11 never delivers to SDL, so the mapping reads them
+    // straight from here ("k<code>" specs and D-pad defaults).
+    unsigned long key_state[EV_NLONGS(KEY_MAX + 1)];
+} EvdevMouse;
+
+static bool pointer_backend_key_pressed(ControllerState *con, int key_code)
+{
+    EvdevMouse *em = con->rawinput_handle;
+    if (em == NULL || key_code <= 0 || key_code > KEY_MAX) {
+        return false;
+    }
+    return ev_test_bit(key_code, em->key_state);
+}
+
+static ControllerState *evdev_find_controller(const char *devnode)
+{
+    ControllerState *iter;
+    QTAILQ_FOREACH(iter, &available_controllers, entry) {
+        if (iter->type == INPUT_DEVICE_RAWINPUT_MOUSE &&
+            iter->rawinput_path != NULL &&
+            strcmp(iter->rawinput_path, devnode) == 0) {
+            return iter;
+        }
+    }
+    return NULL;
+}
+
+static void evdev_add_device(const char *devnode)
+{
+    if (evdev_find_controller(devnode)) {
+        return;
+    }
+
+    int fd = open(devnode, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+    if (fd < 0) {
+        // EACCES right after hotplug is normal: udev has not fixed the
+        // permissions yet. The IN_ATTRIB watch retries when it does.
+        DPRINTF("evdev: open %s failed: %s\n", devnode, strerror(errno));
+        return;
+    }
+
+    // Keep only pointer devices: a left button plus absolute or relative
+    // X/Y axes. This skips keyboards, gamepads (BTN_SOUTH etc.) and the
+    // various sensor/control nodes.
+    unsigned long ev_bits[EV_NLONGS(EV_MAX + 1)] = { 0 };
+    unsigned long key_bits[EV_NLONGS(KEY_MAX + 1)] = { 0 };
+    unsigned long abs_bits[EV_NLONGS(ABS_MAX + 1)] = { 0 };
+    unsigned long rel_bits[EV_NLONGS(REL_MAX + 1)] = { 0 };
+
+    if (ioctl(fd, EVIOCGBIT(0, sizeof(ev_bits)), ev_bits) < 0 ||
+        !ev_test_bit(EV_KEY, ev_bits) ||
+        ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(key_bits)), key_bits) < 0 ||
+        !ev_test_bit(BTN_LEFT, key_bits)) {
+        close(fd);
+        return;
+    }
+
+    bool has_abs = false;
+    struct input_absinfo ax = { 0 }, ay = { 0 };
+    if (ev_test_bit(EV_ABS, ev_bits) &&
+        ioctl(fd, EVIOCGBIT(EV_ABS, sizeof(abs_bits)), abs_bits) >= 0 &&
+        ev_test_bit(ABS_X, abs_bits) && ev_test_bit(ABS_Y, abs_bits) &&
+        ioctl(fd, EVIOCGABS(ABS_X), &ax) >= 0 &&
+        ioctl(fd, EVIOCGABS(ABS_Y), &ay) >= 0 &&
+        ax.maximum > ax.minimum && ay.maximum > ay.minimum) {
+        has_abs = true; // Sinden & friends: absolute coordinates
+    } else {
+        if (!ev_test_bit(EV_REL, ev_bits) ||
+            ioctl(fd, EVIOCGBIT(EV_REL, sizeof(rel_bits)), rel_bits) < 0 ||
+            !ev_test_bit(REL_X, rel_bits) || !ev_test_bit(REL_Y, rel_bits)) {
+            close(fd);
+            return;
+        }
+    }
+
+    char product[128] = "";
+    if (ioctl(fd, EVIOCGNAME(sizeof(product)), product) < 0 ||
+        product[0] == '\0') {
+        snprintf(product, sizeof(product), "evdev Mouse");
+    }
+
+    // Stable identity for the settings pseudo-GUID. The physical topology
+    // path (usb-.../inputN) tells two identical guns apart as long as each
+    // stays on its USB port, mirroring the Windows device-path hash.
+    char phys[128] = "";
+    char uniq[128] = "";
+    ioctl(fd, EVIOCGPHYS(sizeof(phys)), phys);
+    ioctl(fd, EVIOCGUNIQ(sizeof(uniq)), uniq);
+    const char *stable = phys[0] ? phys : (uniq[0] ? uniq : product);
+
+    // Disambiguate devices with identical product strings
+    int same_name = 0;
+    ControllerState *iter;
+    QTAILQ_FOREACH(iter, &available_controllers, entry) {
+        if (iter->type == INPUT_DEVICE_RAWINPUT_MOUSE &&
+            strncmp(iter->name, product, strlen(product)) == 0) {
+            same_name++;
+        }
+    }
+    char *name;
+    if (same_name > 0) {
+        name = g_strdup_printf("%s #%d", product, same_name + 1);
+    } else {
+        name = g_strdup(product);
+    }
+
+    EvdevMouse *em = g_new0(EvdevMouse, 1);
+    em->fd = fd;
+    em->has_abs = has_abs;
+    em->abs_x = ax;
+    em->abs_y = ay;
+    em->raw_x = ax.value; // current position, so the aim is valid at once
+    em->raw_y = ay.value;
+    if (!has_abs && g_window != NULL) {
+        // Start relative mice at the window center instead of the corner
+        int win_w = 0, win_h = 0;
+        if (SDL_GetWindowSizeInPixels(g_window, &win_w, &win_h)) {
+            em->rel_x = win_w / 2.0f;
+            em->rel_y = win_h / 2.0f;
+        }
+    }
+
+    ControllerState *new_con = g_new0(ControllerState, 1);
+    new_con->type = INPUT_DEVICE_RAWINPUT_MOUSE;
+    new_con->name = name;
+    new_con->rawinput_handle = em;
+    new_con->rawinput_path = g_strdup(devnode);
+    new_con->rawinput_has_abs = has_abs;
+    snprintf(new_con->rawinput_guid, sizeof(new_con->rawinput_guid),
+             "mouse:%08x", fnv1a_hash(stable));
+    new_con->bound = -1;
+    new_con->peripheral_types[0] = PERIPHERAL_NONE;
+    new_con->peripheral_types[1] = PERIPHERAL_NONE;
+
+    QTAILQ_INSERT_TAIL(&available_controllers, new_con, entry);
+    DPRINTF("evdev: added '%s' (%s) as %s\n", new_con->name, devnode,
+            new_con->rawinput_guid);
+
+    // Re-bind to a previously saved port (or to the port a frontend such
+    // as Batocera assigned via "evdev:<path>"). Unlike gamepads, never
+    // auto-bind a mouse to a free port: every system has at least one
+    // regular mouse and grabbing a controller port with it would be
+    // surprising.
+    int port = 0;
+    while (1) {
+        port = xemu_input_get_controller_default_bind_port(new_con, port);
+        if (port < 0) {
+            break;
+        }
+        if (!xemu_input_get_bound(port)) {
+            xemu_input_bind(port, new_con, 0);
+            char buf[128];
+            snprintf(buf, sizeof(buf), "Connected '%s' to port %d",
+                     new_con->name, port + 1);
+            xemu_queue_notification(buf);
+            break;
+        }
+        port++;
+    }
+}
+
+static void evdev_remove_device(const char *devnode)
+{
+    ControllerState *con = evdev_find_controller(devnode);
+    if (con == NULL) {
+        return;
+    }
+
+    DPRINTF("evdev: removed '%s'\n", con->name);
+
+    if (con->bound >= 0) {
+        char buf[128];
+        snprintf(buf, sizeof(buf), "Port %d disconnected", con->bound + 1);
+        xemu_queue_notification(buf);
+
+        // Unbind, but don't save the unbinding so the device is bound to
+        // the same port again when reconnected
+        xemu_input_bind(con->bound, NULL, 0);
+    }
+
+    QTAILQ_REMOVE(&available_controllers, con, entry);
+    EvdevMouse *em = con->rawinput_handle;
+    if (em != NULL) {
+        if (em->fd >= 0) {
+            close(em->fd);
+        }
+        g_free(em);
+    }
+    g_free(con->rawinput_path);
+    g_free((char *)con->name);
+    g_free(con);
+}
+
+static void evdev_drain_device(ControllerState *con)
+{
+    EvdevMouse *em = con->rawinput_handle;
+    struct input_event ev[32];
+
+    for (;;) {
+        ssize_t n = read(em->fd, ev, sizeof(ev));
+        if (n < (ssize_t)sizeof(ev[0])) {
+            // EAGAIN = queue drained; ENODEV = device unplugged, the
+            // inotify IN_DELETE event takes care of removing it
+            break;
+        }
+        for (size_t i = 0; i < n / sizeof(ev[0]); i++) {
+            const struct input_event *e = &ev[i];
+            switch (e->type) {
+            case EV_KEY: {
+                if (e->code <= KEY_MAX) {
+                    unsigned long *w =
+                        &em->key_state[e->code / EV_BITS_PER_LONG];
+                    unsigned long m = 1UL << (e->code % EV_BITS_PER_LONG);
+                    if (e->value) {
+                        *w |= m;
+                    } else {
+                        *w &= ~m;
+                    }
+                }
+                uint32_t bit = 0;
+                switch (e->code) {
+                case BTN_LEFT:   bit = XEMU_RAWINPUT_BUTTON_LEFT;   break;
+                case BTN_RIGHT:  bit = XEMU_RAWINPUT_BUTTON_RIGHT;  break;
+                case BTN_MIDDLE: bit = XEMU_RAWINPUT_BUTTON_MIDDLE; break;
+                case BTN_SIDE:   bit = XEMU_RAWINPUT_BUTTON_X1;     break;
+                case BTN_EXTRA:  bit = XEMU_RAWINPUT_BUTTON_X2;     break;
+                }
+                if (bit != 0) {
+                    if (e->value) {
+                        con->rawinput_buttons |= bit;
+                    } else {
+                        con->rawinput_buttons &= ~bit;
+                    }
+                }
+                break;
+            }
+            case EV_ABS:
+                if (e->code == ABS_X) {
+                    em->raw_x = e->value;
+                } else if (e->code == ABS_Y) {
+                    em->raw_y = e->value;
+                }
+                break;
+            case EV_REL:
+                if (e->code == REL_X) {
+                    em->rel_x += e->value;
+                } else if (e->code == REL_Y) {
+                    em->rel_y += e->value;
+                }
+                break;
+            }
+        }
+    }
+}
+
+void xemu_rawinput_process_pending(void)
+{
+    if (!g_initialized) {
+        return;
+    }
+
+    // Hotplug: watch /dev/input for created/removed event nodes. IN_ATTRIB
+    // retries devices whose permissions udev had not set yet at IN_CREATE.
+    if (g_inotify_fd >= 0) {
+        char buf[4096]
+            __attribute__((aligned(__alignof__(struct inotify_event))));
+        for (;;) {
+            ssize_t len = read(g_inotify_fd, buf, sizeof(buf));
+            if (len <= 0) {
+                break;
+            }
+            for (char *p = buf; p < buf + len;) {
+                const struct inotify_event *ie =
+                    (const struct inotify_event *)p;
+                if (ie->len > 0 &&
+                    strncmp(ie->name, "event", 5) == 0) {
+                    char devnode[NAME_MAX + 16];
+                    snprintf(devnode, sizeof(devnode), "/dev/input/%s",
+                             ie->name);
+                    if (ie->mask & IN_DELETE) {
+                        evdev_remove_device(devnode);
+                    } else if (ie->mask & (IN_CREATE | IN_ATTRIB)) {
+                        evdev_add_device(devnode);
+                    }
+                }
+                p += sizeof(struct inotify_event) + ie->len;
+            }
+        }
+    }
+
+    // Drain queued input events of every tracked mouse
+    ControllerState *iter;
+    QTAILQ_FOREACH(iter, &available_controllers, entry) {
+        if (iter->type == INPUT_DEVICE_RAWINPUT_MOUSE) {
+            evdev_drain_device(iter);
+        }
+    }
+}
+
+void xemu_rawinput_init(SDL_Window *window)
+{
+    assert(!g_initialized);
+
+    g_window = window;
+
+    DIR *dir = opendir("/dev/input");
+    if (dir == NULL) {
+        fprintf(stderr, "evdev: cannot open /dev/input: %s\n",
+                strerror(errno));
+        return;
+    }
+    struct dirent *de;
+    while ((de = readdir(dir)) != NULL) {
+        if (strncmp(de->d_name, "event", 5) == 0) {
+            char devnode[NAME_MAX + 16];
+            snprintf(devnode, sizeof(devnode), "/dev/input/%s", de->d_name);
+            evdev_add_device(devnode);
+        }
+    }
+    closedir(dir);
+
+    g_inotify_fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+    if (g_inotify_fd >= 0) {
+        inotify_add_watch(g_inotify_fd, "/dev/input",
+                          IN_CREATE | IN_DELETE | IN_ATTRIB);
+    }
+
+    g_initialized = true;
+}
+
+void xemu_rawinput_update_controller_state(ControllerState *state)
+{
+    state->buttons = 0;
+    memset(state->axis, 0, sizeof(state->axis));
+
+    pointer_apply_mapping(state);
+
+    EvdevMouse *em = state->rawinput_handle;
+    if (em == NULL || g_window == NULL) {
+        return;
+    }
+
+    int win_w = 0, win_h = 0;
+    if (!SDL_GetWindowSizeInPixels(g_window, &win_w, &win_h) ||
+        win_w <= 0 || win_h <= 0) {
+        return;
+    }
+
+    // Aim position in window pixels. Absolute devices (lightguns) span
+    // their full range over the window; in fullscreen (the Batocera case)
+    // window == screen, matching the gun's screen calibration. Relative
+    // mice steer a private accumulated position.
+    int px, py;
+    if (em->has_abs) {
+        px = (int)((int64_t)(em->raw_x - em->abs_x.minimum) * win_w /
+                   (em->abs_x.maximum - em->abs_x.minimum));
+        py = (int)((int64_t)(em->raw_y - em->abs_y.minimum) * win_h /
+                   (em->abs_y.maximum - em->abs_y.minimum));
+    } else {
+        em->rel_x = MIN(MAX(em->rel_x, 0.0f), (float)(win_w - 1));
+        em->rel_y = MIN(MAX(em->rel_y, 0.0f), (float)(win_h - 1));
+        px = (int)em->rel_x;
+        py = (int)em->rel_y;
+    }
+    state->rawinput_client_x = px;
+    state->rawinput_client_y = py;
+
+    pointer_apply_aim(state, px, py, win_w, win_h);
+}
+
+#endif // __linux__

--- a/ui/xemu-input.c
+++ b/ui/xemu-input.c
@@ -30,11 +30,14 @@
 
 #include "xemu-input.h"
 #include "xemu-notifications.h"
+#include "xemu-rawinput.h"
 #include "xemu-settings.h"
 #include <stdio.h>
 #include <stdlib.h>
 
 #include "system/blockdev.h"
+
+SDL_Window *xemu_get_window(void); // ui/xemu.c
 
 // #define DEBUG_INPUT
 
@@ -88,6 +91,26 @@ static void xemu_input_print_controller_state(ControllerState *state)
 ControllerStateList available_controllers =
     QTAILQ_HEAD_INITIALIZER(available_controllers);
 ControllerState *bound_controllers[4] = { NULL, NULL, NULL, NULL };
+
+// Game display rectangle in window pixels, updated each frame by the
+// renderer. Used to map lightgun/mouse positions to aim coordinates.
+static int game_display_rect[4]; // x, y, w, h
+
+void xemu_input_set_game_display_rect(int x, int y, int w, int h)
+{
+    game_display_rect[0] = x;
+    game_display_rect[1] = y;
+    game_display_rect[2] = w;
+    game_display_rect[3] = h;
+}
+
+void xemu_input_get_game_display_rect(int *x, int *y, int *w, int *h)
+{
+    *x = game_display_rect[0];
+    *y = game_display_rect[1];
+    *w = game_display_rect[2];
+    *h = game_display_rect[3];
+}
 const char *bound_drivers[4] = { DRIVER_DUKE, DRIVER_DUKE, DRIVER_DUKE,
                                  DRIVER_DUKE };
 int test_mode;
@@ -254,6 +277,8 @@ static const char *get_bound_driver(int port)
         return DRIVER_DUKE;
     if (strcmp(driver, DRIVER_S) == 0)
         return DRIVER_S;
+    if (strcmp(driver, DRIVER_LIGHTGUN) == 0)
+        return DRIVER_LIGHTGUN;
 
     return DRIVER_DUKE;
 }
@@ -308,6 +333,9 @@ void xemu_input_init(void)
     }
 
     QTAILQ_INSERT_TAIL(&available_controllers, new_con, entry);
+
+    // Enumerate HID mice/lightguns (Raw Input on Windows, evdev on Linux)
+    xemu_rawinput_init(xemu_get_window());
 }
 
 int xemu_input_get_controller_default_bind_port(ControllerState *state, int start)
@@ -317,10 +345,22 @@ int xemu_input_get_controller_default_bind_port(ControllerState *state, int star
         SDL_GUIDToString(state->sdl_joystick_guid, guid, sizeof(guid));
     } else if (state->type == INPUT_DEVICE_SDL_KEYBOARD) {
         snprintf(guid, sizeof(guid), "keyboard");
+    } else if (state->type == INPUT_DEVICE_RAWINPUT_MOUSE) {
+        snprintf(guid, sizeof(guid), "%s", state->rawinput_guid);
     }
 
     for (int i = start; i < 4; i++) {
-        if (strcmp(guid, *port_index_to_settings_key_map[i]) == 0) {
+        const char *saved = *port_index_to_settings_key_map[i];
+        if (strcmp(guid, saved) == 0) {
+            return i;
+        }
+        // Frontends (e.g. Batocera's configgen) can address a mouse or
+        // lightgun by its device node instead of the hashed pseudo-GUID:
+        // port1 = "evdev:/dev/input/event5"
+        if (state->type == INPUT_DEVICE_RAWINPUT_MOUSE &&
+            state->rawinput_path != NULL &&
+            strncmp(saved, "evdev:", 6) == 0 &&
+            strcmp(saved + 6, state->rawinput_path) == 0) {
             return i;
         }
     }
@@ -491,6 +531,8 @@ void xemu_input_update_controller(ControllerState *state)
         xemu_input_update_sdl_kbd_controller_state(state);
     } else if (state->type == INPUT_DEVICE_SDL_GAMEPAD) {
         xemu_input_update_sdl_controller_state(state);
+    } else if (state->type == INPUT_DEVICE_RAWINPUT_MOUSE) {
+        xemu_rawinput_update_controller_state(state);
     }
 
     state->last_input_updated_ts = qemu_clock_get_us(QEMU_CLOCK_REALTIME);
@@ -498,6 +540,8 @@ void xemu_input_update_controller(ControllerState *state)
 
 void xemu_input_update_controllers(void)
 {
+    xemu_rawinput_process_pending();
+
     ControllerState *iter;
     QTAILQ_FOREACH(iter, &available_controllers, entry) {
         xemu_input_update_controller(iter);
@@ -692,6 +736,9 @@ void xemu_input_bind(int index, ControllerState *state, int save)
                 SDL_GUIDToString(state->sdl_joystick_guid, guid_buf, sizeof(guid_buf));
             } else if (state->type == INPUT_DEVICE_SDL_KEYBOARD) {
                 snprintf(guid_buf, sizeof(guid_buf), "keyboard");
+            } else if (state->type == INPUT_DEVICE_RAWINPUT_MOUSE) {
+                snprintf(guid_buf, sizeof(guid_buf), "%s",
+                         state->rawinput_guid);
             }
         }
         xemu_settings_set_string(port_index_to_settings_key_map[index], guid_buf);

--- a/ui/xemu-input.h
+++ b/ui/xemu-input.h
@@ -34,9 +34,11 @@
 
 #define DRIVER_DUKE "usb-xbox-gamepad"
 #define DRIVER_S "usb-xbox-gamepad-s"
+#define DRIVER_LIGHTGUN "usb-xbox-lightgun"
 
 #define DRIVER_DUKE_DISPLAY_NAME "Xbox Controller"
 #define DRIVER_S_DISPLAY_NAME "Xbox Controller S"
+#define DRIVER_LIGHTGUN_DISPLAY_NAME "Lightgun (EMS TopGun II)"
 
 enum controller_state_buttons_mask {
     CONTROLLER_BUTTON_A          = (1 << 0),
@@ -54,6 +56,9 @@ enum controller_state_buttons_mask {
     CONTROLLER_BUTTON_LSTICK     = (1 << 12),
     CONTROLLER_BUTTON_RSTICK     = (1 << 13),
     CONTROLLER_BUTTON_GUIDE      = (1 << 14), // Extension
+    // Extension: lightgun pointing inside the game display area. Reported
+    // by the usb-xbox-lightgun driver as XID_LIGHTGUN_ONSCREEN (0x2000).
+    CONTROLLER_BUTTON_LIGHTGUN_ONSCREEN = (1 << 15),
 };
 
 #define CONTROLLER_STATE_BUTTON_ID_TO_MASK(x) (1<<x)
@@ -71,6 +76,7 @@ enum controller_state_axis_index {
 enum controller_input_device_type {
     INPUT_DEVICE_SDL_KEYBOARD,
     INPUT_DEVICE_SDL_GAMEPAD,
+    INPUT_DEVICE_RAWINPUT_MOUSE, // HID mouse/lightgun (Raw Input / evdev)
 };
 
 enum peripheral_type { PERIPHERAL_NONE, PERIPHERAL_XMU, PERIPHERAL_TYPE_COUNT };
@@ -103,6 +109,23 @@ typedef struct ControllerState {
     SDL_Joystick       *sdl_joystick;
     SDL_JoystickID      sdl_joystick_id;
     SDL_GUID            sdl_joystick_guid;
+
+    // if type == INPUT_DEVICE_RAWINPUT_MOUSE
+    void     *rawinput_handle;      // Backend handle: Raw Input HANDLE on
+                                    // Windows, EvdevMouse* on Linux
+    char     *rawinput_path;        // Device path (owned): interface path on
+                                    // Windows, /dev/input/eventN on Linux
+    char      rawinput_guid[16];    // Stable pseudo-GUID for settings ("mouse:xxxxxxxx")
+    uint32_t  rawinput_buttons;     // XEMU_RAWINPUT_BUTTON_* bits
+    int32_t   rawinput_client_x;    // Last aim position, window client pixels
+    int32_t   rawinput_client_y;
+    bool      rawinput_has_abs;     // Device reports absolute positions (e.g. Sinden)
+    float     rawinput_smooth_nx;   // Filtered aim, normalized [-1, 1]
+    float     rawinput_smooth_ny;
+    float     rawinput_smooth_dx;   // Filtered aim velocity (units/s)
+    float     rawinput_smooth_dy;
+    uint64_t  rawinput_smooth_ts;   // Timestamp (ns) of last filter step
+    bool      rawinput_smooth_valid;
 
     enum peripheral_type peripheral_types[2];
     void *peripherals[2];
@@ -145,6 +168,11 @@ void xemu_save_peripheral_settings(int player_index, int peripheral_index,
 void xemu_input_set_test_mode(int enabled);
 int xemu_input_get_test_mode(void);
 void xemu_input_reset_input_mapping(ControllerState *state);
+
+// Game display rectangle in window pixels, updated each frame by the
+// renderer. Used to map lightgun/mouse positions to aim coordinates.
+void xemu_input_set_game_display_rect(int x, int y, int w, int h);
+void xemu_input_get_game_display_rect(int *x, int *y, int *w, int *h);
 
 #ifdef __cplusplus
 }

--- a/ui/xemu-pointer-aim.c.inc
+++ b/ui/xemu-pointer-aim.c.inc
@@ -1,0 +1,325 @@
+/*
+ * xemu pointer/lightgun aim processing (platform independent)
+ *
+ * Shared between the per-platform mouse backends (xemu-rawinput.c on
+ * Windows, xemu-evdev.c on Linux): custom button mapping, aim-to-stick
+ * transform, adaptive 1-euro smoothing filter, sensitivity scaling and the
+ * ONSCREEN test. Included as a .c.inc from inside each backend's platform
+ * section so everything stays static to that translation unit.
+ *
+ * Copyright (C) 2026 xemu contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+static uint32_t fnv1a_hash(const char *s)
+{
+    uint32_t h = 0x811c9dc5;
+    while (*s) {
+        h ^= (uint8_t)*s++;
+        h *= 0x01000193;
+    }
+    return h;
+}
+
+// ---------------------------------------------------------------------------
+// Custom button mapping (input.lightgun_mapping.* settings). Empty specs
+// keep the default fixed mouse mapping, so this whole feature is inert
+// unless configured.
+// Spec formats: "mouse:<hash>:<left|right|middle|x1|x2>" (any detected
+// mouse, not only the aiming one) or "key:<SDL key name>".
+
+typedef enum {
+    MAP_SRC_NONE = 0,
+    MAP_SRC_MOUSE,
+    MAP_SRC_MOUSE_KEY, // raw key/button code read from the pointer device
+    MAP_SRC_KEY,
+} MapSourceKind;
+
+typedef struct MapSource {
+    MapSourceKind kind;
+    char mouse_guid[20]; // "mouse:xxxxxxxx"
+    uint32_t mouse_button; // XEMU_RAWINPUT_BUTTON_*
+    int key_code; // raw input-event code ("k<code>" specs)
+    SDL_Scancode scancode;
+} MapSource;
+
+typedef struct MapSlot {
+    const char **spec; // config string
+    const char *parsed_from; // spec value the cache was built from
+    uint32_t def_mouse_button; // default source (0 = none)
+    int def_key_code; // default raw key code on the aiming device (0 = none)
+    int def_key_code2; // alternate default raw key code (0 = none)
+    uint32_t controller_button; // 0 when the target is an axis
+    int axis; // CONTROLLER_AXIS_* target, -1 = none (analog triggers)
+    MapSource src;
+} MapSlot;
+
+// Whether the pointer device behind `con` currently reports the raw
+// key/button `key_code` as pressed. Lightguns often expose extra buttons
+// as keyboard keys or joystick buttons that never reach SDL (X11 ignores
+// joystick-class devices), so the backend reads them straight from the
+// device. Windows has no such path and always returns false.
+static bool pointer_backend_key_pressed(ControllerState *con, int key_code);
+
+static void map_parse(MapSource *out, const char *spec)
+{
+    memset(out, 0, sizeof(*out));
+
+    if (strncmp(spec, "mouse:", 6) == 0) {
+        const char *btn = strchr(spec + 6, ':');
+        if (btn == NULL || (size_t)(btn - spec) >= sizeof(out->mouse_guid)) {
+            return;
+        }
+        memcpy(out->mouse_guid, spec, btn - spec);
+        out->mouse_guid[btn - spec] = '\0';
+        btn++;
+        if (strcmp(btn, "left") == 0) {
+            out->mouse_button = XEMU_RAWINPUT_BUTTON_LEFT;
+        } else if (strcmp(btn, "right") == 0) {
+            out->mouse_button = XEMU_RAWINPUT_BUTTON_RIGHT;
+        } else if (strcmp(btn, "middle") == 0) {
+            out->mouse_button = XEMU_RAWINPUT_BUTTON_MIDDLE;
+        } else if (strcmp(btn, "x1") == 0) {
+            out->mouse_button = XEMU_RAWINPUT_BUTTON_X1;
+        } else if (strcmp(btn, "x2") == 0) {
+            out->mouse_button = XEMU_RAWINPUT_BUTTON_X2;
+        } else if (btn[0] == 'k' && btn[1] >= '0' && btn[1] <= '9') {
+            // Raw input-event code on the device, e.g. "k103" = KEY_UP.
+            // Lets lightgun extra buttons (D-pad, pump, BTN_1..) work even
+            // when the windowing system never delivers them as keyboard.
+            out->key_code = atoi(btn + 1);
+            if (out->key_code > 0) {
+                out->kind = MAP_SRC_MOUSE_KEY;
+            }
+            return;
+        } else {
+            return;
+        }
+        out->kind = MAP_SRC_MOUSE;
+    } else if (strncmp(spec, "key:", 4) == 0) {
+        out->scancode = SDL_GetScancodeFromName(spec + 4);
+        if (out->scancode != SDL_SCANCODE_UNKNOWN) {
+            out->kind = MAP_SRC_KEY;
+        }
+    }
+}
+
+static bool map_source_pressed(const MapSource *src, ControllerState *own)
+{
+    switch (src->kind) {
+    case MAP_SRC_MOUSE: {
+        if (strcmp(own->rawinput_guid, src->mouse_guid) == 0) {
+            return (own->rawinput_buttons & src->mouse_button) != 0;
+        }
+        ControllerState *iter;
+        QTAILQ_FOREACH(iter, &available_controllers, entry) {
+            if (iter->type == INPUT_DEVICE_RAWINPUT_MOUSE &&
+                strcmp(iter->rawinput_guid, src->mouse_guid) == 0) {
+                return (iter->rawinput_buttons & src->mouse_button) != 0;
+            }
+        }
+        return false;
+    }
+    case MAP_SRC_MOUSE_KEY: {
+        if (strcmp(own->rawinput_guid, src->mouse_guid) == 0) {
+            return pointer_backend_key_pressed(own, src->key_code);
+        }
+        ControllerState *iter;
+        QTAILQ_FOREACH(iter, &available_controllers, entry) {
+            if (iter->type == INPUT_DEVICE_RAWINPUT_MOUSE &&
+                strcmp(iter->rawinput_guid, src->mouse_guid) == 0) {
+                return pointer_backend_key_pressed(iter, src->key_code);
+            }
+        }
+        return false;
+    }
+    case MAP_SRC_KEY: {
+        const bool *kb = SDL_GetKeyboardState(NULL);
+        return kb != NULL && kb[src->scancode];
+    }
+    default:
+        return false;
+    }
+}
+
+// Translate the device's raw button state (plus any custom [mapping]
+// bindings) into ControllerState.buttons/axis. Assumes both were zeroed by
+// the caller.
+static void pointer_apply_mapping(ControllerState *state)
+{
+    // Button mapping: each function uses its custom [mapping] binding when
+    // configured, otherwise the default mouse button, or the default raw
+    // key on the aiming device (the D-pad of guns such as the Sinden shows
+    // up as arrow keys on the gun's own event device).
+    static MapSlot map_slots[] = {
+        { &g_config.input.lightgun_mapping.trigger, NULL,
+          XEMU_RAWINPUT_BUTTON_LEFT, 0, 0, CONTROLLER_BUTTON_A, -1 },
+        { &g_config.input.lightgun_mapping.b, NULL,
+          XEMU_RAWINPUT_BUTTON_RIGHT, 0, 0, CONTROLLER_BUTTON_B, -1 },
+        { &g_config.input.lightgun_mapping.start, NULL,
+          XEMU_RAWINPUT_BUTTON_MIDDLE, 0, 0, CONTROLLER_BUTTON_START, -1 },
+        { &g_config.input.lightgun_mapping.back, NULL,
+          XEMU_RAWINPUT_BUTTON_X1, 0, 0, CONTROLLER_BUTTON_BACK, -1 },
+        { &g_config.input.lightgun_mapping.x, NULL,
+          XEMU_RAWINPUT_BUTTON_X2, 0, 0, CONTROLLER_BUTTON_X, -1 },
+        // D-pad defaults: arrow keys on the device, or the BTN_5..BTN_8
+        // codes Batocera's Sinden driver emits on its virtual gun device
+        { &g_config.input.lightgun_mapping.dpad_up, NULL, 0,
+          103 /* KEY_UP */, 261 /* BTN_5 */, CONTROLLER_BUTTON_DPAD_UP, -1 },
+        { &g_config.input.lightgun_mapping.dpad_down, NULL, 0,
+          108 /* KEY_DOWN */, 262 /* BTN_6 */,
+          CONTROLLER_BUTTON_DPAD_DOWN, -1 },
+        { &g_config.input.lightgun_mapping.dpad_left, NULL, 0,
+          105 /* KEY_LEFT */, 263 /* BTN_7 */,
+          CONTROLLER_BUTTON_DPAD_LEFT, -1 },
+        { &g_config.input.lightgun_mapping.dpad_right, NULL, 0,
+          106 /* KEY_RIGHT */, 264 /* BTN_8 */,
+          CONTROLLER_BUTTON_DPAD_RIGHT, -1 },
+        { &g_config.input.lightgun_mapping.y, NULL, 0, 0, 0,
+          CONTROLLER_BUTTON_Y, -1 },
+        { &g_config.input.lightgun_mapping.white, NULL, 0, 0, 0,
+          CONTROLLER_BUTTON_WHITE, -1 },
+        { &g_config.input.lightgun_mapping.black, NULL, 0, 0, 0,
+          CONTROLLER_BUTTON_BLACK, -1 },
+        { &g_config.input.lightgun_mapping.lstick, NULL, 0, 0, 0,
+          CONTROLLER_BUTTON_LSTICK, -1 },
+        { &g_config.input.lightgun_mapping.rstick, NULL, 0, 0, 0,
+          CONTROLLER_BUTTON_RSTICK, -1 },
+        { &g_config.input.lightgun_mapping.ltrig, NULL, 0, 0, 0, 0,
+          CONTROLLER_AXIS_LTRIG },
+        { &g_config.input.lightgun_mapping.rtrig, NULL, 0, 0, 0, 0,
+          CONTROLLER_AXIS_RTRIG },
+        { &g_config.input.lightgun_mapping.guide, NULL, 0, 0, 0,
+          CONTROLLER_BUTTON_GUIDE, -1 },
+    };
+
+    uint32_t mb = state->rawinput_buttons;
+    for (size_t i = 0; i < ARRAY_SIZE(map_slots); i++) {
+        MapSlot *slot = &map_slots[i];
+        const char *spec = *slot->spec;
+
+        if (spec == NULL || spec[0] == '\0') {
+            if ((slot->def_mouse_button && (mb & slot->def_mouse_button)) ||
+                (slot->def_key_code &&
+                 pointer_backend_key_pressed(state, slot->def_key_code)) ||
+                (slot->def_key_code2 &&
+                 pointer_backend_key_pressed(state, slot->def_key_code2))) {
+                state->buttons |= slot->controller_button;
+            }
+            continue;
+        }
+
+        if (slot->parsed_from != spec) { // config string changed, re-parse
+            map_parse(&slot->src, spec);
+            slot->parsed_from = spec;
+        }
+        if (map_source_pressed(&slot->src, state)) {
+            if (slot->axis >= 0) {
+                state->axis[slot->axis] = 32767; // full trigger pull
+            } else {
+                state->buttons |= slot->controller_button;
+            }
+        }
+    }
+}
+
+// Turn an aim position in window client pixels into the emulated lightgun
+// stick axes + ONSCREEN bit, applying smoothing and sensitivity. The game
+// display rect is used when available; otherwise the caller-provided
+// fallback dimensions (whole window client area, <= 0 = unknown).
+static void pointer_apply_aim(ControllerState *state, int px, int py,
+                              int fallback_w, int fallback_h)
+{
+    int rx, ry, rw, rh;
+    xemu_input_get_game_display_rect(&rx, &ry, &rw, &rh);
+    if (rw <= 0 || rh <= 0) {
+        // Game not rendering yet; fall back to the whole client area
+        if (fallback_w <= 0 || fallback_h <= 0) {
+            return;
+        }
+        rx = ry = 0;
+        rw = fallback_w;
+        rh = fallback_h;
+    }
+
+    float nx = 2.0f * (px - rx) / rw - 1.0f; // [-1,1], left -> right
+    float ny = 1.0f - 2.0f * (py - ry) / rh; // [-1,1], bottom -> top
+
+    // Smooth the aim to tame hand/camera jitter, using a "1-euro filter":
+    // an adaptive low-pass whose cutoff rises with speed. While nearly
+    // still it filters hard (rock-solid crosshair); on fast moves it opens
+    // up completely, so there is no perceivable lag.
+    float smoothing = g_config.input.lightgun_smoothing;
+    if (smoothing > 0.0f) {
+        smoothing = MIN(smoothing, 1.0f);
+        uint64_t now = SDL_GetTicksNS();
+        if (!state->rawinput_smooth_valid) {
+            state->rawinput_smooth_nx = nx;
+            state->rawinput_smooth_ny = ny;
+            state->rawinput_smooth_dx = 0.0f;
+            state->rawinput_smooth_dy = 0.0f;
+            state->rawinput_smooth_valid = true;
+        } else {
+            float dt = (now - state->rawinput_smooth_ts) / 1e9f;
+            dt = MIN(MAX(dt, 1e-4f), 0.1f);
+
+            // Filtered velocity (1 Hz cutoff): jitter averages out to ~0,
+            // real hand movement produces a sustained value
+            const float two_pi = 6.28318531f;
+            float ad = 1.0f / (1.0f + 1.0f / (two_pi * 1.0f * dt));
+            float raw_dx = (nx - state->rawinput_smooth_nx) / dt;
+            float raw_dy = (ny - state->rawinput_smooth_ny) / dt;
+            state->rawinput_smooth_dx +=
+                ad * (raw_dx - state->rawinput_smooth_dx);
+            state->rawinput_smooth_dy +=
+                ad * (raw_dy - state->rawinput_smooth_dy);
+
+            // Cutoff frequency: low while still (strong smoothing, more so
+            // at higher smoothing settings), raised in proportion to speed
+            // so fast moves pass through unfiltered
+            float min_cutoff = 6.0f - 5.5f * smoothing; // 6 Hz .. 0.5 Hz
+            const float beta = 5.0f;
+            float cx = min_cutoff + beta * fabsf(state->rawinput_smooth_dx);
+            float cy = min_cutoff + beta * fabsf(state->rawinput_smooth_dy);
+            float ax = 1.0f / (1.0f + 1.0f / (two_pi * cx * dt));
+            float ay = 1.0f / (1.0f + 1.0f / (two_pi * cy * dt));
+            state->rawinput_smooth_nx +=
+                ax * (nx - state->rawinput_smooth_nx);
+            state->rawinput_smooth_ny +=
+                ay * (ny - state->rawinput_smooth_ny);
+        }
+        state->rawinput_smooth_ts = now;
+        nx = state->rawinput_smooth_nx;
+        ny = state->rawinput_smooth_ny;
+    } else {
+        state->rawinput_smooth_valid = false;
+    }
+
+    // Sensitivity scales the aim range around the screen center
+    float sensitivity = g_config.input.lightgun_sensitivity;
+    if (sensitivity > 0.0f) {
+        nx *= sensitivity;
+        ny *= sensitivity;
+    }
+
+    if (nx >= -1.0f && nx <= 1.0f && ny >= -1.0f && ny <= 1.0f) {
+        state->buttons |= CONTROLLER_BUTTON_LIGHTGUN_ONSCREEN;
+    }
+
+    nx = MIN(MAX(nx, -1.0f), 1.0f);
+    ny = MIN(MAX(ny, -1.0f), 1.0f);
+    state->axis[CONTROLLER_AXIS_LSTICK_X] = (int16_t)(nx * 32767.0f);
+    state->axis[CONTROLLER_AXIS_LSTICK_Y] = (int16_t)(ny * 32767.0f);
+}

--- a/ui/xemu-rawinput.c
+++ b/ui/xemu-rawinput.c
@@ -1,0 +1,434 @@
+/*
+ * xemu Raw Input mouse support
+ *
+ * Enumerates HID mice individually via the Windows Raw Input API so that
+ * multiple pointer devices (e.g. Sinden Lightguns, which appear as absolute
+ * mice) can be told apart and bound to different controller ports.
+ *
+ * Copyright (C) 2026 xemu contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "qemu/osdep.h"
+
+#include "xemu-rawinput.h"
+#include "xemu-input.h"
+#include "xemu-notifications.h"
+#include "xemu-settings.h"
+
+#ifdef _WIN32
+
+#include <math.h>
+#include <windows.h>
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_system.h>
+
+// #define DEBUG_RAWINPUT
+#ifdef DEBUG_RAWINPUT
+#define DPRINTF(fmt, ...) fprintf(stderr, fmt, ##__VA_ARGS__)
+#else
+#define DPRINTF(fmt, ...) do {} while (0)
+#endif
+
+// HidD_GetProductString, loaded dynamically to avoid a hid.dll link dep
+typedef BOOLEAN(WINAPI *HidD_GetProductString_t)(HANDLE, PVOID, ULONG);
+static HidD_GetProductString_t p_HidD_GetProductString;
+
+static HWND g_hwnd;
+static bool g_initialized;
+
+// Shared aim/mapping logic (also used by the Linux evdev backend)
+#include "xemu-pointer-aim.c.inc"
+
+static bool pointer_backend_key_pressed(ControllerState *con, int key_code)
+{
+    // Raw Input receives no keyboard events from pointer devices; gun
+    // extra buttons arrive as regular mouse buttons on Windows.
+    (void)con;
+    (void)key_code;
+    return false;
+}
+
+static ControllerState *rawinput_find_controller(HANDLE hdev)
+{
+    ControllerState *iter;
+    QTAILQ_FOREACH(iter, &available_controllers, entry) {
+        if (iter->type == INPUT_DEVICE_RAWINPUT_MOUSE &&
+            iter->rawinput_handle == (void *)hdev) {
+            return iter;
+        }
+    }
+    return NULL;
+}
+
+static char *rawinput_get_device_path(HANDLE hdev)
+{
+    UINT size = 0;
+    if (GetRawInputDeviceInfoW(hdev, RIDI_DEVICENAME, NULL, &size) != 0 ||
+        size == 0) {
+        return NULL;
+    }
+    WCHAR *wpath = g_malloc((size + 1) * sizeof(WCHAR));
+    if (GetRawInputDeviceInfoW(hdev, RIDI_DEVICENAME, wpath, &size) ==
+        (UINT)-1) {
+        g_free(wpath);
+        return NULL;
+    }
+    wpath[size] = 0;
+    char *path = g_utf16_to_utf8((const gunichar2 *)wpath, -1, NULL, NULL,
+                                 NULL);
+    g_free(wpath);
+    return path;
+}
+
+static char *rawinput_get_product_name(const char *path)
+{
+    char *name = NULL;
+
+    if (p_HidD_GetProductString) {
+        // path is UTF-8; go through UTF-16 so non-ASCII paths work
+        wchar_t *wpath =
+            (wchar_t *)g_utf8_to_utf16(path, -1, NULL, NULL, NULL);
+        if (wpath == NULL) {
+            return g_strdup("HID Mouse");
+        }
+        HANDLE h = CreateFileW(wpath, 0, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                               NULL, OPEN_EXISTING, 0, NULL);
+        g_free(wpath);
+        if (h != INVALID_HANDLE_VALUE) {
+            WCHAR product[128] = { 0 };
+            if (p_HidD_GetProductString(h, product, sizeof(product) - 2)) {
+                if (product[0]) {
+                    name = g_utf16_to_utf8((const gunichar2 *)product, -1,
+                                           NULL, NULL, NULL);
+                }
+            }
+            CloseHandle(h);
+        }
+    }
+
+    if (name == NULL || name[0] == '\0') {
+        g_free(name);
+        name = g_strdup("HID Mouse");
+    }
+    return name;
+}
+
+static void rawinput_add_device(HANDLE hdev)
+{
+    RID_DEVICE_INFO info = { .cbSize = sizeof(info) };
+    UINT info_size = sizeof(info);
+
+    if (rawinput_find_controller(hdev)) {
+        return;
+    }
+    if (GetRawInputDeviceInfoW(hdev, RIDI_DEVICEINFO, &info, &info_size) ==
+            (UINT)-1 ||
+        info.dwType != RIM_TYPEMOUSE) {
+        return;
+    }
+
+    char *path = rawinput_get_device_path(hdev);
+    if (path == NULL) {
+        return;
+    }
+
+    // Skip the terminal services virtual mouse
+    if (strstr(path, "RDP_MOU") != NULL) {
+        g_free(path);
+        return;
+    }
+
+    char *product = rawinput_get_product_name(path);
+
+    // Disambiguate devices with identical product strings
+    int same_name = 0;
+    ControllerState *iter;
+    QTAILQ_FOREACH(iter, &available_controllers, entry) {
+        if (iter->type == INPUT_DEVICE_RAWINPUT_MOUSE &&
+            strncmp(iter->name, product, strlen(product)) == 0) {
+            same_name++;
+        }
+    }
+    char *name;
+    if (same_name > 0) {
+        name = g_strdup_printf("%s #%d", product, same_name + 1);
+        g_free(product);
+    } else {
+        name = product;
+    }
+
+    ControllerState *new_con = g_new0(ControllerState, 1);
+    new_con->type = INPUT_DEVICE_RAWINPUT_MOUSE;
+    new_con->name = name;
+    new_con->rawinput_handle = (void *)hdev;
+    new_con->rawinput_path = path;
+    snprintf(new_con->rawinput_guid, sizeof(new_con->rawinput_guid),
+             "mouse:%08x", fnv1a_hash(path));
+    new_con->bound = -1;
+    new_con->peripheral_types[0] = PERIPHERAL_NONE;
+    new_con->peripheral_types[1] = PERIPHERAL_NONE;
+
+    QTAILQ_INSERT_TAIL(&available_controllers, new_con, entry);
+    DPRINTF("rawinput: added '%s' (%s) as %s\n", new_con->name, path,
+            new_con->rawinput_guid);
+
+    // Re-bind to a previously saved port. Unlike gamepads, never auto-bind
+    // a mouse to a free port: every system has at least one regular mouse
+    // and grabbing a controller port with it would be surprising.
+    int port = 0;
+    while (1) {
+        port = xemu_input_get_controller_default_bind_port(new_con, port);
+        if (port < 0) {
+            break;
+        }
+        if (!xemu_input_get_bound(port)) {
+            xemu_input_bind(port, new_con, 0);
+            char buf[128];
+            snprintf(buf, sizeof(buf), "Connected '%s' to port %d",
+                     new_con->name, port + 1);
+            xemu_queue_notification(buf);
+            break;
+        }
+        port++;
+    }
+}
+
+static void rawinput_remove_device(HANDLE hdev)
+{
+    ControllerState *con = rawinput_find_controller(hdev);
+    if (con == NULL) {
+        return;
+    }
+
+    DPRINTF("rawinput: removed '%s'\n", con->name);
+
+    if (con->bound >= 0) {
+        char buf[128];
+        snprintf(buf, sizeof(buf), "Port %d disconnected", con->bound + 1);
+        xemu_queue_notification(buf);
+
+        // Unbind, but don't save the unbinding so the device is bound to
+        // the same port again when reconnected
+        xemu_input_bind(con->bound, NULL, 0);
+    }
+
+    QTAILQ_REMOVE(&available_controllers, con, entry);
+    g_free(con->rawinput_path);
+    g_free((char *)con->name);
+    g_free(con);
+}
+
+static void rawinput_handle_mouse_input(HANDLE hdev, const RAWMOUSE *mouse)
+{
+    ControllerState *con = rawinput_find_controller(hdev);
+    if (con == NULL) {
+        return;
+    }
+
+    if (mouse->usFlags & MOUSE_MOVE_ABSOLUTE) {
+        // Absolute coordinates, normalized to [0, 65535] over the screen
+        // (or the whole virtual desktop if MOUSE_VIRTUAL_DESKTOP is set).
+        // This is what Sinden Lightguns report.
+        bool virt = mouse->usFlags & MOUSE_VIRTUAL_DESKTOP;
+        int ox = virt ? GetSystemMetrics(SM_XVIRTUALSCREEN) : 0;
+        int oy = virt ? GetSystemMetrics(SM_YVIRTUALSCREEN) : 0;
+        int w = GetSystemMetrics(virt ? SM_CXVIRTUALSCREEN : SM_CXSCREEN);
+        int h = GetSystemMetrics(virt ? SM_CYVIRTUALSCREEN : SM_CYSCREEN);
+
+        POINT pt = { ox + MulDiv(mouse->lLastX, w, 65535),
+                     oy + MulDiv(mouse->lLastY, h, 65535) };
+        ScreenToClient(g_hwnd, &pt);
+        con->rawinput_client_x = pt.x;
+        con->rawinput_client_y = pt.y;
+        con->rawinput_has_abs = true;
+    }
+    // Relative devices are handled in
+    // xemu_rawinput_update_controller_state() by following the system
+    // cursor, which tracks them anyway.
+
+    USHORT f = mouse->usButtonFlags;
+    if (f & RI_MOUSE_LEFT_BUTTON_DOWN)
+        con->rawinput_buttons |= XEMU_RAWINPUT_BUTTON_LEFT;
+    if (f & RI_MOUSE_LEFT_BUTTON_UP)
+        con->rawinput_buttons &= ~XEMU_RAWINPUT_BUTTON_LEFT;
+    if (f & RI_MOUSE_RIGHT_BUTTON_DOWN)
+        con->rawinput_buttons |= XEMU_RAWINPUT_BUTTON_RIGHT;
+    if (f & RI_MOUSE_RIGHT_BUTTON_UP)
+        con->rawinput_buttons &= ~XEMU_RAWINPUT_BUTTON_RIGHT;
+    if (f & RI_MOUSE_MIDDLE_BUTTON_DOWN)
+        con->rawinput_buttons |= XEMU_RAWINPUT_BUTTON_MIDDLE;
+    if (f & RI_MOUSE_MIDDLE_BUTTON_UP)
+        con->rawinput_buttons &= ~XEMU_RAWINPUT_BUTTON_MIDDLE;
+    if (f & RI_MOUSE_BUTTON_4_DOWN)
+        con->rawinput_buttons |= XEMU_RAWINPUT_BUTTON_X1;
+    if (f & RI_MOUSE_BUTTON_4_UP)
+        con->rawinput_buttons &= ~XEMU_RAWINPUT_BUTTON_X1;
+    if (f & RI_MOUSE_BUTTON_5_DOWN)
+        con->rawinput_buttons |= XEMU_RAWINPUT_BUTTON_X2;
+    if (f & RI_MOUSE_BUTTON_5_UP)
+        con->rawinput_buttons &= ~XEMU_RAWINPUT_BUTTON_X2;
+}
+
+// Hotplug events arrive while SDL pumps the message loop, outside the QEMU
+// main loop lock. Binding/unbinding devices there is unsafe, so queue them
+// and let xemu_rawinput_process_pending() handle them under the lock.
+#define MAX_PENDING_DEVICE_CHANGES 16
+static struct {
+    HANDLE hdev;
+    bool arrival;
+} g_pending_changes[MAX_PENDING_DEVICE_CHANGES];
+static int g_num_pending_changes;
+
+static bool rawinput_message_hook(void *userdata, MSG *msg)
+{
+    if (msg->message == WM_INPUT) {
+        RAWINPUT raw;
+        UINT size = sizeof(raw);
+        if (GetRawInputData((HRAWINPUT)msg->lParam, RID_INPUT, &raw, &size,
+                            sizeof(RAWINPUTHEADER)) != (UINT)-1 &&
+            raw.header.dwType == RIM_TYPEMOUSE) {
+            rawinput_handle_mouse_input(raw.header.hDevice, &raw.data.mouse);
+        }
+    } else if (msg->message == WM_INPUT_DEVICE_CHANGE) {
+        if ((msg->wParam == GIDC_ARRIVAL || msg->wParam == GIDC_REMOVAL) &&
+            g_num_pending_changes < MAX_PENDING_DEVICE_CHANGES) {
+            g_pending_changes[g_num_pending_changes].hdev =
+                (HANDLE)msg->lParam;
+            g_pending_changes[g_num_pending_changes].arrival =
+                msg->wParam == GIDC_ARRIVAL;
+            g_num_pending_changes++;
+        }
+    }
+    return true; // let SDL continue processing the message
+}
+
+void xemu_rawinput_process_pending(void)
+{
+    for (int i = 0; i < g_num_pending_changes; i++) {
+        if (g_pending_changes[i].arrival) {
+            rawinput_add_device(g_pending_changes[i].hdev);
+        } else {
+            rawinput_remove_device(g_pending_changes[i].hdev);
+        }
+    }
+    g_num_pending_changes = 0;
+}
+
+void xemu_rawinput_init(SDL_Window *window)
+{
+    assert(!g_initialized);
+
+    g_hwnd = (HWND)SDL_GetPointerProperty(SDL_GetWindowProperties(window),
+                                          SDL_PROP_WINDOW_WIN32_HWND_POINTER,
+                                          NULL);
+    if (g_hwnd == NULL) {
+        fprintf(stderr, "rawinput: could not get window handle\n");
+        return;
+    }
+
+    HMODULE hid = LoadLibraryA("hid.dll");
+    if (hid) {
+        p_HidD_GetProductString = (HidD_GetProductString_t)GetProcAddress(
+            hid, "HidD_GetProductString");
+    }
+
+    // Enumerate mice already connected
+    UINT num_devices = 0;
+    if (GetRawInputDeviceList(NULL, &num_devices,
+                              sizeof(RAWINPUTDEVICELIST)) == 0 &&
+        num_devices > 0) {
+        RAWINPUTDEVICELIST *list =
+            g_new0(RAWINPUTDEVICELIST, num_devices);
+        UINT n = GetRawInputDeviceList(list, &num_devices,
+                                       sizeof(RAWINPUTDEVICELIST));
+        if (n != (UINT)-1) {
+            for (UINT i = 0; i < n; i++) {
+                if (list[i].dwType == RIM_TYPEMOUSE) {
+                    rawinput_add_device(list[i].hDevice);
+                }
+            }
+        }
+        g_free(list);
+    }
+
+    // Receive WM_INPUT for mice (also when unfocused) plus hotplug events
+    RAWINPUTDEVICE rid = {
+        .usUsagePage = 0x01, // HID_USAGE_PAGE_GENERIC
+        .usUsage = 0x02,     // HID_USAGE_GENERIC_MOUSE
+        .dwFlags = RIDEV_INPUTSINK | RIDEV_DEVNOTIFY,
+        .hwndTarget = g_hwnd,
+    };
+    if (!RegisterRawInputDevices(&rid, 1, sizeof(rid))) {
+        fprintf(stderr, "rawinput: RegisterRawInputDevices failed (%lu)\n",
+                GetLastError());
+        return;
+    }
+
+    SDL_SetWindowsMessageHook(rawinput_message_hook, NULL);
+    g_initialized = true;
+}
+
+void xemu_rawinput_update_controller_state(ControllerState *state)
+{
+    state->buttons = 0;
+    memset(state->axis, 0, sizeof(state->axis));
+
+    pointer_apply_mapping(state);
+
+    // Aim position in window client pixels
+    int px, py;
+    if (state->rawinput_has_abs) {
+        px = state->rawinput_client_x;
+        py = state->rawinput_client_y;
+    } else {
+        // Relative mice steer the system cursor; follow it
+        POINT pt;
+        if (!GetCursorPos(&pt) || g_hwnd == NULL) {
+            return;
+        }
+        ScreenToClient(g_hwnd, &pt);
+        px = pt.x;
+        py = pt.y;
+    }
+
+    // Whole client area, used as aim rect until the game renders
+    int fallback_w = -1, fallback_h = -1;
+    RECT cr;
+    if (g_hwnd != NULL && GetClientRect(g_hwnd, &cr)) {
+        fallback_w = cr.right;
+        fallback_h = cr.bottom;
+    }
+
+    pointer_apply_aim(state, px, py, fallback_w, fallback_h);
+}
+
+#elif !defined(__linux__) // Linux implements this API in xemu-evdev.c
+
+void xemu_rawinput_init(SDL_Window *window)
+{
+    (void)window;
+}
+
+void xemu_rawinput_process_pending(void)
+{
+}
+
+void xemu_rawinput_update_controller_state(ControllerState *state)
+{
+    (void)state;
+}
+
+#endif

--- a/ui/xemu-rawinput.h
+++ b/ui/xemu-rawinput.h
@@ -1,0 +1,62 @@
+/*
+ * xemu per-device mouse/lightgun support
+ *
+ * Enumerates HID mice individually (Raw Input API on Windows, evdev on
+ * Linux — see xemu-rawinput.c and xemu-evdev.c) so that multiple pointer
+ * devices (e.g. Sinden Lightguns, which appear as absolute mice) can be
+ * told apart and bound to different controller ports. Each detected mouse
+ * is exposed as a ControllerState of type INPUT_DEVICE_RAWINPUT_MOUSE in
+ * the available controllers list.
+ *
+ * Copyright (C) 2026 xemu contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef XEMU_RAWINPUT_H
+#define XEMU_RAWINPUT_H
+
+#include "xemu-input.h"
+
+// Button bits stored in ControllerState.rawinput_buttons
+#define XEMU_RAWINPUT_BUTTON_LEFT   (1 << 0)
+#define XEMU_RAWINPUT_BUTTON_RIGHT  (1 << 1)
+#define XEMU_RAWINPUT_BUTTON_MIDDLE (1 << 2)
+#define XEMU_RAWINPUT_BUTTON_X1     (1 << 3)
+#define XEMU_RAWINPUT_BUTTON_X2     (1 << 4)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Enumerate HID mice and start receiving per-device input. Must be called
+// after the main SDL window has been created, with the QEMU main loop lock
+// held. No-op on hosts without a backend (e.g. macOS).
+void xemu_rawinput_init(SDL_Window *window);
+
+// Process queued device arrivals/removals. Hotplug notifications come in
+// while SDL pumps the Windows message loop, outside the QEMU main loop
+// lock, so they are deferred to this function which must be called with
+// the lock held.
+void xemu_rawinput_process_pending(void);
+
+// Recompute buttons/axes of a ControllerState of type
+// INPUT_DEVICE_RAWINPUT_MOUSE from the latest Raw Input data.
+void xemu_rawinput_update_controller_state(ControllerState *state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/ui/xui/gl-helpers.cc
+++ b/ui/xui/gl-helpers.cc
@@ -799,7 +799,8 @@ void RenderController(float frame_x, float frame_y, uint32_t primary_color,
     if (strcmp(bound_drivers[state->bound], DRIVER_S) == 0)
         RenderControllerS(frame_x, frame_y, primary_color, secondary_color,
                           state);
-    else if (strcmp(bound_drivers[state->bound], DRIVER_DUKE) == 0)
+    else
+        // Duke graphic is also used as a stand-in for the lightgun driver
         RenderDukeController(frame_x, frame_y, primary_color, secondary_color,
                              state);
 }
@@ -971,6 +972,12 @@ void RenderFramebuffer(GLint tex, int width, int height, bool flip)
             scale[1] = w_ratio/t_ratio;
         }
     }
+
+    // Publish where the game image lands in the window, for lightgun aiming
+    int game_w = (int)(scale[0] * width);
+    int game_h = (int)(scale[1] * height);
+    xemu_input_set_game_display_rect((width - game_w) / 2,
+                                     (height - game_h) / 2, game_w, game_h);
 
     RenderFramebuffer(tex, width, height, flip, scale);
 }

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -200,6 +200,8 @@ void MainMenuInputView::Draw()
         driver = DRIVER_DUKE_DISPLAY_NAME;
     else if (strcmp(driver, DRIVER_S) == 0)
         driver = DRIVER_S_DISPLAY_NAME;
+    else if (strcmp(driver, DRIVER_LIGHTGUN) == 0)
+        driver = DRIVER_LIGHTGUN_DISPLAY_NAME;
 
     ImGui::Columns(2, "", false);
     ImGui::SetColumnWidth(0, ImGui::GetWindowWidth()*0.25);
@@ -211,9 +213,11 @@ void MainMenuInputView::Draw()
     ImGui::SetNextItemWidth(-FLT_MIN);
     if (ImGui::BeginCombo("###InputDrivers", driver,
                           ImGuiComboFlags_NoArrowButton)) {
-        const char *available_drivers[] = { DRIVER_DUKE, DRIVER_S };
+        const char *available_drivers[] = { DRIVER_DUKE, DRIVER_S,
+                                            DRIVER_LIGHTGUN };
         const char *driver_display_names[] = { DRIVER_DUKE_DISPLAY_NAME,
-                                               DRIVER_S_DISPLAY_NAME };
+                                               DRIVER_S_DISPLAY_NAME,
+                                               DRIVER_LIGHTGUN_DISPLAY_NAME };
         bool is_selected = false;
         int num_drivers = sizeof(driver_display_names) / sizeof(driver_display_names[0]);
         for (int i = 0; i < num_drivers; i++) {
@@ -572,6 +576,33 @@ void MainMenuInputView::Draw()
     Toggle("Background controller input capture",
            &g_config.input.background_input_capture,
            "Capture even if window is unfocused (requires restart)");
+
+    // These keep mouse/lightgun clicks from triggering UI shortcuts
+    // while playing
+    Toggle("Disable double-click fullscreen toggle",
+           &g_config.input.disable_dblclick_fullscreen,
+           "Keep double left-click (lightgun trigger) from toggling "
+           "fullscreen");
+    Toggle("Disable right-click menu",
+           &g_config.input.disable_rclick_menu,
+           "Keep right-click (lightgun secondary button) from opening the "
+           "xemu menu");
+
+    char slider_buf[64];
+    snprintf(slider_buf, sizeof(slider_buf), "Lightgun aim smoothing (%d%%)",
+             (int)(g_config.input.lightgun_smoothing * 100));
+    Slider("Lightgun aim smoothing", &g_config.input.lightgun_smoothing,
+           slider_buf);
+
+    // Sensitivity 50%..150%, mapped onto the widget's 0..1 range
+    float sens_t = g_config.input.lightgun_sensitivity - 0.5f;
+    if (sens_t < 0.0f) sens_t = 0.0f;
+    if (sens_t > 1.0f) sens_t = 1.0f;
+    snprintf(slider_buf, sizeof(slider_buf),
+             "Lightgun aim sensitivity (%d%%)",
+             (int)((sens_t + 0.5f) * 100));
+    Slider("Lightgun aim sensitivity", &sens_t, slider_buf);
+    g_config.input.lightgun_sensitivity = sens_t + 0.5f;
 }
 
 void MainMenuInputView::Hide()
@@ -583,6 +614,26 @@ void MainMenuInputView::PopulateTableController(ControllerState *state)
 {
     if (!state)
         return;
+
+    if (state->type == INPUT_DEVICE_RAWINPUT_MOUSE) {
+        // Mice/lightguns have a fixed mapping and no controller_map
+        static constexpr const char *mouse_mapping[][2] = {
+            { "Aim (Left Stick)", "Pointer Position" },
+            { "A (Trigger)", "Left Button" },
+            { "B", "Right Button" },
+            { "Start", "Middle Button" },
+            { "Back", "Button 4" },
+            { "X", "Button 5" },
+        };
+        for (auto &row : mouse_mapping) {
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::Text("%s", row[0]);
+            ImGui::TableSetColumnIndex(1);
+            ImGui::Text("%s", row[1]);
+        }
+        return;
+    }
 
     // Must match g_keyboard_scancode_map and the controller
     // button map below.

--- a/ui/xui/main.cc
+++ b/ui/xui/main.cc
@@ -290,10 +290,12 @@ void xemu_hud_update(void)
         } else if (ImGui::IsKeyPressed(ImGuiKey_F2)) {
             g_scene_mgr.PushScene(g_popup_menu);
         } else if (menu_button ||
-                   (ImGui::IsMouseClicked(ImGuiMouseButton_Right) &&
+                   (!g_config.input.disable_rclick_menu &&
+                    ImGui::IsMouseClicked(ImGuiMouseButton_Right) &&
                     !ImGui::IsAnyItemFocused() && !ImGui::IsAnyItemHovered())) {
             g_scene_mgr.PushScene(g_popup_menu);
-        } else if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
+        } else if (!g_config.input.disable_dblclick_fullscreen &&
+                   ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
             xemu_toggle_fullscreen();
         }
 


### PR DESCRIPTION
This adds lightgun support to xemu: an emulated **EMS TopGun II** (`usb-xbox-lightgun`, VID `0x0b9a` PID `0x016b`, XID subtype `0x50`) selectable as the emulated device on any controller port, aimed with real lightguns (Sinden and anything that presents itself as a pointer device) or a regular mouse.

Games genuinely detect a lightgun on the port, **including in-game calibration**: the `SET_REPORT` calibration report is accepted and its offsets are applied to the aim, matching real hardware behavior (`XInputSetLightgunCalibration`).

## Why a per-device input backend

Aiming requires telling multiple pointer devices apart: every system has at least one regular mouse, and 2-gun games need two guns on separate ports. SDL merges all mice into one virtual pointer, so this PR adds a small per-platform enumeration backend that exposes each pointer device individually as a bindable input device (listed by product name in the Input menu, DemulShooter-style):

- **Windows — Raw Input**: per-device `WM_INPUT` via the SDL message hook, absolute coordinates as reported by guns like the Sinden, hotplug via `WM_INPUT_DEVICE_CHANGE` (deferred to the main loop, since the hook runs outside the iothread lock).
- **Linux — evdev**: `/dev/input/event*` enumeration (absolute or relative pointers), hotplug via inotify. Saved port bindings also accept an `evdev:<node>` alias so frontends can assign detected guns to ports at launch time — [Batocera](https://batocera.org) integration uses this. Gun extra buttons that arrive as keyboard keys or low `BTN_*` codes on the gun's own device are read directly from it, because X11 ignores joystick-classified devices and those events never reach SDL (this is what makes e.g. the Sinden D-pad work out of the box).
- **Other hosts**: stubs — no pointer devices are listed, everything else is unaffected.

The platform-independent aim pipeline (`ui/xemu-pointer-aim.c.inc`, shared by both backends) maps the device position onto the actual game render area, reports the `ONSCREEN` wButtons flag accordingly, and offers optional adaptive smoothing (1-euro filter: steady crosshair when still, no added latency on fast moves) and sensitivity scaling, both exposed as sliders in the Input menu.

Buttons follow a fixed default mapping (trigger=A, right=B, middle=Start, X1=Back, X2=X) and every function (17 slots, including D-pad, White/Black and analog triggers for service menus) can be remapped to any detected pointer-device button or keyboard key via the `input.lightgun_mapping.*` settings.

## Compatibility

- No behavior changes for existing users: mice are **never auto-bound** to a port (unlike gamepads, every system has a mouse — grabbing a port with it would be surprising), and the two new UI-shortcut guards (`input.disable_dblclick_fullscreen`, `input.disable_rclick_menu`, useful so a gun trigger doesn't toggle fullscreen) **default to off**.
- The XID gamepad path is untouched; the lightgun device embeds and reuses the gamepad report handling.

## Testing

- Windows 11: Sinden Lightgun and regular mice, Silent Scope Complete (SS1/SS2/SS3 all playable, in-game calibration verified end-to-end)
- Batocera Linux 43 (x86_64): two Sinden guns simultaneously on ports 1/2, frontend-assigned via the `evdev:` alias, D-pad and extra buttons via direct device reads
- A build of this feature has been distributed to the lightgun community for several days (hundreds of downloads) without regressions reported on pad-only setups

Happy to split, rename options or adjust the approach as preferred.