### PR TITLE
nv2a: Add lock-free fast path for fence polling reads

### DIFF
--- a/hw/xbox/nv2a/pgraph/pgraph.c
+++ b/hw/xbox/nv2a/pgraph/pgraph.c
@@ -44,6 +44,28 @@ uint64_t pgraph_read(void *opaque, hwaddr addr, unsigned int size)
     NV2AState *d = (NV2AState *)opaque;
     PGRAPHState *pg = &d->pgraph;
 
+    /*
+     * Lock-free fast path for the GPU fence register the guest busy-polls.
+     * The Xbox D3D runtime polls NV_PGRAPH_PATT_COLOR0 for its fence value;
+     * taking pg->lock for each poll convoys with the FIFO puller, which
+     * needs the same lock to advance the fence being polled for. A
+     * momentarily stale read is what real hardware gives a CPU polling an
+     * asynchronously updated register. The write side is serialized: the
+     * fence method runs under pg->lock, and guest MMIO writes to this
+     * register are issued by the same single vCPU that polls it.
+     */
+    if (addr == NV_PGRAPH_PATT_COLOR0 && size == 4) {
+        uint64_t fr = qatomic_read(&pg->regs_[NV_PGRAPH_PATT_COLOR0]);
+        /*
+         * Pairs with the smp_wmb at the fence write site in pgraph_method,
+         * so that the pgraph effects preceding the fence are visible once
+         * the new fence value is.
+         */
+        smp_rmb();
+        nv2a_reg_log_read(NV_PGRAPH, addr, size, fr);
+        return fr;
+    }
+
     qemu_mutex_lock(&pg->lock);
 
     uint64_t r = 0;
@@ -702,7 +724,14 @@ int pgraph_method(NV2AState *d, unsigned int subchannel,
     case NV_CONTEXT_PATTERN: {
         switch (method) {
         case NV044_SET_MONOCHROME_COLOR0:
-            pgraph_reg_w(pg, NV_PGRAPH_PATT_COLOR0, parameter);
+            /*
+             * Xbox D3D GPU fence value, busy-polled by the guest CPU; see
+             * the lock-free read path in pgraph_read. The barrier orders
+             * the pgraph effects of preceding methods before the fence
+             * store becomes visible to the polling vCPU.
+             */
+            smp_wmb();
+            pgraph_reg_w_atomic(pg, NV_PGRAPH_PATT_COLOR0, parameter);
             break;
         default:
             goto unhandled;

--- a/hw/xbox/nv2a/pgraph/pgraph.h
+++ b/hw/xbox/nv2a/pgraph/pgraph.h
@@ -315,6 +315,22 @@ static inline void pgraph_reg_w(PGRAPHState *pg, unsigned int r, uint32_t v)
     pg->regs_[r] = v;
 }
 
+/*
+ * Variant of pgraph_reg_w for registers that pgraph_read serves without
+ * taking pg->lock: the atomic store keeps the compiler from tearing or
+ * eliding the write under a concurrent lock-free reader. Writers remain
+ * serialized by pg->lock, so the dirty-tracking compare can stay plain.
+ */
+static inline void pgraph_reg_w_atomic(PGRAPHState *pg, unsigned int r,
+                                       uint32_t v)
+{
+    assert(r % 4 == 0);
+    if (pg->regs_[r] != v) {
+        bitmap_set(pg->regs_dirty, r / sizeof(uint32_t), 1);
+    }
+    qatomic_set(&pg->regs_[r], v);
+}
+
 void pgraph_clear_dirty_reg_map(PGRAPHState *pg);
 
 static inline bool pgraph_is_reg_dirty(PGRAPHState *pg, unsigned int reg)


### PR DESCRIPTION
Fixes #1376

### Problem

Project Gotham Racing 2 races with AI cars run at 10–20 fps (the game
time-dilates) while solo time attack holds 30 fps, on hardware from a GTX 1060
up to an RTX 4080 Super per the compatibility reports. Rendering resolution
scale has no effect on the slowdown, no host thread is saturated, and the host
GPU sits under 50% — pointing at a latency problem rather than a throughput
problem.

### Root cause

The Xbox D3D runtime implements GPU fences by writing a sequence number into
`NV_PGRAPH_PATT_COLOR0` (via `NV044_SET_MONOCHROME_COLOR0` in the pushbuffer)
and busy-polling the register from the CPU until the value appears.

Instrumenting PGRAPH MMIO access frequency during a race showed ~580k reads of
this single register in a short gameplay segment — an order of magnitude more
than all other PGRAPH accesses combined. Every poll acquires `pgraph.lock`,
which is the same lock the FIFO puller cycles per engine method (at the site
commented `// TODO: this is fucked`). The polling guest therefore stalls the
very thread that advances the fence it is waiting on. Since QEMU mutexes on
Windows don't spin, each collision is a full thread sleep/wake; the convoy
costs ~11µs per draw batch, and these scenes submit 3,500–5,000 batches per
frame. Sampling profiles (Very Sleepy against a symbolized build) confirm the
threads spend the slowdown blocked in `qemu_mutex_lock_impl` from the puller
and MMIO paths rather than doing work.

### Change

Serve aligned 32-bit reads of `NV_PGRAPH_PATT_COLOR0` with a lock-free
snapshot in `pgraph_read`, before taking `pgraph.lock`. A momentarily stale
value matches real hardware behavior for a CPU polling an asynchronously
updated register. An `smp_wmb()` at the fence write site pairs with an
`smp_rmb()` in the read path so the new fence value cannot be observed before
the pgraph effects that precede it on weakly ordered hosts (macOS/ARM,
Windows/ARM). The fence store goes through a new `pgraph_reg_w_atomic()`
helper (same dirty-bit tracking as `pgraph_reg_w`, atomic store) so it cannot
race the lock-free reader. The write side remains serialized: the fence
method runs under `pgraph.lock`, and guest MMIO writes to the register come
from the same single vCPU that polls it.

`scripts/checkpatch.pl` reports clean.

*Revised after review feedback: an earlier version of this PR also served
`NV_PGRAPH_INTR` lock-free. That path raced the plain read-modify-writes of
`pending_interrupts` and was not justified by the profiling data (only the
fence register was measured hot), so it has been dropped rather than patched
— interrupt handling is back to exactly stock behavior.*

### Results

Measured on PGR2 (PAL), Windows 11, GTX 1060, OpenGL backend, using a savestate
of a 6-car race in the Hong Kong underpass section (the worst case we found):

| | before | after |
|---|---|---|
| guest FPS (Video Debug overlay) | 17–19 | 29–30 |
| game speed vs wall clock (lap timer) | ~35% | 100% |

Verified over several days of regular play: no rendering artifacts, no audio
issues, no crashes, full races and menus behave normally. The same savestate
loads and performs identically on this branch rebased onto current master.

Since the fence-polling idiom belongs to the D3D runtime rather than to PGR2,
other titles whose slowdowns scale with scene complexity may benefit; testing
across more titles would be welcome.

### Development transparency

This fix was developed with substantial assistance from an AI coding agent
(Anthropic's Claude), which performed the profiling, instrumentation, and
patch drafting under my direction; I have reviewed the change and tested it
extensively in real gameplay. The commit carries a Co-authored-by line to that
effect. Happy to rework anything — including reimplementing from scratch based
on the diagnosis — if AI-assisted patches are a concern for the project.
