### PR TITLE
apu: Return sample count for NV_PAPU_XGSCNT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ build.log
 /macos-libs/
 /macos-pkgs/
 /xemu.iconset/
+/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ build.log
 /macos-libs/
 /macos-pkgs/
 /xemu.iconset/
-/.vs

--- a/hw/xbox/mcpx/apu/apu.c
+++ b/hw/xbox/mcpx/apu/apu.c
@@ -50,7 +50,7 @@ static uint64_t mcpx_apu_read(void *opaque, hwaddr addr, unsigned int size)
     uint64_t r = 0;
     switch (addr) {
     case NV_PAPU_XGSCNT:
-        r = qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) / 100; //???
+        r = (uint64_t)d->ep_frame_div * NUM_SAMPLES_PER_FRAME; //???
         break;
     default:
         if (addr < 0x20000) {

--- a/hw/xbox/mcpx/apu/apu.c
+++ b/hw/xbox/mcpx/apu/apu.c
@@ -50,7 +50,7 @@ static uint64_t mcpx_apu_read(void *opaque, hwaddr addr, unsigned int size)
     uint64_t r = 0;
     switch (addr) {
     case NV_PAPU_XGSCNT:
-        r = (uint64_t)d->ep_frame_div * NUM_SAMPLES_PER_FRAME; //???
+        r = (uint64_t)d->ep_frame_div * NUM_SAMPLES_PER_FRAME;
         break;
     default:
         if (addr < 0x20000) {


### PR DESCRIPTION
For innocent tears as seen in this report: https://xemu.app/titles/4b550001/#Innocent-Tears

The majority of the audio would be desynced and not play fully due to
`r = qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) / 100;`

the fix 
`r = (uint64_t)d->ep_frame_div * NUM_SAMPLES_PER_FRAME;`
will now properly report back how many samples have been processed, therefore keeping the voices and audio in sync. 

Ive only tested this on Innocent Tears, as a translation is being released soon.

---

* Fixes #579
* Fixes #2023
* Fixes #2106
* Fixes #2332
* Fixes #2578