### PR TITLE
target/i386: Preserve x87 load precision

### DIFF
--- a/target/i386/tcg/fpu_helper.c
+++ b/target/i386/tcg/fpu_helper.c
@@ -435,6 +435,14 @@ static void fpu_raise_exception(CPUX86State *env, uintptr_t retaddr)
 #endif
 }
 
+static FloatX80RoundPrec tmp_maximise_precision(float_status *st)
+{
+    FloatX80RoundPrec old = get_floatx80_rounding_precision(st);
+
+    set_floatx80_rounding_precision(floatx80_precision_x, st);
+    return old;
+}
+
 void helper_flds_FT0(CPUX86State *env, uint32_t val)
 {
     int old_flags = save_exception_flags(env);
@@ -451,6 +459,7 @@ void helper_flds_FT0(CPUX86State *env, uint32_t val)
 void helper_fldl_FT0(CPUX86State *env, uint64_t val)
 {
     int old_flags = save_exception_flags(env);
+    FloatX80RoundPrec old = tmp_maximise_precision(&env->fp_status);
     union {
         float64 f;
         uint64_t i;
@@ -458,6 +467,7 @@ void helper_fldl_FT0(CPUX86State *env, uint64_t val)
 
     u.i = val;
     FT0 = float64_to_floatx80(u.f, &env->fp_status);
+    set_floatx80_rounding_precision(old, &env->fp_status);
     merge_exception_flags(env, old_flags);
 }
 
@@ -487,6 +497,7 @@ void helper_fldl_ST0(CPUX86State *env, uint64_t val)
 {
     int old_flags = save_exception_flags(env);
     int new_fpstt;
+    FloatX80RoundPrec old = tmp_maximise_precision(&env->fp_status);
     union {
         float64 f;
         uint64_t i;
@@ -497,14 +508,8 @@ void helper_fldl_ST0(CPUX86State *env, uint64_t val)
     env->fpregs[new_fpstt].d = float64_to_floatx80(u.f, &env->fp_status);
     env->fpstt = new_fpstt;
     env->fptags[new_fpstt] = 0; /* validate stack entry */
+    set_floatx80_rounding_precision(old, &env->fp_status);
     merge_exception_flags(env, old_flags);
-}
-
-static FloatX80RoundPrec tmp_maximise_precision(float_status *st)
-{
-    FloatX80RoundPrec old = get_floatx80_rounding_precision(st);
-    set_floatx80_rounding_precision(floatx80_precision_x, st);
-    return old;
 }
 
 void helper_fildl_ST0(CPUX86State *env, int32_t val)

--- a/target/i386/tcg/translate.c
+++ b/target/i386/tcg/translate.c
@@ -1627,18 +1627,9 @@ static void gen_set_fptag(int offs, int value)
     tcg_gen_st8_i32(tmp, p, offsetof(CPUX86State, fptags[0]) + offs);
 }
 
-static bool fpu_using_double_precision(DisasContext *s)
+static bool fpu_rounding_to_single(DisasContext *s)
 {
-    /*
-     * XXX: Currently emulating double extended precision with double precision
-     * when using hard floats.
-     */
-    return s->flags & HF_FPU_PC_MASK;
-}
-
-static void gen_movi_f32(DisasContext *s, TCGv_f32 ret, float arg)
-{
-    tcg_gen_mov32i_f32(ret, tcg_constant_i32(*(uint32_t *)&arg));
+    return !(s->flags & HF_FPU_PC_MASK);
 }
 
 static void gen_movi_f64(DisasContext *s, TCGv_f64 ret, double arg)
@@ -1662,28 +1653,11 @@ static void gen_flcr(DisasContext *s)
     s->flcr_set = true;
 }
 
-static void gen_mov32f_i64(TCGv_i64 ret, TCGv_f32 arg)
-{
-    TCGv_f64 t = tcg_temp_new_f64();
-    tcg_gen_cvt32f_f64(t, arg);
-    tcg_gen_mov64f_i64(ret, t);
-}
-
-static void gen_mov32f_i32(TCGv_i32 ret, TCGv_f32 arg)
-{
-    tcg_gen_mov32f_i32(ret, arg);
-}
-
 static void gen_mov32i_f64(TCGv_f64 ret, TCGv_i32 arg)
 {
     TCGv_f32 t = tcg_temp_new_f32();
     tcg_gen_mov32i_f32(t, arg);
     tcg_gen_cvt32f_f64(ret, t);
-}
-
-static void gen_mov32i_f32(TCGv_f32 ret, TCGv_i32 arg)
-{
-    tcg_gen_mov32i_f32(ret, arg);
 }
 
 static void gen_mov64f_i32(TCGv_i32 ret, TCGv_f64 arg)
@@ -1698,32 +1672,33 @@ static void gen_mov64f_i64(TCGv_i64 ret, TCGv_f64 arg)
     tcg_gen_mov64f_i64(ret, arg);
 }
 
-static void gen_mov64i_f32(TCGv_f32 ret, TCGv_i64 arg)
-{
-    TCGv_f64 t = tcg_temp_new_f64();
-    tcg_gen_mov64i_f64(t, arg);
-    tcg_gen_cvt64f_f32(ret, t);
-}
-
 static void gen_mov64i_f64(TCGv_f64 ret, TCGv_i64 arg)
 {
     tcg_gen_mov64i_f64(ret, arg);
 }
 
-#define PREC 32
-#include "ops_fpu.h"
-#undef PREC
-
 #define PREC 64
 #include "ops_fpu.h"
 #undef PREC
 
-#define fp_pc_wrapper(f) \
-    (fpu_using_double_precision(s) ? glue(f, _f64) : glue(f, _f32))
+/*
+ * The precision-control field rounds arithmetic results, not register loads
+ * or moves. Keep the hard-float register cache at the maximum available
+ * precision and explicitly round affected results below.
+ */
+#define fp_wrapper(f) glue(f, _f64)
+
+static void gen_round_to_single(TCGv_f64 value)
+{
+    TCGv_f32 tmp = tcg_temp_new_f32();
+
+    tcg_gen_cvt64f_f32(tmp, value);
+    tcg_gen_cvt32f_f64(value, tmp);
+}
 
 static void gen_flush_fp(DisasContext *s)
 {
-    fp_pc_wrapper(flush_fp_regs)(s);
+    fp_wrapper(flush_fp_regs)(s);
     s->fpstt_delta = 0;
     s->flcr_set = false;
 }
@@ -1774,26 +1749,26 @@ static void gen_fpop(DisasContext *s)
     tcg_gen_addi_i32(fpstt, fpstt, 1);
     tcg_gen_andi_i32(fpstt, fpstt, 7);
 
-    fp_pc_wrapper(gen_fpop)(s);
+    fp_wrapper(gen_fpop)(s);
     s->fpstt_delta += 1;
 }
 
 static void gen_fmov_FT0_STN(DisasContext *s, int st_index)
 {
     GEN_HELPER_FALLBACK_v_i(fmov_FT0_STN, st_index);
-    fp_pc_wrapper(gen_fmov_FT0_STN)(s, st_index);
+    fp_wrapper(gen_fmov_FT0_STN)(s, st_index);
 }
 
 static void gen_fmov_ST0_STN(DisasContext *s, int st_index)
 {
     GEN_HELPER_FALLBACK_v_i(fmov_ST0_STN, st_index);
-    fp_pc_wrapper(gen_fmov_ST0_STN)(s, st_index);
+    fp_wrapper(gen_fmov_ST0_STN)(s, st_index);
 }
 
 static void gen_fmov_STN_ST0(DisasContext *s, int st_index)
 {
     GEN_HELPER_FALLBACK_v_i(fmov_STN_ST0, st_index);
-    fp_pc_wrapper(gen_fmov_STN_ST0)(s, st_index);
+    fp_wrapper(gen_fmov_STN_ST0)(s, st_index);
 }
 
 static void gen_fxchg_ST0_STN(DisasContext *s, int st_index)
@@ -1801,13 +1776,8 @@ static void gen_fxchg_ST0_STN(DisasContext *s, int st_index)
     GEN_HELPER_FALLBACK_v_i(fxchg_ST0_STN, st_index);
 
     /* Ensure ST0, STN are loaded */
-    if (fpu_using_double_precision(s)) {
-        get_stn_f64(s, 0);
-        get_stn_f64(s, st_index);
-    } else {
-        get_stn_f32(s, 0);
-        get_stn_f32(s, st_index);
-    }
+    get_stn_f64(s, 0);
+    get_stn_f64(s, st_index);
     TCGv_fp i = s->fpregs[(s->fpstt_delta + 0) & 7];
     s->fpregs[(s->fpstt_delta + 0) & 7] =
         s->fpregs[(s->fpstt_delta + st_index) & 7];
@@ -1831,89 +1801,92 @@ static void gen_enter_mmx(DisasContext *s)
 static void gen_flds_FT0(DisasContext *s, TCGv_i32 arg)
 {
     GEN_HELPER_FALLBACK_v_T(flds_FT0, arg);
-    fp_pc_wrapper(gen_flds_FT0)(s, arg);
+    fp_wrapper(gen_flds_FT0)(s, arg);
 }
 
 static void gen_flds_ST0(DisasContext *s, TCGv_i32 arg)
 {
     GEN_HELPER_FALLBACK_v_T(flds_ST0, arg);
     gen_fpush(s);
-    fp_pc_wrapper(gen_flds_ST0)(s, arg);
+    fp_wrapper(gen_flds_ST0)(s, arg);
 }
 
 static void gen_fldl_FT0(DisasContext *s, TCGv_i64 arg)
 {
     GEN_HELPER_FALLBACK_v_T(fldl_FT0, arg);
-    fp_pc_wrapper(gen_fldl_FT0)(s, arg);
+    fp_wrapper(gen_fldl_FT0)(s, arg);
 }
 
 static void gen_fldl_ST0(DisasContext *s, TCGv_i64 arg)
 {
     GEN_HELPER_FALLBACK_v_T(fldl_ST0, arg);
     gen_fpush(s);
-    fp_pc_wrapper(gen_fldl_ST0)(s, arg);
+    fp_wrapper(gen_fldl_ST0)(s, arg);
 }
 
 static void gen_fildl_FT0(DisasContext *s, TCGv_i32 arg)
 {
     GEN_HELPER_FALLBACK_v_T(fildl_FT0, arg);
-    fp_pc_wrapper(gen_fildl_FT0)(s, arg);
+    fp_wrapper(gen_fildl_FT0)(s, arg);
 }
 
 static void gen_fildl_ST0(DisasContext *s, TCGv_i32 arg)
 {
     GEN_HELPER_FALLBACK_v_T(fildl_ST0, arg);
     gen_fpush(s);
-    fp_pc_wrapper(gen_fildl_ST0)(s, arg);
+    fp_wrapper(gen_fildl_ST0)(s, arg);
 }
 
 static void gen_fildll_ST0(DisasContext *s, TCGv_i64 arg)
 {
     GEN_HELPER_FALLBACK_v_T(fildll_ST0, arg);
     gen_fpush(s);
-    fp_pc_wrapper(gen_fildll_ST0)(s, arg);
+    fp_wrapper(gen_fildll_ST0)(s, arg);
 }
 
 static void gen_fsts_ST0(DisasContext *s, TCGv_i32 arg)
 {
     GEN_HELPER_FALLBACK_T_v(fsts_ST0, arg);
-    fp_pc_wrapper(gen_fsts_ST0)(s, arg);
+    fp_wrapper(gen_fsts_ST0)(s, arg);
 }
 
 static void gen_fstl_ST0(DisasContext *s, TCGv_i64 arg)
 {
     GEN_HELPER_FALLBACK_T_v(fstl_ST0, arg);
-    fp_pc_wrapper(gen_fstl_ST0)(s, arg);
+    fp_wrapper(gen_fstl_ST0)(s, arg);
 }
 
 static void gen_fistl_ST0(DisasContext *s, TCGv_i32 arg)
 {
     GEN_HELPER_FALLBACK_T_v(fistl_ST0, arg);
-    fp_pc_wrapper(gen_fistl_ST0)(s, arg);
+    fp_wrapper(gen_fistl_ST0)(s, arg);
 }
 
 static void gen_fistll_ST0(DisasContext *s, TCGv_i64 arg)
 {
     GEN_HELPER_FALLBACK_T_v(fistll_ST0, arg);
-    fp_pc_wrapper(gen_fistll_ST0)(s, arg);
+    fp_wrapper(gen_fistll_ST0)(s, arg);
 }
 
 static void gen_fchs_ST0(DisasContext *s)
 {
     GEN_HELPER_FALLBACK_v_v(fchs_ST0);
-    fp_pc_wrapper(gen_fchs_ST0)(s);
+    fp_wrapper(gen_fchs_ST0)(s);
 }
 
 static void gen_fabs_ST0(DisasContext *s)
 {
     GEN_HELPER_FALLBACK_v_v(fabs_ST0);
-    fp_pc_wrapper(gen_fabs_ST0)(s);
+    fp_wrapper(gen_fabs_ST0)(s);
 }
 
 static void gen_fsqrt(DisasContext *s)
 {
     GEN_HELPER_FALLBACK_v_v(fsqrt);
-    fp_pc_wrapper(gen_fsqrt)(s);
+    gen_fsqrt_f64(s);
+    if (fpu_rounding_to_single(s)) {
+        gen_round_to_single(get_st0_f64(s));
+    }
 }
 
 static void gen_clear_fpus_c2(DisasContext *s)
@@ -1927,21 +1900,24 @@ static void gen_clear_fpus_c2(DisasContext *s)
 static void gen_fsin(DisasContext *s)
 {
     GEN_HELPER_FALLBACK_v_v(fsin);
-    fp_pc_wrapper(gen_fsin)(s);
+    fp_wrapper(gen_fsin)(s);
     gen_clear_fpus_c2(s); /* FIXME: Does not check range correctly */
 }
 
 static void gen_fcos(DisasContext *s)
 {
     GEN_HELPER_FALLBACK_v_v(fcos);
-    fp_pc_wrapper(gen_fcos)(s);
+    fp_wrapper(gen_fcos)(s);
     gen_clear_fpus_c2(s); /* FIXME: Does not check range correctly */
 }
 
 static void gen_helper_fp_arith_ST0_FT0(DisasContext *s, int op)
 {
     if (g_use_hard_fpu) {
-        fp_pc_wrapper(gen_helper_fp_arith_ST0_FT0)(s, op);
+        gen_helper_fp_arith_ST0_FT0_f64(s, op);
+        if (op != 2 && op != 3 && fpu_rounding_to_single(s)) {
+            gen_round_to_single(get_st0_f64(s));
+        }
     } else {
         switch (op) {
         case 0:
@@ -1981,7 +1957,10 @@ static void gen_fcom_ST0_FT0(DisasContext *s)
 static void gen_helper_fp_arith_STN_ST0(DisasContext *s, int op, int opreg)
 {
     if (g_use_hard_fpu) {
-        fp_pc_wrapper(gen_helper_fp_arith_STN_ST0)(s, op, opreg);
+        gen_helper_fp_arith_STN_ST0_f64(s, op, opreg);
+        if (fpu_rounding_to_single(s)) {
+            gen_round_to_single(get_stn_f64(s, opreg));
+        }
     } else {
         TCGv_i32 tmp = tcg_constant_i32(opreg);
 
@@ -2011,20 +1990,20 @@ static void gen_helper_fp_arith_STN_ST0(DisasContext *s, int op, int opreg)
 static void gen_fld1_ST0(DisasContext *s)
 {
     GEN_HELPER_FALLBACK_v_v(fld1_ST0);
-    fp_pc_wrapper(gen_fld1_ST0)(s);
+    fp_wrapper(gen_fld1_ST0)(s);
 }
 
 static void gen_fldz_ST0(DisasContext *s)
 {
     GEN_HELPER_FALLBACK_v_v(fldz_ST0);
-    fp_pc_wrapper(gen_fldz_ST0)(s);
+    fp_wrapper(gen_fldz_ST0)(s);
     /* FIXME: Set tag word */
 }
 
 static void gen_fldz_FT0(DisasContext *s)
 {
     GEN_HELPER_FALLBACK_v_v(fldz_FT0);
-    fp_pc_wrapper(gen_fldz_FT0)(s);
+    fp_wrapper(gen_fldz_FT0)(s);
 }
 
 static void gen_exception(DisasContext *s, int trapno)

--- a/tests/tcg/i386/test-i386-fld-pc.c
+++ b/tests/tcg/i386/test-i386-fld-pc.c
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Test x87 precision control for loads and arithmetic.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+union x87_value {
+    struct {
+        uint64_t significand;
+        uint16_t sign_exp;
+    };
+    long double value;
+};
+
+static const double load_input = 314159265.35897934;
+static const double add_input = 16777216.0;
+static const double one = 1.0;
+
+int main(void)
+{
+    union x87_value load_result;
+    union x87_value add_result;
+    uint16_t old_cw;
+    uint16_t single_cw;
+    int ret = 0;
+
+    __asm__ volatile("fnstcw %0" : "=m"(old_cw));
+    single_cw = old_cw & ~0xf00;
+    __asm__ volatile("fldcw %0" : : "m"(single_cw));
+
+    __asm__ volatile("fldl %1; fstpt %0"
+                     : "=m"(load_result.value)
+                     : "m"(load_input)
+                     : "st");
+    __asm__ volatile("fldl %1; faddl %2; fstpt %0"
+                     : "=m"(add_result.value)
+                     : "m"(add_input), "m"(one)
+                     : "st");
+
+    __asm__ volatile("fldcw %0" : : "m"(old_cw));
+
+    if (load_result.significand != UINT64_C(0x95cd850adf309000) ||
+        load_result.sign_exp != 0x401b) {
+        printf("FAIL: FLD rounded by precision control\n");
+        ret = 1;
+    }
+    if (add_result.significand != UINT64_C(0x8000000000000000) ||
+        add_result.sign_exp != 0x4017) {
+        printf("FAIL: FADD ignored precision control\n");
+        ret = 1;
+    }
+
+    return ret;
+}


### PR DESCRIPTION
## Summary

The hard-FPU path used the x87 precision-control field to select both the
arithmetic width and the register-cache width. With single precision selected,
`FLD m64` therefore rounded the loaded double to 24 bits even though x87
precision control applies only to arithmetic results.

Keep hard-FPU registers at the maximum available precision and explicitly
round the affected arithmetic results. The soft-FPU load helpers now also
widen double inputs at maximum precision.

Fixes #2883.
Fixes #536  // as noted by Triticum0
Fixes #572  // as noted by Triticum0

## Testing

- Added `test-i386-fld-pc`, covering an exact `FLD m64` followed by an
  operation that must round to single precision.
- Verified the hard-FPU path preserves `314159265.35897934` across `FLD m64`
  and returns `314159265` from the title's conversion routine.
- Verified the same result with hard-FPU emulation disabled.
- NFL Fever 2004 reaches the title screen and rendered attract sequence.
- `ninja -C build qemu-system-i386`
- `scripts/checkpatch.pl`: 0 errors
