### PR TITLE
nv2a/vk: only finish when a vertex RAM update affects a pending draw

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1234,6 +1234,8 @@ void pgraph_vk_finish(PGRAPHState *pg, FinishReason finish_reason)
                                 BUFFER_VERTEX_INLINE);
         sync_staging_buffer(pg, cmd, BUFFER_UNIFORM_STAGING, BUFFER_UNIFORM);
         bitmap_clear(r->uploaded_bitmap, 0, r->bitmap_size);
+        r->num_vertex_ram_referenced = 0;
+        r->vertex_ram_referenced_overflowed = false;
         flush_memory_buffer(pg, cmd);
         VK_CHECK(vkEndCommandBuffer(r->aux_command_buffer));
         r->in_aux_command_buffer = false;
@@ -1565,6 +1567,17 @@ static void sync_vertex_ram_buffer(PGRAPHState *pg)
         return;
     }
 
+    /* Preserve the exact (unaligned) ranges before they are rounded out to page
+     * boundaries below. These are the bytes the upcoming draw will actually
+     * source vertices from, and are registered as referenced once this draw's
+     * own uploads are done.
+     */
+    MemorySyncRequirement precise[NV2A_VERTEXSHADER_ATTRIBUTES];
+    size_t num_precise = r->num_vertex_ram_buffer_syncs;
+
+    memcpy(precise, r->vertex_ram_buffer_syncs,
+           num_precise * sizeof(precise[0]));
+
     // Align sync requirements to page boundaries
     NV2A_VK_DGROUP_BEGIN("Sync vertex RAM buffer");
 
@@ -1635,6 +1648,15 @@ static void sync_vertex_ram_buffer(PGRAPHState *pg)
     }
 
     r->num_vertex_ram_buffer_syncs = 0;
+
+    /* Register after the uploads above: the draw that reads these bytes has not
+     * been recorded into the command buffer yet, so its own upload is not a
+     * conflict with itself.
+     */
+    for (size_t i = 0; i < num_precise; i++) {
+        pgraph_vk_mark_vertex_ram_referenced(pg, precise[i].addr,
+                                             precise[i].size);
+    }
 
     NV2A_VK_DGROUP_END();
 }

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -51,6 +51,9 @@ typedef struct MemorySyncRequirement {
     hwaddr addr, size;
 } MemorySyncRequirement;
 
+/* Max distinct vertex RAM byte ranges tracked per command buffer. */
+#define VK_MAX_VERTEX_RAM_REFERENCED 256
+
 typedef struct RenderPassState {
     VkFormat color_format;
     VkFormat zeta_format;
@@ -376,6 +379,17 @@ typedef struct PGRAPHVkState {
     unsigned long *uploaded_bitmap;
     size_t bitmap_size;
 
+    /* Byte ranges of BUFFER_VERTEX_RAM that draws already recorded into the
+     * current command buffer will source vertices from. Used to determine
+     * whether a RAM buffer update actually conflicts with pending work, rather
+     * than relying on the page-granular uploaded_bitmap alone. Reset whenever
+     * the command buffer is submitted. If more ranges are needed than fit,
+     * overflowed is set and we fall back to conservative behavior.
+     */
+    MemorySyncRequirement vertex_ram_referenced[VK_MAX_VERTEX_RAM_REFERENCED];
+    size_t num_vertex_ram_referenced;
+    bool vertex_ram_referenced_overflowed;
+
     VkVertexInputAttributeDescription vertex_attribute_descriptions[NV2A_VERTEXSHADER_ATTRIBUTES];
     int vertex_attribute_to_description_location[NV2A_VERTEXSHADER_ATTRIBUTES];
     int num_active_vertex_attribute_descriptions;
@@ -499,6 +513,8 @@ void pgraph_vk_bind_vertex_attributes(NV2AState *d, unsigned int min_element,
 void pgraph_vk_bind_vertex_attributes_inline(NV2AState *d);
 void pgraph_vk_update_vertex_ram_buffer(PGRAPHState *pg, hwaddr offset, void *data,
                                     VkDeviceSize size);
+void pgraph_vk_mark_vertex_ram_referenced(PGRAPHState *pg, hwaddr addr,
+                                          hwaddr size);
 VkDeviceSize pgraph_vk_update_index_buffer(PGRAPHState *pg, void *data,
                                            VkDeviceSize size);
 VkDeviceSize pgraph_vk_update_vertex_inline_buffer(PGRAPHState *pg, void **data,

--- a/hw/xbox/nv2a/pgraph/vk/vertex.c
+++ b/hw/xbox/nv2a/pgraph/vk/vertex.c
@@ -42,6 +42,86 @@ VkDeviceSize pgraph_vk_update_vertex_inline_buffer(PGRAPHState *pg, void **data,
                                       sizes, count, 1);
 }
 
+void pgraph_vk_mark_vertex_ram_referenced(PGRAPHState *pg, hwaddr addr,
+                                          hwaddr size)
+{
+    PGRAPHVkState *r = pg->vk_renderer_state;
+
+    if (!size) {
+        return;
+    }
+
+    /* Coalesce with the previous entry when possible: consecutive attributes of
+     * one draw are frequently adjacent or overlapping.
+     */
+    if (r->num_vertex_ram_referenced) {
+        MemorySyncRequirement *p =
+            &r->vertex_ram_referenced[r->num_vertex_ram_referenced - 1];
+
+        if (addr >= p->addr && addr <= p->addr + p->size) {
+            hwaddr end = MAX(p->addr + p->size, addr + size);
+            p->size = end - p->addr;
+            return;
+        }
+    }
+
+    if (r->num_vertex_ram_referenced >= VK_MAX_VERTEX_RAM_REFERENCED) {
+        /* Out of slots. Fall back to assuming everything is referenced, which
+         * restores the old (conservative) behavior for this command buffer.
+         */
+        r->vertex_ram_referenced_overflowed = true;
+        return;
+    }
+
+    r->vertex_ram_referenced[r->num_vertex_ram_referenced++] =
+        (MemorySyncRequirement){ .addr = addr, .size = size };
+}
+
+/*
+ * Determine whether writing `size` bytes of `data` at `offset` would actually
+ * change any byte that a draw already recorded into the current command buffer
+ * is going to read.
+ *
+ * The uploaded_bitmap test alone is page-granular, and sync_vertex_ram_buffer()
+ * aligns sync ranges outward to TARGET_PAGE_SIZE, so a guest write anywhere in
+ * a page containing vertex data forces a full-page re-upload and looks like a
+ * conflict. In practice the overwhelming majority of those uploads rewrite
+ * identical bytes, or change only bytes outside the ranges any pending draw
+ * sources vertices from.
+ *
+ * This is strictly narrower than the bitmap test but still conservative: it
+ * returns true whenever a byte within a referenced range is about to change.
+ */
+static bool vertex_ram_update_conflicts(PGRAPHVkState *r, hwaddr offset,
+                                        const void *data, VkDeviceSize size)
+{
+    if (r->vertex_ram_referenced_overflowed) {
+        return true;
+    }
+
+    const uint8_t *cur = r->storage_buffers[BUFFER_VERTEX_RAM].mapped;
+    const uint8_t *incoming = data;
+
+    for (size_t i = 0; i < r->num_vertex_ram_referenced; i++) {
+        hwaddr ref_start = r->vertex_ram_referenced[i].addr;
+        hwaddr ref_end = ref_start + r->vertex_ram_referenced[i].size;
+
+        /* Intersect the referenced range with the region being written. */
+        hwaddr start = MAX(ref_start, offset);
+        hwaddr end = MIN(ref_end, offset + size);
+
+        if (start >= end) {
+            continue;
+        }
+
+        if (memcmp(cur + start, incoming + (start - offset), end - start)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void pgraph_vk_update_vertex_ram_buffer(PGRAPHState *pg, hwaddr offset,
                                         void *data, VkDeviceSize size)
 {
@@ -54,7 +134,8 @@ void pgraph_vk_update_vertex_ram_buffer(PGRAPHState *pg, hwaddr offset,
     size_t nbits = end_bit - start_bit;
 
     if (find_next_bit(r->uploaded_bitmap, start_bit + nbits, start_bit) <
-        end_bit) {
+            end_bit &&
+        vertex_ram_update_conflicts(r, offset, data, size)) {
         // Vertex data changed while building the draw list. Finish drawing
         // before updating RAM buffer.
         pgraph_vk_finish(pg, VK_FINISH_REASON_VERTEX_BUFFER_DIRTY);


### PR DESCRIPTION
## Problem

`sync_vertex_ram_buffer()` rounds each vertex attribute range outward to page boundaries before testing guest dirty state:

```c
hwaddr start_addr = r->vertex_ram_buffer_syncs[i].addr & TARGET_PAGE_MASK;
hwaddr end_addr = r->vertex_ram_buffer_syncs[i].addr +
                  r->vertex_ram_buffer_syncs[i].size;
end_addr = ROUND_UP(end_addr, TARGET_PAGE_SIZE);
```

`pgraph_vk_update_vertex_ram_buffer()` then tests for write-after-read hazards against `uploaded_bitmap`, which is also page-granular.

The combination means a guest write *anywhere* in a page that happens to contain vertex data forces a full-page re-upload, collides with the bitmap, and submits the command buffer via `VK_FINISH_REASON_VERTEX_BUFFER_DIRTY` — even when the bytes those pending draws will read are all unchanged. Games that keep per-object state (matrices, animation, particle data) adjacent to vertex data in the same page pay this on nearly every draw.

## Measurements

I instrumented the hazard path to compare incoming bytes against the current contents of `BUFFER_VERTEX_RAM` — i.e. what the not-yet-submitted draws will actually read. Dead or Alive 2 Ultimate, ~98,000 reported conflicts:

| Metric | Value |
| --- | --- |
| Average upload per reported conflict | ~9,200 B (≈2.25 pages) |
| Average distance from first to last differing byte | ~3,682 B |
| Average bytes actually differing | ~754 B (~8% of the upload) |
| Uploads byte-for-byte identical to buffer contents | 2.9% |
| Smallest differing span observed | 1 byte |

So roughly **92% of every "vertex data changed" upload rewrites identical bytes**, and the changed bytes that do exist are frequently outside the ranges any pending draw sources vertices from.

## Change

Track the exact, pre-alignment ranges that draws already recorded into the current command buffer will read (`pgraph_vk_mark_vertex_ram_referenced()`). These are registered *after* each draw's own uploads complete, so a draw is never treated as conflicting with itself.

`pgraph_vk_update_vertex_ram_buffer()` keeps the page bitmap as a cheap first-level filter, then compares only the intersection of the pending write with those referenced ranges, finishing only when a byte inside one of them is genuinely about to change.

This narrows the test rather than removing it, and remains conservative in three ways:

1. The comparison is on actual bytes, not just addresses.
2. The recorded ranges are a superset of what the GPU indexes (they come from the same `update_memory_buffer()` calls that drive the existing sync logic).
3. If a command buffer needs more than `VK_MAX_VERTEX_RAM_REFERENCED` (256) distinct ranges, an overflow flag restores the previous behavior for that command buffer.

## Results

Dead or Alive 2 Ultimate, the stage where this was originally observed:

- Before: 40-47 fps (MSPF ~1), `FINISH_VERTEX_BUFFER_DIRTY` continuously non-zero (49-57)
- After:  59-60 fps (MSPF ~14), `FINISH_VERTEX_BUFFER_DIRTY: 0`

## Testing notes and limitations

- Tested on Windows (mingw cross build), NVIDIA RTX 3080 Ti, Vulkan renderer.
- `DRAW_ARRAYS` was 0 in every scene I captured; the affected stages use the inline-elements and inline-arrays paths. **The `draw_arrays` path is therefore not exercised by my testing** and would benefit from review or testing by someone with a title that uses it.
- Game coverage is limited. A missed referenced range would present as flickering or stale geometry rather than a crash.
- Setting `VK_MAX_VERTEX_RAM_REFERENCED` to 0 forces the overflow path and restores the old behavior, which is a convenient way to A/B any suspected regression.

## Relationship to #2345

#2345 proposed adding `&& r->in_draw` to the same condition. That was rejected as removing too much of the safety net, and I think that read was correct — in fact it removes all of it. `r->in_draw` is only true between `begin_draw()` and `end_draw()`, all three callers of `pgraph_vk_update_vertex_ram_buffer()` run with it false, and `pgraph_vk_finish()` asserts `!r->in_draw`, so the condition can never be true. The branch becomes unreachable and the hazard check is disabled outright.

The review comment there asked what data was actually changing. The table above is that answer, and this change acts on it by making the test precise instead of bypassing it.