### PR TITLE
hw/ide/atapi: Delay DVD read completion interrupt slightly

### DIFF
--- a/hw/ide/atapi.c
+++ b/hw/ide/atapi.c
@@ -183,6 +183,42 @@ void ide_atapi_cmd_ok(IDEState *s)
     ide_bus_set_irq(s->bus);
 }
 
+/*
+ * Defer the read completion interrupt to approximate drive latency.
+ * Instant completion appears to expose a loader race in some titles,
+ * e.g. Rayman Arena hanging between races (xemu-project/xemu#1443).
+ */
+#define ATAPI_COMPLETION_DELAY_US 5000
+
+static QEMUTimer *atapi_completion_timer;
+static IDEState *atapi_completion_pending;
+
+static void atapi_deferred_completion_cb(void *opaque)
+{
+    IDEState *s = atapi_completion_pending;
+
+    if (!s) {
+        return;
+    }
+    atapi_completion_pending = NULL;
+    s->status = READY_STAT | SEEK_STAT;
+    s->nsector = (s->nsector & ~7) | ATAPI_INT_REASON_IO | ATAPI_INT_REASON_CD;
+    ide_bus_set_irq(s->bus);
+}
+
+static void atapi_defer_completion(IDEState *s)
+{
+    if (!atapi_completion_timer) {
+        atapi_completion_timer = timer_new_us(
+            QEMU_CLOCK_VIRTUAL, atapi_deferred_completion_cb, NULL);
+    }
+    /* keep BSY visible to the guest until the timer fires */
+    s->status = READY_STAT | SEEK_STAT | BUSY_STAT;
+    atapi_completion_pending = s;
+    timer_mod(atapi_completion_timer,
+              qemu_clock_get_us(QEMU_CLOCK_VIRTUAL) + ATAPI_COMPLETION_DELAY_US);
+}
+
 void ide_atapi_cmd_error(IDEState *s, int sense_key, int asc)
 {
     trace_ide_atapi_cmd_error(s, sense_key, asc);
@@ -383,9 +419,7 @@ static void ide_atapi_cmd_read_dma_cb(void *opaque, int ret)
     }
 
     if (s->packet_transfer_size <= 0) {
-        s->status = READY_STAT | SEEK_STAT;
-        s->nsector = (s->nsector & ~7) | ATAPI_INT_REASON_IO | ATAPI_INT_REASON_CD;
-        ide_bus_set_irq(s->bus);
+        atapi_defer_completion(s);
         goto eot;
     }
 

--- a/hw/ide/atapi.c
+++ b/hw/ide/atapi.c
@@ -187,6 +187,7 @@ void ide_atapi_cmd_ok(IDEState *s)
  * Defer the read completion interrupt to approximate drive latency.
  * Instant completion appears to expose a loader race in some titles,
  * e.g. Rayman Arena hanging between races (xemu-project/xemu#1443).
+ * Define to 0 to restore instant completion.
  */
 #define ATAPI_COMPLETION_DELAY_US 5000
 
@@ -419,7 +420,14 @@ static void ide_atapi_cmd_read_dma_cb(void *opaque, int ret)
     }
 
     if (s->packet_transfer_size <= 0) {
-        atapi_defer_completion(s);
+        if (ATAPI_COMPLETION_DELAY_US > 0) {
+            atapi_defer_completion(s);
+        } else {
+            s->status = READY_STAT | SEEK_STAT;
+            s->nsector =
+                (s->nsector & ~7) | ATAPI_INT_REASON_IO | ATAPI_INT_REASON_CD;
+            ide_bus_set_irq(s->bus);
+        }
         goto eot;
     }
 


### PR DESCRIPTION
This might fix #1443. Yes I used claude. I just wanted to play Rayman..

---

Debugging a hung instance with gdb showed the guest CPU in the kernel idle loop, the last DVD read completed cleanly, drive idle, and no IDE interrupt pending or masked. The emulator side looked healthy, so the game seems to be waiting on an event of its own that never got signaled.

Reads in xemu complete instantly (back to back 128 KB reads with zero gap in a captured trace), so my guess is a race in the game's streaming code that real drive latency hides. The same game reportedly hangs similarly on Dolphin, which fits. It would also explain the BIOS-dependent symptom (hang vs "dirty or damaged disc"), as different kernels handle the stuck wait differently.

The change keeps BSY set and delivers the completion interrupt of ATAPI DMA reads 5 ms of virtual time later, roughly matching real drive behavior. Defining the delay to 0 restores instant completion.

Before: the hang reproduced on the first race transition. After: multiple race and save transitions in a row worked. Not conclusive proof of a timing race, but a strong signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)