### PR TITLE
ui: Add system action mapping configuration

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -223,6 +223,210 @@ input:
           type: bool
           default: false
 
+  system_actions:
+    toggle_pause:
+      scancode:
+        type: integer
+        default: 19 # P
+      ctrl:
+        type: bool
+        default: true
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    reset:
+      scancode:
+        type: integer
+        default: 21 # R
+      ctrl:
+        type: bool
+        default: true
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    power_off:
+      scancode:
+        type: integer
+        default: 20 # Q
+      ctrl:
+        type: bool
+        default: true
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    eject_disc:
+      scancode:
+        type: integer
+        default: 8 # E
+      ctrl:
+        type: bool
+        default: true
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    load_disc:
+      scancode:
+        type: integer
+        default: 18 # O
+      ctrl:
+        type: bool
+        default: true
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    screenshot:
+      scancode:
+        type: integer
+        default: 69 # F12
+      ctrl: bool
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    toggle_fullscreen:
+      scancode:
+        type: integer
+        default: 68 # F11
+      ctrl: bool
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    toggle_monitor:
+      scancode:
+        type: integer
+        default: 53 # GraveAccent/Tilde
+      ctrl: bool
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    toggle_main_menu:
+      scancode:
+        type: integer
+        default: 58 # F1
+      ctrl: bool
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    toggle_popup_menu:
+      scancode:
+        type: integer
+        default: 59 # F2
+      ctrl: bool
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1:
+        type: integer
+        default: 16384 # CONTROLLER_BUTTON_GUIDE (1<<14)
+      controller_chord_2:
+        type: integer
+        default: 768 # CONTROLLER_BUTTON_BACK (1<<8) | CONTROLLER_BUTTON_START (1<<9)
+    snapshot_load_1:
+      scancode:
+        type: integer
+        default: 62 # F5
+      ctrl: bool
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    snapshot_load_2:
+      scancode:
+        type: integer
+        default: 63 # F6
+      ctrl: bool
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    snapshot_load_3:
+      scancode:
+        type: integer
+        default: 64 # F7
+      ctrl: bool
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    snapshot_load_4:
+      scancode:
+        type: integer
+        default: 65 # F8
+      ctrl: bool
+      shift: bool
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    snapshot_save_1:
+      scancode:
+        type: integer
+        default: 62 # F5
+      ctrl: bool
+      shift:
+        type: bool
+        default: true
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    snapshot_save_2:
+      scancode:
+        type: integer
+        default: 63 # F6
+      ctrl: bool
+      shift:
+        type: bool
+        default: true
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    snapshot_save_3:
+      scancode:
+        type: integer
+        default: 64 # F7
+      ctrl: bool
+      shift:
+        type: bool
+        default: true
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+    snapshot_save_4:
+      scancode:
+        type: integer
+        default: 65 # F8
+      ctrl: bool
+      shift:
+        type: bool
+        default: true
+      alt: bool
+      super: bool
+      controller_chord_1: integer
+      controller_chord_2: integer
+
 display:
   renderer:
     type: enum

--- a/ui/xui/input-manager.cc
+++ b/ui/xui/input-manager.cc
@@ -1,6 +1,7 @@
 #include "ui/xui/main-menu.hh"
 #include "input-manager.hh"
 #include "../xemu-input.h"
+#include "system-actions-manager.hh"
 #include "common.hh"
 
 InputManager g_input_mgr;
@@ -33,6 +34,8 @@ void InputManager::Update()
                 }
             }
         }
+
+        SystemActionsManager::HandleController(m_buttons);
     }
 
     // If the mouse is moved, wake the ui

--- a/ui/xui/main.cc
+++ b/ui/xui/main.cc
@@ -49,6 +49,7 @@
 #include "debug.hh"
 #include "welcome.hh"
 #include "menubar.hh"
+#include "system-actions-manager.hh"
 #include "compat.hh"
 #if defined(_WIN32)
 #include "update.hh"
@@ -157,6 +158,7 @@ void xemu_hud_init(SDL_Window* window, void* sdl_gl_context)
     InitializeStyle();
     g_main_menu.SetNextViewIndex(g_config.general.last_viewed_menu_index);
     first_boot_window.is_open = g_config.general.show_welcome;
+    SystemActionsManager::Init();
 }
 
 void xemu_hud_cleanup(void)
@@ -272,37 +274,11 @@ void xemu_hud_update(void)
     if (!ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow) &&
         !g_scene_mgr.IsDisplayingScene()) {
 
-        // If the guide button is pressed, wake the ui
-        bool menu_button = false;
-        uint32_t buttons = g_input_mgr.CombinedButtons();
-        if (buttons & CONTROLLER_BUTTON_GUIDE) {
-            menu_button = true;
-        }
-
-        // Allow controllers without a guide button to also work
-        if ((buttons & CONTROLLER_BUTTON_BACK) &&
-            (buttons & CONTROLLER_BUTTON_START)) {
-            menu_button = true;
-        }
-
-        if (ImGui::IsKeyPressed(ImGuiKey_F1)) {
-            g_scene_mgr.PushScene(g_main_menu);
-        } else if (ImGui::IsKeyPressed(ImGuiKey_F2)) {
-            g_scene_mgr.PushScene(g_popup_menu);
-        } else if (menu_button ||
-                   (ImGui::IsMouseClicked(ImGuiMouseButton_Right) &&
-                    !ImGui::IsAnyItemFocused() && !ImGui::IsAnyItemHovered())) {
+        if (ImGui::IsMouseClicked(ImGuiMouseButton_Right) &&
+            !ImGui::IsAnyItemFocused() && !ImGui::IsAnyItemHovered()) {
             g_scene_mgr.PushScene(g_popup_menu);
         } else if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
             xemu_toggle_fullscreen();
-        }
-
-        bool mod_key_down = ImGui::IsKeyDown(ImGuiKey_ModShift);
-        for (int f_key = 0; f_key < 4; ++f_key) {
-            if (ImGui::IsKeyPressed((enum ImGuiKey)(ImGuiKey_F5 + f_key))) {
-                ActionActivateBoundSnapshot(f_key, mod_key_down);
-                break;
-            }
         }
     }
 

--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -27,6 +27,7 @@
 #include "actions.hh"
 #include "compat.hh"
 #include "update.hh"
+#include "system-actions-manager.hh"
 #include "../xemu-os-utils.h"
 
 extern float g_main_menu_height; // FIXME
@@ -43,36 +44,8 @@ bool g_capture_renderdoc_frame = false;
 
 void ProcessKeyboardShortcuts(void)
 {
-    if (IsShortcutKeyPressed(ImGuiKey_E)) {
-        ActionEjectDisc();
-    }
-
-    if (IsShortcutKeyPressed(ImGuiKey_O)) {
-        ActionLoadDisc();
-    }
-
-    if (IsShortcutKeyPressed(ImGuiKey_P)) {
-        ActionTogglePause();
-    }
-
-    if (IsShortcutKeyPressed(ImGuiKey_R)) {
-        ActionReset();
-    }
-
-    if (IsShortcutKeyPressed(ImGuiKey_Q)) {
-        ActionShutdown();
-    }
-
-    if (ImGui::IsKeyPressed(ImGuiKey_GraveAccent)) {
-        monitor_window.ToggleOpen();
-    }
-
-    if (ImGui::IsKeyPressed(ImGuiKey_F12)) {
-        ActionScreenshot();
-    }
-
-    if (ImGui::IsKeyPressed(ImGuiKey_F11)) {
-        xemu_toggle_fullscreen();
+    if (!g_main_menu.IsInputRebinding()) {
+        SystemActionsManager::HandleKeyboard();
     }
 
 #ifdef CONFIG_RENDERDOC

--- a/ui/xui/meson.build
+++ b/ui/xui/meson.build
@@ -18,6 +18,7 @@ xemu_ss.add(files(
   'scene-manager.cc',
   'scene.cc',
   'snapshot-manager.cc',
+  'system-actions-manager.cc',
   'viewport-manager.cc',
   'welcome.cc',
   'widgets.cc',

--- a/ui/xui/system-actions-manager.cc
+++ b/ui/xui/system-actions-manager.cc
@@ -1,0 +1,203 @@
+//
+// xemu User Interface
+//
+// Copyright (C) 2026 Matt Borgerson
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "system-actions-manager.hh"
+#include "actions.hh"
+#include "main-menu.hh"
+#include "popup-menu.hh"
+#include "monitor.hh"
+#include "scene-manager.hh"
+#include "xemu-hud.h"
+#include "../xemu-settings.h"
+#include "../xemu-input.h"
+
+#include <imgui.h>
+#include <imgui_impl_sdl3.h>
+
+IMGUI_IMPL_API ImGuiKey
+ImGui_ImplSDL3_KeyEventToImGuiKey(SDL_Keycode keycode, SDL_Scancode scancode);
+
+void SystemActionsManager::InitInstance()
+{
+    m_bindings.clear();
+
+    auto add_binding =
+        [this](const char *name, const int &scancode, const bool &ctrl,
+               const bool &shift, const bool &alt, const bool &super,
+               std::vector<std::reference_wrapper<const int>> chords,
+               std::function<void()> cb) {
+            m_bindings.push_back({ name, std::cref(scancode), std::cref(ctrl),
+                                   std::cref(shift), std::cref(alt),
+                                   std::cref(super), std::move(chords), cb });
+        };
+
+#define ADD_ACTION(NAME, CALLBACK)                                            \
+    add_binding(                                                              \
+        #NAME, g_config.input.system_actions.NAME.scancode,                   \
+        g_config.input.system_actions.NAME.ctrl,                              \
+        g_config.input.system_actions.NAME.shift,                             \
+        g_config.input.system_actions.NAME.alt,                               \
+        g_config.input.system_actions.NAME.super,                             \
+        { std::cref(g_config.input.system_actions.NAME.controller_chord_1),   \
+          std::cref(g_config.input.system_actions.NAME.controller_chord_2) }, \
+        CALLBACK)
+
+    ADD_ACTION(toggle_pause, ActionTogglePause);
+    ADD_ACTION(reset, ActionReset);
+    ADD_ACTION(power_off, ActionShutdown);
+    ADD_ACTION(eject_disc, ActionEjectDisc);
+    ADD_ACTION(load_disc, ActionLoadDisc);
+    ADD_ACTION(screenshot, ActionScreenshot);
+    ADD_ACTION(toggle_fullscreen, xemu_toggle_fullscreen);
+    ADD_ACTION(toggle_monitor, [] { monitor_window.ToggleOpen(); });
+    auto is_ui_busy = [] {
+        return ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow) ||
+               g_scene_mgr.IsDisplayingScene();
+    };
+
+    ADD_ACTION(toggle_main_menu, [is_ui_busy] {
+        if (!is_ui_busy()) {
+            g_scene_mgr.PushScene(g_main_menu);
+        }
+    });
+    ADD_ACTION(toggle_popup_menu, [is_ui_busy] {
+        if (!is_ui_busy()) {
+            g_scene_mgr.PushScene(g_popup_menu);
+        }
+    });
+    ADD_ACTION(snapshot_load_1, [is_ui_busy] {
+        if (!is_ui_busy()) {
+            ActionActivateBoundSnapshot(0, false);
+        }
+    });
+    ADD_ACTION(snapshot_load_2, [is_ui_busy] {
+        if (!is_ui_busy()) {
+            ActionActivateBoundSnapshot(1, false);
+        }
+    });
+    ADD_ACTION(snapshot_load_3, [is_ui_busy] {
+        if (!is_ui_busy()) {
+            ActionActivateBoundSnapshot(2, false);
+        }
+    });
+    ADD_ACTION(snapshot_load_4, [is_ui_busy] {
+        if (!is_ui_busy()) {
+            ActionActivateBoundSnapshot(3, false);
+        }
+    });
+    ADD_ACTION(snapshot_save_1, [is_ui_busy] {
+        if (!is_ui_busy()) {
+            ActionActivateBoundSnapshot(0, true);
+        }
+    });
+    ADD_ACTION(snapshot_save_2, [is_ui_busy] {
+        if (!is_ui_busy()) {
+            ActionActivateBoundSnapshot(1, true);
+        }
+    });
+    ADD_ACTION(snapshot_save_3, [is_ui_busy] {
+        if (!is_ui_busy()) {
+            ActionActivateBoundSnapshot(2, true);
+        }
+    });
+    ADD_ACTION(snapshot_save_4, [is_ui_busy] {
+        if (!is_ui_busy()) {
+            ActionActivateBoundSnapshot(3, true);
+        }
+    });
+
+#undef ADD_ACTION
+
+    m_prev_controller_buttons = 0;
+    m_suppressed = false;
+    m_initialized = true;
+}
+
+bool SystemActionsManager::HandleKeyboardShortcuts()
+{
+    if (!m_initialized || m_suppressed) {
+        return false;
+    }
+
+    ImGuiIO &io = ImGui::GetIO();
+    if (io.WantCaptureKeyboard) {
+        return false;
+    }
+
+    bool action_invoked = false;
+
+    for (const auto &b : m_bindings) {
+        if (b.scancode.get() == 0) {
+            continue;
+        }
+
+        SDL_Keycode keycode = SDL_GetKeyFromScancode(
+            (SDL_Scancode)b.scancode.get(), SDL_KMOD_NONE, false);
+        ImGuiKey key = ImGui_ImplSDL3_KeyEventToImGuiKey(
+            keycode, (SDL_Scancode)b.scancode.get());
+
+        if (key == ImGuiKey_None || !ImGui::IsKeyPressed(key)) {
+            continue;
+        }
+
+        if (b.ctrl.get() != io.KeyCtrl || b.shift.get() != io.KeyShift ||
+            b.alt.get() != io.KeyAlt || b.super.get() != io.KeySuper) {
+            continue;
+        }
+
+        if (b.callback) {
+            b.callback();
+            action_invoked = true;
+        }
+    }
+
+    return action_invoked;
+}
+
+bool SystemActionsManager::HandleControllerShortcuts(unsigned int buttons)
+{
+    if (!m_initialized || m_suppressed) {
+        return false;
+    }
+
+    bool action_invoked = false;
+
+    for (const auto &b : m_bindings) {
+        for (const auto &chord_ref : b.controller_chords) {
+            auto chord_mask = static_cast<unsigned int>(chord_ref.get());
+
+            if (chord_mask == 0) {
+                continue;
+            }
+
+            bool chord_active = (buttons & chord_mask) == chord_mask;
+            bool chord_was_active =
+                (m_prev_controller_buttons & chord_mask) == chord_mask;
+
+            if (chord_active && !chord_was_active) {
+                if (b.callback) {
+                    b.callback();
+                    action_invoked = true;
+                }
+            }
+        }
+    }
+
+    m_prev_controller_buttons = buttons;
+    return action_invoked;
+}

--- a/ui/xui/system-actions-manager.hh
+++ b/ui/xui/system-actions-manager.hh
@@ -1,0 +1,86 @@
+//
+// xemu User Interface
+//
+// Copyright (C) 2026 Matt Borgerson
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#pragma once
+
+#include <string>
+#include <vector>
+#include <functional>
+#include <cstdint>
+#include <SDL3/SDL.h>
+
+struct SystemActionBinding {
+    std::string name;
+    std::reference_wrapper<const int> scancode;
+    std::reference_wrapper<const bool> ctrl;
+    std::reference_wrapper<const bool> shift;
+    std::reference_wrapper<const bool> alt;
+    std::reference_wrapper<const bool> super;
+    std::vector<std::reference_wrapper<const int>> controller_chords;
+    std::function<void()> callback;
+};
+
+class SystemActionsManager {
+private:
+    std::vector<SystemActionBinding> m_bindings{};
+    unsigned int m_prev_controller_buttons = 0;
+    bool m_initialized = false;
+    bool m_suppressed = false;
+
+    static SystemActionsManager &GetInstance()
+    {
+        static SystemActionsManager instance;
+        return instance;
+    }
+
+    SystemActionsManager() = default;
+
+    void InitInstance();
+    bool HandleKeyboardShortcuts();
+    bool HandleControllerShortcuts(unsigned int buttons);
+    void SetSuppressedInstance(bool suppressed)
+    {
+        m_suppressed = suppressed;
+    }
+    bool IsSuppressedInstance() const
+    {
+        return m_suppressed;
+    }
+
+public:
+    static void Init()
+    {
+        GetInstance().InitInstance();
+    }
+    static bool HandleKeyboard()
+    {
+        return GetInstance().HandleKeyboardShortcuts();
+    }
+    static bool HandleController(unsigned int buttons)
+    {
+        return GetInstance().HandleControllerShortcuts(buttons);
+    }
+    static void SetSuppressed(bool suppressed)
+    {
+        GetInstance().SetSuppressedInstance(suppressed);
+    }
+    static bool IsSuppressed()
+    {
+        return GetInstance().IsSuppressedInstance();
+    }
+};


### PR DESCRIPTION
This change introduces a `SystemActionsManager` to facilitate rebindable keyboard/controller invocation of emulator actions.

Partially addresses #362 - I think we can leave it open until somebody writes a GUI to facilitate remapping
Fixes #1654