### PR TITLE
Fix 2906 memory leak in slow vga path

### DIFF
--- a/hw/xbox/nv2a/pgraph/null/renderer.c
+++ b/hw/xbox/nv2a/pgraph/null/renderer.c
@@ -17,10 +17,30 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "qemu/osdep.h"
+#include "renderer.h"
+
 #include "qemu/thread.h"
-#include "hw/hw.h"
 #include "hw/xbox/nv2a/nv2a_int.h"
+
+static void pgraph_null_init(NV2AState *d, Error **errp)
+{
+    PGRAPHState *pg = &d->pgraph;
+
+    pg->null_renderer_state = g_malloc0(sizeof(*pg->null_renderer_state));
+}
+
+static void pgraph_null_finalize(NV2AState *d)
+{
+    PGRAPHState *pg = &d->pgraph;
+    PGRAPHNullState *r = pg->null_renderer_state;
+    if (r) {
+        if (r->blank_texture) {
+            glDeleteTextures(1, &r->blank_texture);
+        }
+        g_free(r);
+        pg->null_renderer_state = NULL;
+    }
+}
 
 static void pgraph_null_sync(NV2AState *d)
 {
@@ -111,34 +131,56 @@ static void pgraph_null_surface_update(NV2AState *d, bool upload,
 {
 }
 
-static void pgraph_null_init(NV2AState *d, Error **errp)
+static int pgraph_null_get_framebuffer_surface(NV2AState *d)
 {
     PGRAPHState *pg = &d->pgraph;
-    pg->null_renderer_state = NULL;
+    PGRAPHNullState *r = pg->null_renderer_state;
+    if (r) {
+        if (!r->blank_texture) {
+            static const uint8_t black_pixel[4] = { 0, 0, 0, 255 };
+            glGenTextures(1, &r->blank_texture);
+            glBindTexture(GL_TEXTURE_2D, r->blank_texture);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA,
+                         GL_UNSIGNED_BYTE, black_pixel);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        }
+
+        return r->blank_texture;
+    }
+
+    return 0;
 }
 
-static PGRAPHRenderer pgraph_null_renderer = {
-    .type = CONFIG_DISPLAY_RENDERER_NULL,
-    .name = "Null",
-    .ops = {
-        .init = pgraph_null_init,
-        .clear_report_value = pgraph_null_clear_report_value,
-        .clear_surface = pgraph_null_clear_surface,
-        .draw_begin = pgraph_null_draw_begin,
-        .draw_end = pgraph_null_draw_end,
-        .flip_stall = pgraph_null_flip_stall,
-        .flush_draw = pgraph_null_flush_draw,
-        .get_report = pgraph_null_get_report,
-        .image_blit = pgraph_null_image_blit,
-        .pre_savevm_trigger = pgraph_null_pre_savevm_trigger,
-        .pre_savevm_wait = pgraph_null_pre_savevm_wait,
-        .pre_shutdown_trigger = pgraph_null_pre_shutdown_trigger,
-        .pre_shutdown_wait = pgraph_null_pre_shutdown_wait,
-        .process_pending = pgraph_null_process_pending,
-        .process_pending_reports = pgraph_null_process_pending_reports,
-        .surface_update = pgraph_null_surface_update,
-    }
-};
+static PGRAPHRenderer
+    pgraph_null_renderer = { .type = CONFIG_DISPLAY_RENDERER_NULL,
+                             .name = "Null",
+                             .ops = {
+                                 .init = pgraph_null_init,
+                                 .finalize = pgraph_null_finalize,
+                                 .clear_report_value =
+                                     pgraph_null_clear_report_value,
+                                 .clear_surface = pgraph_null_clear_surface,
+                                 .draw_begin = pgraph_null_draw_begin,
+                                 .draw_end = pgraph_null_draw_end,
+                                 .flip_stall = pgraph_null_flip_stall,
+                                 .flush_draw = pgraph_null_flush_draw,
+                                 .get_report = pgraph_null_get_report,
+                                 .image_blit = pgraph_null_image_blit,
+                                 .pre_savevm_trigger =
+                                     pgraph_null_pre_savevm_trigger,
+                                 .pre_savevm_wait = pgraph_null_pre_savevm_wait,
+                                 .pre_shutdown_trigger =
+                                     pgraph_null_pre_shutdown_trigger,
+                                 .pre_shutdown_wait =
+                                     pgraph_null_pre_shutdown_wait,
+                                 .process_pending = pgraph_null_process_pending,
+                                 .process_pending_reports =
+                                     pgraph_null_process_pending_reports,
+                                 .surface_update = pgraph_null_surface_update,
+                                 .get_framebuffer_surface =
+                                     pgraph_null_get_framebuffer_surface,
+                             } };
 
 static void __attribute__((constructor)) register_renderer(void)
 {

--- a/hw/xbox/nv2a/pgraph/null/renderer.h
+++ b/hw/xbox/nv2a/pgraph/null/renderer.h
@@ -1,0 +1,30 @@
+/*
+ * Geforce NV2A PGRAPH NULL Renderer
+ *
+ * Copyright (c) 2026 Matt Borgerson
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef HW_XBOX_NV2A_PGRAPH_NULL_RENDERER_H
+#define HW_XBOX_NV2A_PGRAPH_NULL_RENDERER_H
+
+#include "qemu/osdep.h"
+#include <epoxy/gl.h>
+
+struct PGRAPHNullState {
+    GLuint blank_texture;
+};
+
+#endif // HW_XBOX_NV2A_PGRAPH_NULL_RENDERER_H

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -669,13 +669,21 @@ static void xb_surface_gl_create_texture(DisplaySurface *surface)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 }
 
-static void xb_surface_gl_destroy_texture(DisplaySurface *surface)
+static void xb_surface_gl_destroy_texture(GLuint texture, DisplaySurface *surface)
 {
-    if (!surface || !surface->texture) {
+    if (!texture) {
         return;
     }
-    glDeleteTextures(1, &surface->texture);
-    surface->texture = 0;
+
+    glDeleteTextures(1, &texture);
+
+    // It is possible that the surface that was used during the call to
+    // xb_surface_gl_create_texture has been overwritten by the vsync thread.
+    // Both paths are guarded by the main loop lock so a trivial check before
+    // clearing the texture name is sufficient.
+    if (surface->texture == texture) {
+        surface->texture = 0;
+    }
 }
 
 static bool xb_console_gl_check_format(DisplayChangeListener *dcl,
@@ -855,7 +863,7 @@ static void gl_render_frame(struct xemu_console *scon)
 
     if (release_surface_texture) {
         xemu_main_loop_lock();
-        xb_surface_gl_destroy_texture(scon->surface);
+        xb_surface_gl_destroy_texture(tex, scon->surface);
         xemu_main_loop_unlock();
     }
 


### PR DESCRIPTION
 PR #2691 decoupled the guest vblank handling from xemu GUI updates. This introduced a condition where the vblank timer may fire during a call to  `gl_render_frame`.
    
In cases where `gl_render_frame` falls back to creating a local texture (e.g., direct writes to the framebuffer by the guest or every frame when using the null renderer backend) this creates a race where the surface initiated by the slow path fallback may be mutated by the vblank timer thread before the paired call to `xb_surface_gl_destroy_texture`, leaking the created texture.
    
When using the null renderer with the UI at 60 fps, this happens extremely often, creating a very noticeable memory leak.
    
This PR ensures that the texture is always deleted, even if the surface is updated before the destroy call.
    
As a bonus, the second commit creates a blank texture in the null renderer which is reused for every frame, bypassing the churn of creating and immediately destroying textures in `gl_render_frame`'s fallback path. For clarity, I've verified that the first commit alone resolves the memory leak, this is just a further optimization and is not masking the leak.

Fixes #2906
