### PR TITLE
nv2a/vk: fix infinite loop selecting compute workgroup size

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/instance.c
+++ b/hw/xbox/nv2a/pgraph/vk/instance.c
@@ -419,6 +419,9 @@ static bool select_physical_device(PGRAPHState *pg, Error **errp)
     }
 
     vkGetPhysicalDeviceProperties(r->physical_device, &r->device_props);
+    r->max_1d_compute_group_size =
+        MIN(r->device_props.limits.maxComputeWorkGroupSize[0],
+            r->device_props.limits.maxComputeWorkGroupInvocations);
     xemu_settings_set_string(&g_config.display.vulkan.preferred_physical_device,
                              r->device_props.deviceName);
     r->vk_api_version = MIN(r->vk_api_version, r->device_props.apiVersion);

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -331,6 +331,7 @@ typedef struct PGRAPHVkState {
     VkPhysicalDevice physical_device;
     VkPhysicalDeviceFeatures enabled_physical_device_features;
     VkPhysicalDeviceProperties device_props;
+    uint32_t max_1d_compute_group_size;
     VkDevice device;
     VmaAllocator allocator;
     uint32_t allocator_last_submit_index;

--- a/hw/xbox/nv2a/pgraph/vk/surface-compute.c
+++ b/hw/xbox/nv2a/pgraph/vk/surface-compute.c
@@ -334,19 +334,13 @@ void pgraph_vk_compute_finish_complete(PGRAPHVkState *r)
 
 static int get_workgroup_size_for_output_units(PGRAPHVkState *r, int output_units)
 {
-    int group_size = 1024;
-
     // FIXME: Smarter workgroup size calculation could factor in multiple
     //        submissions. For now we will just pick the highest number that
     //        evenly divides output_units.
 
-    while (group_size > 1) {
-        if (group_size > r->device_props.limits.maxComputeWorkGroupSize[0]) {
-            continue;
-        }
-        if (output_units % group_size == 0) {
-            break;
-        }
+    int group_size = 1024;
+    while (group_size > 1 && (group_size > r->max_1d_compute_group_size ||
+                              output_units % group_size != 0)) {
         group_size /= 2;
     }
 


### PR DESCRIPTION
The workgroup-size selection loop in `surface-compute.c` starts at 1024 and
halves until it divides the output unit count:

```c
while (group_size > 1) {
    if (group_size > r->device_props.limits.maxComputeWorkGroupSize[0]) {
        continue;   /* skips the only decrement */
    }
    ...
    group_size /= 2;
}
```

When the device reports `maxComputeWorkGroupSize[0]` below the starting
value, the `continue` bypasses the only `group_size /= 2`, so the loop never
terminates and the emulator hangs at surface conversion. This is reachable on
real hardware: V3DV (Raspberry Pi 5) reports 256 for both
`maxComputeWorkGroupSize[0]` and `maxComputeWorkGroupInvocations`.

Clamp the starting size to both device limits before searching. On desktop
drivers that report 1024 or more, the clamp is a no-op and behaviour is
unchanged; on smaller GPUs the loop terminates and the compute path works.

Found and verified on a Raspberry Pi 5 (V3DV / Mesa Vulkan 1.2), where Halo 2
reaches gameplay with this fix and hangs at first surface download without it.
