### PR TITLE
ui/gl: survive limited desktop OpenGL

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/gpuprops.c
+++ b/hw/xbox/nv2a/pgraph/gl/gpuprops.c
@@ -109,7 +109,8 @@ static GLuint compile_shader(GLenum type, const char *source)
         log[sizeof(log) - 1] = '\0';
         fprintf(stderr, "GL shader type %d compilation failed: %s\n", type,
                 log);
-        assert(!"GL shader compilation failed");
+        glDeleteShader(shader);
+        return 0;
     }
 
     return shader;
@@ -121,12 +122,22 @@ static GLuint create_program(const char *vert_source, const char *geom_source,
     GLuint vert_shader = compile_shader(GL_VERTEX_SHADER, vert_source);
     GLuint geom_shader = compile_shader(GL_GEOMETRY_SHADER, geom_source);
     GLuint frag_shader = compile_shader(GL_FRAGMENT_SHADER, frag_source);
+    if (!vert_shader || !geom_shader || !frag_shader) {
+        glDeleteShader(vert_shader);
+        glDeleteShader(geom_shader);
+        glDeleteShader(frag_shader);
+        return 0;
+    }
 
     GLuint shader_prog = glCreateProgram();
     glAttachShader(shader_prog, vert_shader);
     glAttachShader(shader_prog, geom_shader);
     glAttachShader(shader_prog, frag_shader);
     glLinkProgram(shader_prog);
+
+    glDeleteShader(vert_shader);
+    glDeleteShader(geom_shader);
+    glDeleteShader(frag_shader);
 
     GLint success;
     glGetProgramiv(shader_prog, GL_LINK_STATUS, &success);
@@ -135,12 +146,9 @@ static GLuint create_program(const char *vert_source, const char *geom_source,
         glGetProgramInfoLog(shader_prog, sizeof(log), NULL, log);
         log[sizeof(log) - 1] = '\0';
         fprintf(stderr, "GL shader linking failed: %s\n", log);
-        assert(!"GL shader linking failed");
+        glDeleteProgram(shader_prog);
+        return 0;
     }
-
-    glDeleteShader(vert_shader);
-    glDeleteShader(geom_shader);
-    glDeleteShader(frag_shader);
 
     return shader_prog;
 }
@@ -181,7 +189,12 @@ static uint8_t *render_geom_shader_triangles(int width, int height)
 
     GLuint shader_prog = create_program(
         vertex_shader_source, geometry_shader_source, fragment_shader_source);
-    assert(shader_prog != 0);
+    if (shader_prog == 0) {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glDeleteRenderbuffers(1, &rbo);
+        glDeleteFramebuffers(1, &fbo);
+        return NULL;
+    }
 
     glUseProgram(shader_prog);
     check_gl_error("glUseProgram");
@@ -339,6 +352,12 @@ void pgraph_gl_determine_gpu_properties(void)
     const int height = 480;
 
     uint8_t *pixels = render_geom_shader_triangles(width, height);
+    if (pixels == NULL) {
+        fprintf(stderr,
+                "GL geometry shader probe unavailable; using defaults\n");
+        return;
+    }
+
     determine_triangle_winding_order(pixels, width, height,
                                      &pgraph_gl_gpu_properties);
     g_free(pixels);

--- a/hw/xbox/nv2a/pgraph/gl/gpuprops.c
+++ b/hw/xbox/nv2a/pgraph/gl/gpuprops.c
@@ -353,10 +353,11 @@ void pgraph_gl_determine_gpu_properties(void)
 
     uint8_t *pixels = render_geom_shader_triangles(width, height);
     if (pixels == NULL) {
-        fprintf(stderr,
-                "GL geometry shader probe unavailable; using defaults\n");
+        fprintf(stderr, "GL geometry shader probe failed\n");
+        pgraph_gl_gpu_properties.valid = false;
         return;
     }
+    pgraph_gl_gpu_properties.valid = true;
 
     determine_triangle_winding_order(pixels, width, height,
                                      &pgraph_gl_gpu_properties);

--- a/hw/xbox/nv2a/pgraph/gl/gpuprops.c
+++ b/hw/xbox/nv2a/pgraph/gl/gpuprops.c
@@ -25,7 +25,7 @@
 static GPUProperties pgraph_gl_gpu_properties;
 
 static const char *vertex_shader_source =
-    "#version 400\n"
+    PROBE_GLSL_VERSION_DIRECTIVE
     "out vec3 v_fragColor;\n"
     "\n"
     "vec2 positions[11] = vec2[](\n"
@@ -62,7 +62,7 @@ static const char *vertex_shader_source =
     "}\n";
 
 static const char *geometry_shader_source =
-    "#version 400\n"
+    PROBE_GLSL_VERSION_DIRECTIVE
     "layout(triangles) in;\n"
     "layout(triangle_strip, max_vertices = 3) out;\n"
     "out vec3 fragColor;\n"
@@ -87,7 +87,7 @@ static const char *geometry_shader_source =
     "}\n";
 
 static const char *fragment_shader_source =
-    "#version 400\n"
+    PROBE_GLSL_VERSION_DIRECTIVE
     "out vec4 outColor;\n"
     "in vec3 fragColor;\n"
     "\n"

--- a/hw/xbox/nv2a/pgraph/gl/renderer.c
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.c
@@ -46,6 +46,13 @@ static void pgraph_gl_init(NV2AState *d, Error **errp)
 {
     PGRAPHState *pg = &d->pgraph;
 
+    if (!pgraph_gl_get_gpu_properties()->valid) {
+        error_setg(errp,
+                   "OpenGL renderer unavailable: GPU capability probe failed "
+                   "(OpenGL 4.0 support is required)");
+        return;
+    }
+
     pg->gl_renderer_state = g_malloc0(sizeof(*pg->gl_renderer_state));
     PGRAPHGLState *r = pg->gl_renderer_state;
 

--- a/hw/xbox/nv2a/pgraph/gl/renderer.c
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.c
@@ -49,7 +49,7 @@ static void pgraph_gl_init(NV2AState *d, Error **errp)
     if (!pgraph_gl_get_gpu_properties()->valid) {
         error_setg(errp,
                    "OpenGL renderer unavailable: GPU capability probe failed "
-                   "(OpenGL 4.0 support is required)");
+                   "(OpenGL " PROBE_GL_VERSION_STRING " support is required)");
         return;
     }
 

--- a/hw/xbox/nv2a/pgraph/gl/renderer.h
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.h
@@ -293,6 +293,9 @@ unsigned int pgraph_gl_get_surface_scale_factor(NV2AState *d);
 int pgraph_gl_get_framebuffer_surface(NV2AState *d);
 /**  Note: The caller must set up a clean GL context before invoking. */
 void pgraph_gl_determine_gpu_properties(void);
+#define PROBE_GLSL_VERSION_DIRECTIVE "#version 400\n"
+#define PROBE_GL_VERSION_STRING "4.0"
+
 GPUProperties *pgraph_gl_get_gpu_properties(void);
 
 #endif

--- a/hw/xbox/nv2a/pgraph/pgraph.c
+++ b/hw/xbox/nv2a/pgraph/pgraph.c
@@ -321,18 +321,26 @@ static void init_renderer(PGRAPHState *pg)
         return;  // Success
     }
 
-    CONFIG_DISPLAY_RENDERER default_renderer = get_default_renderer();
-    if (default_renderer != g_config.display.renderer) {
-        g_config.display.renderer = default_renderer;
+    static const CONFIG_DISPLAY_RENDERER fallback_order[] = {
+        CONFIG_DISPLAY_RENDERER_OPENGL,
+        CONFIG_DISPLAY_RENDERER_VULKAN,
+        CONFIG_DISPLAY_RENDERER_NULL,
+    };
+    CONFIG_DISPLAY_RENDERER failed = g_config.display.renderer;
+
+    for (int i = 0; i < ARRAY_SIZE(fallback_order); i++) {
+        CONFIG_DISPLAY_RENDERER candidate = fallback_order[i];
+        if (candidate == failed || !renderers[candidate]) {
+            continue;
+        }
+        g_config.display.renderer = candidate;
         if (attempt_renderer_init(pg)) {
             g_autofree gchar *msg = g_strdup_printf(
-                "Switched to default renderer: %s", pg->renderer->name);
+                "Switched to %s renderer", pg->renderer->name);
             xemu_queue_notification(msg);
             return;
         }
     }
-
-    // FIXME: Try others
 
     fprintf(stderr, "Fatal error: cannot initialize renderer\n");
     exit(1);

--- a/hw/xbox/nv2a/pgraph/pgraph.h
+++ b/hw/xbox/nv2a/pgraph/pgraph.h
@@ -97,6 +97,7 @@ typedef struct BetaState {
 } BetaState;
 
 typedef struct GPUProperties {
+    bool valid;
     struct {
         short tri;
         short tri_strip0;

--- a/ui/xui/gl-helpers.cc
+++ b/ui/xui/gl-helpers.cc
@@ -240,8 +240,8 @@ uniform sampler2D tex;
 uniform uint palette[256];
 float gamma_ch(int ch, float col)
 {
-    uint packed = palette[uint(col * 255.0)];
-    return float((packed >> uint(ch * 8)) & 0xFFu) / 255.0;
+    uint entry = palette[uint(col * 255.0)];
+    return float((entry >> uint(ch * 8)) & 0xFFu) / 255.0;
 }
 
 vec4 gamma(vec4 col)

--- a/ui/xui/gl-helpers.cc
+++ b/ui/xui/gl-helpers.cc
@@ -293,6 +293,19 @@ void main() {
     glAttachShader(s->prog, frag);
     glBindFragDataLocation(s->prog, 0, "out_Color");
     glLinkProgram(s->prog);
+
+    GLint link_status;
+    glGetProgramiv(s->prog, GL_LINK_STATUS, &link_status);
+    if (link_status != GL_TRUE) {
+        char link_err[1024];
+        glGetProgramInfoLog(s->prog, sizeof(link_err), NULL, link_err);
+        fprintf(stderr,
+                "NewDecalShader: shader program link failed: %s\n"
+                "--- vertex source ---\n%s\n"
+                "--- fragment source ---\n%s\n",
+                link_err, vert_src, frag_src ? frag_src : "(null)");
+        assert(!"NewDecalShader: shader program link failed");
+    }
     glUseProgram(s->prog);
 
     // Flag shaders for deletion when program is deleted

--- a/ui/xui/gl-helpers.cc
+++ b/ui/xui/gl-helpers.cc
@@ -207,7 +207,7 @@ DecalShader *NewDecalShader(enum ShaderType type)
     s->time = 0;
 
     const char *vert_src = R"(
-#version 150 core
+#version 140
 uniform bool in_FlipY;
 uniform vec4 in_ScaleOffset;
 uniform vec4 in_TexScaleOffset;
@@ -235,12 +235,13 @@ void main() {
     // )";
 
     const char *image_gamma_frag_src = R"(
-#version 400 core
+#version 140
 uniform sampler2D tex;
 uniform uint palette[256];
 float gamma_ch(int ch, float col)
 {
-    return float(bitfieldExtract(palette[uint(col * 255.0)], ch*8, 8)) / 255.0;
+    uint packed = palette[uint(col * 255.0)];
+    return float((packed >> uint(ch * 8)) & 0xFFu) / 255.0;
 }
 
 vec4 gamma(vec4 col)
@@ -261,7 +262,7 @@ void main() {
     // - Blue is a lazy alpha removal for now
     // - Alpha channel passed through
     const char *mask_frag_src = R"(
-#version 150 core
+#version 140
 uniform sampler2D tex;
 uniform vec4 in_ColorPrimary;
 uniform vec4 in_ColorSecondary;


### PR DESCRIPTION
Two small robustness fixes for hosts with limited desktop OpenGL:

- The GPU property probe (geometry shader winding detection) aborted startup
  when its GLSL 4.00 shaders failed to compile. Fall back to defaults and
  continue; drivers capped below GL 4 (e.g. Mesa V3D at 3.1) can otherwise
  never reach the renderer selection.
- Shader program link status was unchecked, so a failed link surfaced later
  as a crash with no diagnostic. Check it and report the info log.

No behaviour change on drivers where the probe and links succeed.
