### PR TITLE
tcg/aarch64: emulate guest TSO with acquire/release accesses

### DIFF
--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -344,6 +344,24 @@ TranslationBlock *tb_gen_code(CPUState *cpu, TCGTBCPUState s)
     tcg_ctx->addr_type = target_long_bits() == 32 ? TCG_TYPE_I32 : TCG_TYPE_I64;
     tcg_ctx->guest_mo = cpu->cc->tcg_ops->guest_default_memory_order;
 
+#ifdef __aarch64__
+    {
+        static int tso = -1;
+        if (tso < 0) {
+            tso = getenv("XEMU_TSO") != NULL;
+            if (tso) {
+                fprintf(stderr,
+                        "tcg: guest TSO via acquire/release accesses "
+                        "(XEMU_TSO)\n");
+            }
+        }
+        if (tso) {
+            tcg_qemu_tso_lowering = true;
+            tcg_ctx->guest_mo = 0;
+        }
+    }
+#endif
+
  restart_translate:
     trace_translate_block(tb, s.pc, tb->tc.ptr);
 

--- a/include/tcg/tcg.h
+++ b/include/tcg/tcg.h
@@ -480,6 +480,8 @@ extern bool tcg_use_softmmu;
 #endif
 
 extern __thread TCGContext *tcg_ctx;
+
+extern bool tcg_qemu_tso_lowering;
 extern const void *tcg_code_gen_epilogue;
 extern uintptr_t tcg_splitwx_diff;
 extern TCGv_env tcg_env;

--- a/tcg/aarch64/tcg-target.c.inc
+++ b/tcg/aarch64/tcg-target.c.inc
@@ -458,6 +458,15 @@ typedef enum {
     I3312_LDRVQ     = 0x3c000000 | 3 << 22 | 0 << 30,
     I3312_STRVQ     = 0x3c000000 | 2 << 22 | 0 << 30,
 
+    I3308_LDAPRB    = 0x38bfc000,
+    I3308_LDAPRH    = 0x78bfc000,
+    I3308_LDAPRW    = 0xb8bfc000,
+    I3308_LDAPRX    = 0xf8bfc000,
+    I3308_STLRB     = 0x089ffc00,
+    I3308_STLRH     = 0x489ffc00,
+    I3308_STLRW     = 0x889ffc00,
+    I3308_STLRX     = 0xc89ffc00,
+
     I3312_TO_I3310  = 0x00200800,
     I3312_TO_I3313  = 0x01000000,
 
@@ -1612,7 +1621,13 @@ static bool tcg_out_qemu_ld_slow_path(TCGContext *s, TCGLabelQemuLdst *lb)
     }
 
     tcg_out_ld_helper_args(s, lb, &ldst_helper_param);
+    if (tcg_qemu_tso_lowering) {
+        tcg_out_mb(s, TCG_MO_ALL);
+    }
     tcg_out_call_int(s, qemu_ld_helpers[opc & MO_SIZE]);
+    if (tcg_qemu_tso_lowering) {
+        tcg_out_mb(s, TCG_MO_ALL);
+    }
     tcg_out_ld_helper_ret(s, lb, false, &ldst_helper_param);
     tcg_out_goto(s, lb->raddr);
     return true;
@@ -1627,7 +1642,13 @@ static bool tcg_out_qemu_st_slow_path(TCGContext *s, TCGLabelQemuLdst *lb)
     }
 
     tcg_out_st_helper_args(s, lb, &ldst_helper_param);
+    if (tcg_qemu_tso_lowering) {
+        tcg_out_mb(s, TCG_MO_ALL);
+    }
     tcg_out_call_int(s, qemu_st_helpers[opc & MO_SIZE]);
+    if (tcg_qemu_tso_lowering) {
+        tcg_out_mb(s, TCG_MO_ALL);
+    }
     tcg_out_goto(s, lb->raddr);
     return true;
 }
@@ -1749,9 +1770,99 @@ static TCGLabelQemuLdst *prepare_host_addr(TCGContext *s, HostAddress *h,
     return ldst;
 }
 
+static TCGReg compose_ordered_addr(TCGContext *s, HostAddress h)
+{
+    if (h.index == TCG_REG_XZR) {
+        return h.base;
+    }
+    if (h.index_ext == TCG_TYPE_I32) {
+        tcg_out_insn(s, 3501, ADD, TCG_TYPE_I64, TCG_REG_TMP2, h.base,
+                     h.index, MO_32, 0);
+    } else {
+        tcg_out_insn(s, 3502, ADD, 1, TCG_REG_TMP2, h.base, h.index);
+    }
+    return TCG_REG_TMP2;
+}
+
+static void tcg_out_qemu_ld_ordered(TCGContext *s, MemOp memop, TCGType ext,
+                                    TCGReg data_r, HostAddress h)
+{
+    TCGReg a = compose_ordered_addr(s, h);
+    MemOp size = memop & MO_SIZE;
+    static const AArch64Insn ldapr[4] = {
+        I3308_LDAPRB, I3308_LDAPRH, I3308_LDAPRW, I3308_LDAPRX,
+    };
+    static const AArch64Insn ldr[4] = {
+        I3312_LDRB, I3312_LDRH, I3312_LDRW, I3312_LDRX,
+    };
+
+    if (size == MO_8) {
+        tcg_out32(s, ldapr[MO_8] | a << 5 | data_r);
+    } else {
+        tcg_insn_unit *br_unal, *br_join;
+
+        tcg_out_logicali(s, I3404_ANDSI, 0, TCG_REG_XZR, a,
+                         (1 << size) - 1);
+        br_unal = s->code_ptr;
+        tcg_out_insn(s, 3202, B_C, TCG_COND_NE, 0);
+
+        tcg_out32(s, ldapr[size] | a << 5 | data_r);
+        br_join = s->code_ptr;
+        tcg_out32(s, I3206_B);
+
+        reloc_pc19(br_unal, tcg_splitwx_to_rx(s->code_ptr));
+        tcg_out_ldst_r(s, ldr[size], data_r, a, TCG_TYPE_I64, TCG_REG_XZR);
+        tcg_out_mb(s, TCG_MO_LD_LD | TCG_MO_LD_ST);
+        reloc_pc26(br_join, tcg_splitwx_to_rx(s->code_ptr));
+    }
+
+    if (memop & MO_SIGN) {
+        tcg_out_sxt(s, (ext || size == MO_32) ? TCG_TYPE_I64 : TCG_TYPE_I32,
+                    size, data_r, data_r);
+    }
+}
+
+static void tcg_out_qemu_st_ordered(TCGContext *s, MemOp memop,
+                                    TCGReg data_r, HostAddress h)
+{
+    TCGReg a = compose_ordered_addr(s, h);
+    MemOp size = memop & MO_SIZE;
+    static const AArch64Insn stlr[4] = {
+        I3308_STLRB, I3308_STLRH, I3308_STLRW, I3308_STLRX,
+    };
+    static const AArch64Insn str[4] = {
+        I3312_STRB, I3312_STRH, I3312_STRW, I3312_STRX,
+    };
+
+    if (size == MO_8) {
+        tcg_out32(s, stlr[MO_8] | a << 5 | data_r);
+        return;
+    }
+
+    tcg_insn_unit *br_unal, *br_join;
+
+    tcg_out_logicali(s, I3404_ANDSI, 0, TCG_REG_XZR, a, (1 << size) - 1);
+    br_unal = s->code_ptr;
+    tcg_out_insn(s, 3202, B_C, TCG_COND_NE, 0);
+
+    tcg_out32(s, stlr[size] | a << 5 | data_r);
+    br_join = s->code_ptr;
+    tcg_out32(s, I3206_B);
+
+    reloc_pc19(br_unal, tcg_splitwx_to_rx(s->code_ptr));
+    tcg_out_mb(s, TCG_MO_ALL);
+    tcg_out_ldst_r(s, str[size], data_r, a, TCG_TYPE_I64, TCG_REG_XZR);
+    reloc_pc26(br_join, tcg_splitwx_to_rx(s->code_ptr));
+}
+
 static void tcg_out_qemu_ld_direct(TCGContext *s, MemOp memop, TCGType ext,
                                    TCGReg data_r, HostAddress h)
 {
+    if (tcg_qemu_tso_lowering) {
+        tcg_out_qemu_ld_ordered(s, memop, ext, data_r, h);
+        return;
+    }
+
     switch (memop & MO_SSIZE) {
     case MO_UB:
         tcg_out_ldst_r(s, I3312_LDRB, data_r, h.base, h.index_ext, h.index);
@@ -1784,6 +1895,11 @@ static void tcg_out_qemu_ld_direct(TCGContext *s, MemOp memop, TCGType ext,
 static void tcg_out_qemu_st_direct(TCGContext *s, MemOp memop,
                                    TCGReg data_r, HostAddress h)
 {
+    if (tcg_qemu_tso_lowering) {
+        tcg_out_qemu_st_ordered(s, memop, data_r, h);
+        return;
+    }
+
     switch (memop & MO_SIZE) {
     case MO_8:
         tcg_out_ldst_r(s, I3312_STRB, data_r, h.base, h.index_ext, h.index);
@@ -1853,6 +1969,10 @@ static void tcg_out_qemu_ldst_i128(TCGContext *s, TCGReg datalo, TCGReg datahi,
     bool use_pair;
 
     ldst = prepare_host_addr(s, &h, addr_reg, oi, is_ld);
+
+    if (tcg_qemu_tso_lowering && !is_ld) {
+        tcg_out_mb(s, TCG_MO_ALL);
+    }
 
     /* Compose the final address, as LDP/STP have no indexing. */
     if (h.index == TCG_REG_XZR) {
@@ -1936,6 +2056,10 @@ static void tcg_out_qemu_ldst_i128(TCGContext *s, TCGReg datalo, TCGReg datahi,
         } else {
             tcg_out_insn(s, 3314, STP, datalo, datahi, base, 0, 1, 0);
         }
+    }
+
+    if (tcg_qemu_tso_lowering && is_ld) {
+        tcg_out_mb(s, TCG_MO_ALL);
     }
 
     if (ldst) {

--- a/tcg/tcg.c
+++ b/tcg/tcg.c
@@ -249,6 +249,7 @@ bool tcg_use_softmmu;
 
 TCGContext tcg_init_ctx;
 __thread TCGContext *tcg_ctx;
+bool tcg_qemu_tso_lowering;
 
 TCGContext **tcg_ctxs;
 unsigned int tcg_cur_ctxs;


### PR DESCRIPTION
Emulating x86's memory model on aarch64 emits a `dmb` before every guest
load and store. Measured on a Raspberry Pi 5 running an x86 guest, those
fences cost roughly a quarter of end-to-end throughput.

This keeps the ordering and drops the fences: guest loads emit LDAPR and
guest stores STLR (RCpc acquire / release, exactly the semantics x86
accesses need). Since both forms are base-register-only and fault on
unaligned addresses without FEAT_LSE2, wider-than-byte accesses test
alignment at run time and fall back to barrier + plain access; the 16-byte
path and TLB-miss helpers keep explicit barriers.

Measured, same binary, fenced vs `XEMU_TSO=1` (Halo 2, bounded runs, equal
guest progress): median frame time −10%, p99 −9%, 1%-low +11%, stutters
−17%. Also validated on GTA San Andreas (steady 60 guest fps) and
Morrowind.

Opt-in via `XEMU_TSO=1` for now; generated code is unchanged without it.
Happy to rework the gate into a config option if there's interest in
promoting it.
