### PR TITLE
i386/tcg: stub rdpmc to return 0 instead of raising #UD

### DIFF
--- a/target/i386/helper.h
+++ b/target/i386/helper.h
@@ -71,7 +71,7 @@ DEF_HELPER_1(rechecking_single_step, void, env)
 DEF_HELPER_1(cpuid, void, env)
 DEF_HELPER_FLAGS_1(rdpid, TCG_CALL_NO_WG, tl, env)
 DEF_HELPER_1(rdtsc, void, env)
-DEF_HELPER_FLAGS_1(rdpmc, TCG_CALL_NO_WG, noreturn, env)
+DEF_HELPER_1(rdpmc, void, env)
 
 #ifndef CONFIG_USER_ONLY
 DEF_HELPER_3(outb, void, env, i32, i32)

--- a/target/i386/tcg/emit.c.inc
+++ b/target/i386/tcg/emit.c.inc
@@ -3572,7 +3572,6 @@ static void gen_RDPMC(DisasContext *s, X86DecodedInsn *decode)
     gen_update_eip_cur(s);
     translator_io_start(&s->base);
     gen_helper_rdpmc(tcg_env);
-    s->base.is_jmp = DISAS_NORETURN;
 }
 
 static void gen_RDTSC(DisasContext *s, X86DecodedInsn *decode)

--- a/target/i386/tcg/misc_helper.c
+++ b/target/i386/tcg/misc_helper.c
@@ -75,7 +75,7 @@ void helper_rdtsc(CPUX86State *env)
     env->regs[R_EDX] = (uint32_t)(val >> 32);
 }
 
-G_NORETURN void helper_rdpmc(CPUX86State *env)
+void helper_rdpmc(CPUX86State *env)
 {
     if (((env->cr[4] & CR4_PCE_MASK) == 0 ) &&
         ((env->hflags & HF_CPL_MASK) != 0)) {
@@ -83,9 +83,16 @@ G_NORETURN void helper_rdpmc(CPUX86State *env)
     }
     cpu_svm_check_intercept_param(env, SVM_EXIT_RDPMC, 0, GETPC());
 
-    /* currently unimplemented */
-    qemu_log_mask(LOG_UNIMP, "x86: unimplemented rdpmc\n");
-    raise_exception_err(env, EXCP06_ILLOP, 0);
+    /*
+     * No performance-monitoring counters are emulated. Mirror the policy the
+     * WHPX accelerator uses for unsupported MSRs (return 0) rather than
+     * raising #UD: rdpmc never faults with an illegal-instruction on real
+     * hardware, and stubbing it lets guests that read the Pentium III PMCs
+     * (e.g. the FastCPU XDK sample) run instead of crashing.
+     */
+    qemu_log_mask(LOG_UNIMP, "x86: unimplemented rdpmc, returning 0\n");
+    env->regs[R_EAX] = 0;
+    env->regs[R_EDX] = 0;
 }
 
 G_NORETURN void helper_pause(CPUX86State *env)


### PR DESCRIPTION
The rdpmc helper inherited from upstream QEMU raised EXCP06_ILLOP (illegal instruction) because no performance-monitoring counters are emulated. On real hardware rdpmc never raises #UD, so guests that read the Pentium III PMCs faulted only under emulation -- e.g. the FastCPU XDK sample crashes with 0xC000001D right after reaching its render loop.

Return EAX:EDX = 0 instead, mirroring the policy the WHPX accelerator already uses for unsupported MSR reads. The CPL/CR4.PCE #GP guard is kept. The helper now writes EAX/EDX like rdtsc, so drop noreturn and the TCG_CALL_NO_WG flag from its declaration and let gen_RDPMC fall through instead of ending the block with DISAS_NORETURN.

<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/e75a02c0-0c3a-4467-beb3-fe27bf1e2dbe" />
