### PR TITLE
nv2a/vk: guard vertex RAM writes on what draws read

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/buffer.c
+++ b/hw/xbox/nv2a/pgraph/vk/buffer.c
@@ -107,8 +107,6 @@ void pgraph_vk_init_buffers(NV2AState *d)
     };
 
     r->bitmap_size = memory_region_size(d->vram) / 4096;
-    r->uploaded_bitmap = bitmap_new(r->bitmap_size);
-    bitmap_clear(r->uploaded_bitmap, 0, r->bitmap_size);
     r->referenced_bitmap = bitmap_new(r->bitmap_size);
     bitmap_clear(r->referenced_bitmap, 0, r->bitmap_size);
 
@@ -169,8 +167,6 @@ void pgraph_vk_finalize_buffers(NV2AState *d)
         destroy_buffer(pg, &r->storage_buffers[i]);
     }
 
-    g_free(r->uploaded_bitmap);
-    r->uploaded_bitmap = NULL;
     g_free(r->referenced_bitmap);
     r->referenced_bitmap = NULL;
 }

--- a/hw/xbox/nv2a/pgraph/vk/buffer.c
+++ b/hw/xbox/nv2a/pgraph/vk/buffer.c
@@ -109,6 +109,8 @@ void pgraph_vk_init_buffers(NV2AState *d)
     r->bitmap_size = memory_region_size(d->vram) / 4096;
     r->uploaded_bitmap = bitmap_new(r->bitmap_size);
     bitmap_clear(r->uploaded_bitmap, 0, r->bitmap_size);
+    r->referenced_bitmap = bitmap_new(r->bitmap_size);
+    bitmap_clear(r->referenced_bitmap, 0, r->bitmap_size);
 
     r->storage_buffers[BUFFER_VERTEX_INLINE] = (StorageBuffer){
         .alloc_info = device_alloc_create_info,
@@ -169,6 +171,8 @@ void pgraph_vk_finalize_buffers(NV2AState *d)
 
     g_free(r->uploaded_bitmap);
     r->uploaded_bitmap = NULL;
+    g_free(r->referenced_bitmap);
+    r->referenced_bitmap = NULL;
 }
 
 bool pgraph_vk_buffer_has_space_for(PGRAPHState *pg, int index,

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1233,7 +1233,6 @@ void pgraph_vk_finish(PGRAPHState *pg, FinishReason finish_reason)
         sync_staging_buffer(pg, cmd, BUFFER_VERTEX_INLINE_STAGING,
                                 BUFFER_VERTEX_INLINE);
         sync_staging_buffer(pg, cmd, BUFFER_UNIFORM_STAGING, BUFFER_UNIFORM);
-        bitmap_clear(r->uploaded_bitmap, 0, r->bitmap_size);
         bitmap_clear(r->referenced_bitmap, 0, r->bitmap_size);
         flush_memory_buffer(pg, cmd);
         VK_CHECK(vkEndCommandBuffer(r->aux_command_buffer));

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1234,6 +1234,7 @@ void pgraph_vk_finish(PGRAPHState *pg, FinishReason finish_reason)
                                 BUFFER_VERTEX_INLINE);
         sync_staging_buffer(pg, cmd, BUFFER_UNIFORM_STAGING, BUFFER_UNIFORM);
         bitmap_clear(r->uploaded_bitmap, 0, r->bitmap_size);
+        bitmap_clear(r->referenced_bitmap, 0, r->bitmap_size);
         flush_memory_buffer(pg, cmd);
         VK_CHECK(vkEndCommandBuffer(r->aux_command_buffer));
         r->in_aux_command_buffer = false;
@@ -1632,6 +1633,11 @@ static void sync_vertex_ram_buffer(PGRAPHState *pg)
             pgraph_vk_update_vertex_ram_buffer(pg, addr, d->vram_ptr + addr,
                                                size);
         }
+    }
+
+    for (int i = 0; i < num_syncs; i++) {
+        bitmap_set(r->referenced_bitmap, merged[i].addr / TARGET_PAGE_SIZE,
+                   merged[i].size / TARGET_PAGE_SIZE);
     }
 
     r->num_vertex_ram_buffer_syncs = 0;

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -373,7 +373,6 @@ typedef struct PGRAPHVkState {
 
     MemorySyncRequirement vertex_ram_buffer_syncs[NV2A_VERTEXSHADER_ATTRIBUTES];
     size_t num_vertex_ram_buffer_syncs;
-    unsigned long *uploaded_bitmap;
     unsigned long *referenced_bitmap;
     size_t bitmap_size;
 

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -374,6 +374,7 @@ typedef struct PGRAPHVkState {
     MemorySyncRequirement vertex_ram_buffer_syncs[NV2A_VERTEXSHADER_ATTRIBUTES];
     size_t num_vertex_ram_buffer_syncs;
     unsigned long *uploaded_bitmap;
+    unsigned long *referenced_bitmap;
     size_t bitmap_size;
 
     VkVertexInputAttributeDescription vertex_attribute_descriptions[NV2A_VERTEXSHADER_ATTRIBUTES];

--- a/hw/xbox/nv2a/pgraph/vk/vertex.c
+++ b/hw/xbox/nv2a/pgraph/vk/vertex.c
@@ -62,7 +62,6 @@ void pgraph_vk_update_vertex_ram_buffer(PGRAPHState *pg, hwaddr offset,
     nv2a_profile_inc_counter(NV2A_PROF_GEOM_BUFFER_UPDATE_1);
     memcpy(r->storage_buffers[BUFFER_VERTEX_RAM].mapped + offset, data, size);
 
-    bitmap_set(r->uploaded_bitmap, start_bit, nbits);
 }
 
 static void update_memory_buffer(NV2AState *d, hwaddr addr, hwaddr size)

--- a/hw/xbox/nv2a/pgraph/vk/vertex.c
+++ b/hw/xbox/nv2a/pgraph/vk/vertex.c
@@ -53,8 +53,7 @@ void pgraph_vk_update_vertex_ram_buffer(PGRAPHState *pg, hwaddr offset,
     size_t end_bit = TARGET_PAGE_ALIGN(offset + size) / TARGET_PAGE_SIZE;
     size_t nbits = end_bit - start_bit;
 
-    if (find_next_bit(r->uploaded_bitmap, start_bit + nbits, start_bit) <
-        end_bit) {
+    if (find_next_bit(r->referenced_bitmap, end_bit, start_bit) < end_bit) {
         // Vertex data changed while building the draw list. Finish drawing
         // before updating RAM buffer.
         pgraph_vk_finish(pg, VK_FINISH_REASON_VERTEX_BUFFER_DIRTY);


### PR DESCRIPTION
The guard before overwriting the vertex RAM mirror tests `uploaded_bitmap`, which records pages uploaded since the last submission. That is not the set that matters.

A page uploaded while an earlier command buffer was being built, and read by a draw recorded into the current one without needing a re-upload, carries no bit. Its contents are then overwritten while a recorded but unexecuted draw still refers to it.

`sync_vertex_ram_buffer` already computes the exact ranges each draw needs, so this marks those instead, and clears the set where `uploaded_bitmap` is cleared — once the work referring to them has been submitted and waited for.

**Measured**, instrumented on Morrowind at 1080p from a snapshot-resumed gameplay scene: the existing guard lets through **3.36 such writes per frame**.

Frame timings are unchanged. The tracked set is larger, but it is the set correctness requires, and no measurable cost came with it:

| | before | after |
|---|---|---|
| fps | 15.4 | 15.2 |
| median frame | 107.8 ms | 109.5 ms |

Both within run-to-run noise on the same scene with the same guest workload.

Tested on a Raspberry Pi 5 with Mesa V3DV only; I have no desktop GPU to hand, so a second pair of eyes on a discrete card would be welcome.

Part of a small series making xemu run well on Raspberry Pi 5 (aarch64 + V3DV): #2977, #2979, #2980, #2981. Each stands alone and they merge in any order.