### PR TITLE
nv2a/vk: persist the pipeline and SPIR-V caches to disk

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -19,6 +19,7 @@
 
 #include "qemu/osdep.h"
 #include "qemu/fast-hash.h"
+#include "ui/xemu-settings.h"
 #include "renderer.h"
 #include <math.h>
 
@@ -121,15 +122,94 @@ static bool pipeline_cache_entry_compare(Lru *lru, LruNode *node,
     return memcmp(&snode->key, key, sizeof(PipelineKey));
 }
 
+static bool pipeline_cache_live;
+static bool pipeline_cache_atexit_registered;
+
+static char *pipeline_cache_path(void)
+{
+    return g_build_filename(xemu_settings_get_base_path(),
+                            "vk_pipeline_cache.bin", NULL);
+}
+
+static bool pipeline_cache_data_is_usable(PGRAPHVkState *r,
+                                          const uint8_t *data, size_t size)
+{
+    if (size < 16 + VK_UUID_SIZE) {
+        return false;
+    }
+
+    uint32_t header_size, header_version, vendor_id, device_id;
+    memcpy(&header_size, data, sizeof(header_size));
+    memcpy(&header_version, data + 4, sizeof(header_version));
+    memcpy(&vendor_id, data + 8, sizeof(vendor_id));
+    memcpy(&device_id, data + 12, sizeof(device_id));
+
+    return header_size <= size &&
+           header_version == VK_PIPELINE_CACHE_HEADER_VERSION_ONE &&
+           vendor_id == r->device_props.vendorID &&
+           device_id == r->device_props.deviceID &&
+           !memcmp(data + 16, r->device_props.pipelineCacheUUID, VK_UUID_SIZE);
+}
+
+static void save_pipeline_cache(PGRAPHVkState *r);
+
+static void save_pipeline_cache_atexit(void)
+{
+    if (!pipeline_cache_live || !g_nv2a) {
+        return;
+    }
+
+    PGRAPHVkState *r = g_nv2a->pgraph.vk_renderer_state;
+    if (r && r->device && r->vk_pipeline_cache) {
+        save_pipeline_cache(r);
+    }
+}
+
+static void save_pipeline_cache(PGRAPHVkState *r)
+{
+    size_t size = 0;
+
+    if (!g_config.perf.cache_shaders) {
+        return;
+    }
+
+    if (vkGetPipelineCacheData(r->device, r->vk_pipeline_cache, &size, NULL) !=
+            VK_SUCCESS ||
+        size == 0) {
+        return;
+    }
+
+    g_autofree uint8_t *data = g_malloc(size);
+    if (vkGetPipelineCacheData(r->device, r->vk_pipeline_cache, &size, data) !=
+        VK_SUCCESS) {
+        return;
+    }
+
+    g_autofree char *path = pipeline_cache_path();
+    g_file_set_contents(path, (const char *)data, size, NULL);
+}
+
 static void init_pipeline_cache(PGRAPHState *pg)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
 
+    g_autofree char *cache_path = pipeline_cache_path();
+    g_autofree gchar *cache_data = NULL;
+    gsize cache_size = 0;
+
+    if (!g_config.perf.cache_shaders ||
+        !g_file_get_contents(cache_path, &cache_data, &cache_size, NULL) ||
+        !pipeline_cache_data_is_usable(r, (const uint8_t *)cache_data,
+                                       cache_size)) {
+        g_clear_pointer(&cache_data, g_free);
+        cache_size = 0;
+    }
+
     VkPipelineCacheCreateInfo cache_info = {
         .sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
         .flags = 0,
-        .initialDataSize = 0,
-        .pInitialData = NULL,
+        .initialDataSize = cache_size,
+        .pInitialData = cache_size ? cache_data : NULL,
         .pNext = NULL,
     };
     VK_CHECK(vkCreatePipelineCache(r->device, &cache_info, NULL,
@@ -147,6 +227,12 @@ static void init_pipeline_cache(PGRAPHState *pg)
     r->pipeline_cache.init_node = pipeline_cache_entry_init;
     r->pipeline_cache.compare_nodes = pipeline_cache_entry_compare;
     r->pipeline_cache.post_node_evict = pipeline_cache_entry_post_evict;
+
+    pipeline_cache_live = true;
+    if (!pipeline_cache_atexit_registered) {
+        atexit(save_pipeline_cache_atexit);
+        pipeline_cache_atexit_registered = true;
+    }
 }
 
 static void finalize_pipeline_cache(PGRAPHState *pg)
@@ -157,6 +243,8 @@ static void finalize_pipeline_cache(PGRAPHState *pg)
     g_free(r->pipeline_cache_entries);
     r->pipeline_cache_entries = NULL;
 
+    save_pipeline_cache(r);
+    pipeline_cache_live = false;
     vkDestroyPipelineCache(r->device, r->vk_pipeline_cache, NULL);
 }
 

--- a/hw/xbox/nv2a/pgraph/vk/glsl.c
+++ b/hw/xbox/nv2a/pgraph/vk/glsl.c
@@ -17,6 +17,8 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "qemu/fast-hash.h"
+#include "xemu-version.h"
 #include "ui/xemu-settings.h"
 #include "renderer.h"
 
@@ -140,9 +142,80 @@ void pgraph_vk_finalize_glsl_compiler(void)
     glslang_finalize_process();
 }
 
+#define SPIRV_MAGIC 0x07230203u
+
+static uint64_t spirv_cache_key(glslang_stage_t stage, const char *glsl_source)
+{
+    g_autofree char *material =
+        g_strdup_printf("%s|%d|%d|%s", xemu_version, (int)stage,
+                        g_config.display.vulkan.debug_shaders ? 1 : 0,
+                        glsl_source);
+    return fast_hash((const uint8_t *)material, strlen(material));
+}
+
+static char *spirv_cache_dir(uint64_t hash)
+{
+    return g_strdup_printf("%sspirv%c%04x", xemu_settings_get_base_path(),
+                           G_DIR_SEPARATOR, (uint32_t)(hash >> 48));
+}
+
+static char *spirv_cache_file(const char *dir, uint64_t hash)
+{
+    return g_strdup_printf("%s%c%012" PRIx64, dir, G_DIR_SEPARATOR,
+                           hash & ~((uint64_t)0xffff << 48));
+}
+
+static GByteArray *spirv_cache_load(uint64_t hash)
+{
+    g_autofree char *dir = spirv_cache_dir(hash);
+    g_autofree char *path = spirv_cache_file(dir, hash);
+    g_autofree gchar *data = NULL;
+    gsize size = 0;
+    uint32_t magic;
+
+    if (!g_file_get_contents(path, &data, &size, NULL)) {
+        return NULL;
+    }
+    if (size < sizeof(magic) || (size % sizeof(uint32_t)) != 0) {
+        return NULL;
+    }
+
+    memcpy(&magic, data, sizeof(magic));
+    if (magic != SPIRV_MAGIC) {
+        return NULL;
+    }
+
+    GByteArray *spirv = g_byte_array_sized_new(size);
+    g_byte_array_append(spirv, (const guint8 *)data, size);
+    return spirv;
+}
+
+static void spirv_cache_store(uint64_t hash, GByteArray *spirv)
+{
+    g_autofree char *dir = spirv_cache_dir(hash);
+
+    if (g_mkdir_with_parents(dir, 0755) != 0) {
+        return;
+    }
+
+    g_autofree char *path = spirv_cache_file(dir, hash);
+    g_file_set_contents(path, (const char *)spirv->data, spirv->len, NULL);
+}
+
 GByteArray *pgraph_vk_compile_glsl_to_spv(glslang_stage_t stage,
                                           const char *glsl_source)
 {
+    const bool use_cache = g_config.perf.cache_shaders;
+    uint64_t hash = 0;
+
+    if (use_cache) {
+        hash = spirv_cache_key(stage, glsl_source);
+        GByteArray *cached = spirv_cache_load(hash);
+        if (cached) {
+            return cached;
+        }
+    }
+
     const glslang_input_t input = {
         .language = GLSLANG_SOURCE_GLSL,
         .stage = stage,
@@ -239,7 +312,13 @@ GByteArray *pgraph_vk_compile_glsl_to_spv(glslang_stage_t stage,
     glslang_program_delete(program);
     glslang_shader_delete(shader);
 
-    return g_byte_array_new_take(data, num_program_bytes);
+    GByteArray *spirv = g_byte_array_new_take(data, num_program_bytes);
+
+    if (use_cache) {
+        spirv_cache_store(hash, spirv);
+    }
+
+    return spirv;
 }
 
 VkShaderModule pgraph_vk_create_shader_module_from_spv(PGRAPHVkState *r, GByteArray *spv)


### PR DESCRIPTION
The Vulkan renderer creates its `VkPipelineCache` empty on every launch and
destroys it without reading it back, and recompiles identical GLSL through
glslang each run. Both caches are rebuilt from scratch every time xemu starts.

Two commits:

- **Pipeline cache** — load the blob at init, write it back on exit. The cache
  header carries vendor ID, device ID and a driver UUID, so data from a
  different device or an updated driver is rejected before the driver sees it,
  and the write goes through `g_file_set_contents` so an interrupted save
  cannot truncate a good cache.
- **SPIR-V cache** — key compiled SPIR-V on source, stage, the debug-shader
  flag and the xemu version, stored with the same sharded layout the GL shader
  cache already uses. Entries are rejected unless the SPIR-V magic word and
  word alignment hold.

Both honour the existing "Cache shaders to disk" setting.

One detail worth calling out: `finalize_pipeline_cache` alone is not enough.
It runs from the renderer's `ops.finalize`, which fires on a renderer switch,
while a normal quit exits without tearing the device down — so a save placed
only there never runs. The exit handler covers that, and a live flag keeps it
from touching a cache `finalize` already destroyed.

Measured on a Raspberry Pi 5 with Mesa V3DV, where pipeline compilation is
slow enough to be visible. The gain is confined to startup: the boot window
went 20.5 -> 43.7 fps and p99 1282 -> 309 ms once the caches were seeded.
**There is no steady-state gameplay gain and I am not claiming one** — only 27
shaders and 73 pipelines are created across 3089 frames of Morrowind, and a
45-second CPU profile of gameplay contains no compilation samples at all.

#2799 also implements disk caching for both, as part of a larger change that
adds macOS/MoltenVK bundling and loader plumbing. This is only the cache half,
against master, for whichever is easier to take.
