### PR TITLE
UI: add USB keyboard/mouse devices and per-keyboard routing to Input

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -30,6 +30,13 @@ input:
     port3: string
     port4_driver: string
     port4: string
+    # Name of the host keyboard (SDL_GetKeyboardNameForID) that drives the
+    # keyboard-as-controller. Empty = any/all keyboards. When set, that keyboard
+    # is dedicated to the controller and excluded from the guest usb-kbd.
+    keyboard_device: string
+    # Name of the host keyboard that types into the emulated guest usb-kbd.
+    # Empty = all keyboards (except any dedicated to a controller above).
+    guest_keyboard_device: string
   peripherals:
     port1:
       peripheral_type_0: integer

--- a/ui/xemu-input.c
+++ b/ui/xemu-input.c
@@ -90,7 +90,30 @@ ControllerStateList available_controllers =
 ControllerState *bound_controllers[4] = { NULL, NULL, NULL, NULL };
 const char *bound_drivers[4] = { DRIVER_DUKE, DRIVER_DUKE, DRIVER_DUKE,
                                  DRIVER_DUKE };
+// A simple USB HID device (usb-kbd / usb-mouse) attached directly to a player
+// port, if any. This occupies the same daughterboard port as a controller
+// would, so a port has either a controller or a HID device, never both. The
+// specific driver in use is tracked in bound_drivers[].
+static DeviceState *bound_hid_devices[4] = { NULL, NULL, NULL, NULL };
 int test_mode;
+
+// Host keyboard dedicated to the keyboard-as-controller (0 = all keyboards).
+// When set, controller key state is tracked per-device from events (rather than
+// the merged SDL keyboard state) so a second keyboard can drive the guest.
+static SDL_KeyboardID controller_kbd_id;
+static bool controller_kbd_scancodes[SDL_SCANCODE_COUNT];
+// Host keyboard that types into the emulated guest usb-kbd (0 = all keyboards).
+static SDL_KeyboardID guest_kbd_id;
+
+// Per-device keyboard routing needs SDL to attribute key events to a specific
+// device. On Windows the default message-loop path reports which == 0 for every
+// key, so enable low-latency raw keyboard input whenever a specific keyboard is
+// selected. (The hint is ignored on other platforms.)
+static void xemu_input_update_raw_keyboard_hint(void)
+{
+    bool need_raw = (controller_kbd_id != 0) || (guest_kbd_id != 0);
+    SDL_SetHint(SDL_HINT_WINDOWS_RAW_KEYBOARD, need_raw ? "1" : "0");
+}
 
 static const char **port_index_to_settings_key_map[] = {
     &g_config.input.bindings.port1,
@@ -254,11 +277,44 @@ static const char *get_bound_driver(int port)
         return DRIVER_DUKE;
     if (strcmp(driver, DRIVER_S) == 0)
         return DRIVER_S;
+    if (strcmp(driver, DRIVER_KBD) == 0)
+        return DRIVER_KBD;
+    if (strcmp(driver, DRIVER_MOUSE) == 0)
+        return DRIVER_MOUSE;
+    if (strcmp(driver, DRIVER_TABLET) == 0)
+        return DRIVER_TABLET;
 
     return DRIVER_DUKE;
 }
 
+bool xemu_input_driver_is_hid(const char *driver)
+{
+    return driver != NULL && (strcmp(driver, DRIVER_KBD) == 0 ||
+                              strcmp(driver, DRIVER_MOUSE) == 0 ||
+                              strcmp(driver, DRIVER_TABLET) == 0);
+}
+
 static const int port_map[4] = { 3, 4, 1, 2 };
+
+static SDL_KeyboardID resolve_kbd_id_by_name(const char *name)
+{
+    if (name == NULL || name[0] == '\0') {
+        return 0;
+    }
+
+    int count = 0;
+    SDL_KeyboardID *ids = SDL_GetKeyboards(&count);
+    SDL_KeyboardID found = 0;
+    for (int i = 0; ids && i < count; i++) {
+        const char *n = SDL_GetKeyboardNameForID(ids[i]);
+        if (n && strcmp(n, name) == 0) {
+            found = ids[i];
+            break;
+        }
+    }
+    SDL_free(ids);
+    return found;
+}
 
 void xemu_input_init(void)
 {
@@ -297,9 +353,24 @@ void xemu_input_init(void)
     bound_drivers[2] = get_bound_driver(2);
     bound_drivers[3] = get_bound_driver(3);
 
+    // Restore any ports configured to emulate a USB HID device (keyboard/mouse)
+    for (int i = 0; i < 4; i++) {
+        if (xemu_input_driver_is_hid(bound_drivers[i])) {
+            xemu_input_attach_hid(i, bound_drivers[i], 0);
+        }
+    }
+
+    // Restore the host keyboards dedicated to the controller and to the guest
+    // usb-kbd, if configured, and enable raw keyboard input if either is set.
+    controller_kbd_id =
+        resolve_kbd_id_by_name(g_config.input.bindings.keyboard_device);
+    guest_kbd_id =
+        resolve_kbd_id_by_name(g_config.input.bindings.guest_keyboard_device);
+    xemu_input_update_raw_keyboard_hint();
+
     // Check to see if we should auto-bind the keyboard
     int port = xemu_input_get_controller_default_bind_port(new_con, 0);
-    if (port >= 0) {
+    if (port >= 0 && !xemu_input_port_has_hid(port)) {
         xemu_input_bind(port, new_con, 0);
         char buf[128];
         snprintf(buf, sizeof(buf), "Connected '%s' to port %d", new_con->name, port+1);
@@ -348,6 +419,19 @@ void xemu_save_peripheral_settings(int player_index, int peripheral_index,
 
 void xemu_input_process_sdl_events(const SDL_Event *event)
 {
+    // Track key state for a keyboard dedicated to the controller. When no
+    // specific keyboard is selected (id 0) the controller reads the merged
+    // SDL keyboard state instead, so this bookkeeping is skipped.
+    if (controller_kbd_id != 0 &&
+        (event->type == SDL_EVENT_KEY_DOWN ||
+         event->type == SDL_EVENT_KEY_UP)) {
+        if (event->key.which == controller_kbd_id &&
+            event->key.scancode < SDL_SCANCODE_COUNT) {
+            controller_kbd_scancodes[event->key.scancode] =
+                (event->type == SDL_EVENT_KEY_DOWN);
+        }
+    }
+
     if (event->type == SDL_EVENT_GAMEPAD_ADDED) {
         DPRINTF("Controller Added: %d\n", event->gdevice.which);
 
@@ -402,7 +486,8 @@ void xemu_input_process_sdl_events(const SDL_Event *event)
             if (port < 0) {
                 // No (additional) default mappings
                 break;
-            } else if (!xemu_input_get_bound(port)) {
+            } else if (!xemu_input_get_bound(port) &&
+                       !xemu_input_port_has_hid(port)) {
                 xemu_input_bind(port, new_con, 0);
                 did_bind = true;
                 break;
@@ -415,7 +500,8 @@ void xemu_input_process_sdl_events(const SDL_Event *event)
         // Try to bind to any open port, and if so remember the binding
         if (!did_bind && g_config.input.auto_bind) {
             for (port = 0; port < 4; port++) {
-                if (!xemu_input_get_bound(port)) {
+                if (!xemu_input_get_bound(port) &&
+                    !xemu_input_port_has_hid(port)) {
                     xemu_input_bind(port, new_con, 1);
                     did_bind = true;
                     break;
@@ -512,7 +598,10 @@ void xemu_input_update_sdl_kbd_controller_state(ControllerState *state)
     state->buttons = 0;
     memset(state->axis, 0, sizeof(state->axis));
 
-    const bool *kbd = SDL_GetKeyboardState(NULL);
+    // Use per-device key state when a specific host keyboard is dedicated to the
+    // controller; otherwise fall back to the merged keyboard state.
+    const bool *kbd = (controller_kbd_id != 0) ? controller_kbd_scancodes
+                                               : SDL_GetKeyboardState(NULL);
 
 #define KBD_STATE(btn) \
     (kbd[g_config.input.keyboard_controller_scancode_map.btn])
@@ -701,6 +790,13 @@ void xemu_input_bind(int index, ControllerState *state, int save)
 
     // Bind new controller
     if (state) {
+        // A controller and a HID device share the same daughterboard port, so
+        // detach any keyboard/mouse emulated on this port before plugging in the
+        // hub. The bind below persists the port state, so don't save here.
+        if (bound_hid_devices[index]) {
+            xemu_input_detach_hid(index, 0);
+        }
+
         if (state->bound >= 0) {
             // Device was already bound to another port. Unbind it.
             xemu_input_bind(state->bound, NULL, 1);
@@ -751,6 +847,168 @@ void xemu_input_bind(int index, ControllerState *state, int save)
         object_unref(OBJECT(dev));
 
         state->device = usbhub_dev;
+    }
+}
+
+bool xemu_input_port_has_hid(int index)
+{
+    assert(index >= 0 && index < 4);
+    return bound_hid_devices[index] != NULL;
+}
+
+bool xemu_input_relative_mouse_present(void)
+{
+    for (int i = 0; i < 4; i++) {
+        if (bound_hid_devices[i] != NULL &&
+            strcmp(bound_drivers[i], DRIVER_MOUSE) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+SDL_KeyboardID xemu_input_get_controller_kbd_id(void)
+{
+    return controller_kbd_id;
+}
+
+void xemu_input_set_controller_kbd_id(SDL_KeyboardID id, int save)
+{
+    if (id != controller_kbd_id) {
+        controller_kbd_id = id;
+        // Start from a clean per-device state; keys held on the old device must
+        // not remain latched on the controller.
+        memset(controller_kbd_scancodes, 0, sizeof(controller_kbd_scancodes));
+    }
+    xemu_input_update_raw_keyboard_hint();
+
+    if (save) {
+        const char *name = "";
+        if (id != 0) {
+            const char *n = SDL_GetKeyboardNameForID(id);
+            if (n) {
+                name = n;
+            }
+        }
+        xemu_settings_set_string(&g_config.input.bindings.keyboard_device, name);
+    }
+}
+
+bool xemu_input_key_is_controller_only(SDL_KeyboardID which)
+{
+    return controller_kbd_id != 0 && which == controller_kbd_id;
+}
+
+SDL_KeyboardID xemu_input_get_guest_kbd_id(void)
+{
+    return guest_kbd_id;
+}
+
+void xemu_input_set_guest_kbd_id(SDL_KeyboardID id, int save)
+{
+    guest_kbd_id = id;
+    xemu_input_update_raw_keyboard_hint();
+
+    if (save) {
+        const char *name = "";
+        if (id != 0) {
+            const char *n = SDL_GetKeyboardNameForID(id);
+            if (n) {
+                name = n;
+            }
+        }
+        xemu_settings_set_string(&g_config.input.bindings.guest_keyboard_device,
+                                 name);
+    }
+}
+
+bool xemu_input_key_is_for_guest(SDL_KeyboardID which)
+{
+    // A keyboard dedicated to the controller never types into the guest.
+    if (xemu_input_key_is_controller_only(which)) {
+        return false;
+    }
+    // Otherwise, honor the guest keyboard selection (0 = all keyboards).
+    return guest_kbd_id == 0 || which == guest_kbd_id;
+}
+
+void xemu_input_attach_hid(int index, const char *driver, int save)
+{
+    assert(index >= 0 && index < 4);
+    assert(xemu_input_driver_is_hid(driver));
+
+    // A controller and a HID device cannot share a port. Unbind any controller
+    // (and its peripherals) currently occupying this port. This function saves
+    // the resulting port state below, so don't persist the intermediate unbind.
+    if (bound_controllers[index]) {
+        xemu_input_bind(index, NULL, 0);
+    }
+
+    // If a different HID device is already here (e.g. switching keyboard->mouse)
+    // remove it first so the port is free.
+    if (bound_hid_devices[index] &&
+        strcmp(bound_drivers[index], driver) != 0) {
+        qdev_unplug(bound_hid_devices[index], &error_abort);
+        object_unref(OBJECT(bound_hid_devices[index]));
+        bound_hid_devices[index] = NULL;
+    }
+
+    if (bound_hid_devices[index] == NULL) {
+        char *tmp;
+
+        // Create the HID device, plugged directly into this player's port on
+        // the root hub daughterboard.
+        QDict *qdict = qdict_new();
+        qdict_put_str(qdict, "driver", driver);
+
+        static int id_counter = 0;
+        tmp = g_strdup_printf("hid_%d", id_counter++);
+        qdict_put_str(qdict, "id", tmp);
+        g_free(tmp);
+
+        tmp = g_strdup_printf("1.%d", port_map[index]);
+        qdict_put_str(qdict, "port", tmp);
+        g_free(tmp);
+
+        QemuOpts *opts = qemu_opts_from_qdict(qemu_find_opts("device"), qdict,
+                                              &error_abort);
+        DeviceState *dev = qdev_device_add(opts, &error_abort);
+        assert(dev);
+
+        qobject_unref(qdict);
+
+        bound_hid_devices[index] = dev;
+    }
+
+    bound_drivers[index] = driver;
+
+    if (save) {
+        // A HID device has no host input-device binding of its own; clear any
+        // stored controller binding for this port so nothing auto-binds here.
+        xemu_settings_set_string(port_index_to_settings_key_map[index], "");
+        xemu_settings_set_string(port_index_to_driver_settings_key_map[index],
+                                 driver);
+    }
+}
+
+void xemu_input_detach_hid(int index, int save)
+{
+    assert(index >= 0 && index < 4);
+
+    if (bound_hid_devices[index]) {
+        qdev_unplug(bound_hid_devices[index], &error_abort);
+        object_unref(OBJECT(bound_hid_devices[index]));
+        bound_hid_devices[index] = NULL;
+    }
+
+    // Fall back to a controller driver so the port is ready for a controller.
+    if (xemu_input_driver_is_hid(bound_drivers[index])) {
+        bound_drivers[index] = DRIVER_DUKE;
+    }
+
+    if (save) {
+        xemu_settings_set_string(port_index_to_driver_settings_key_map[index],
+                                 bound_drivers[index]);
     }
 }
 

--- a/ui/xemu-input.h
+++ b/ui/xemu-input.h
@@ -34,9 +34,15 @@
 
 #define DRIVER_DUKE "usb-xbox-gamepad"
 #define DRIVER_S "usb-xbox-gamepad-s"
+#define DRIVER_KBD "usb-kbd"
+#define DRIVER_MOUSE "usb-mouse"
+#define DRIVER_TABLET "usb-tablet"
 
 #define DRIVER_DUKE_DISPLAY_NAME "Xbox Controller"
 #define DRIVER_S_DISPLAY_NAME "Xbox Controller S"
+#define DRIVER_KBD_DISPLAY_NAME "Xbox Keyboard"
+#define DRIVER_MOUSE_DISPLAY_NAME "Xbox Mouse (Relative)"
+#define DRIVER_TABLET_DISPLAY_NAME "Xbox Mouse (Absolute)"
 
 enum controller_state_buttons_mask {
     CONTROLLER_BUTTON_A          = (1 << 0),
@@ -133,6 +139,33 @@ void xemu_input_update_sdl_controller_state(ControllerState *state);
 void xemu_input_update_rumble(ControllerState *state);
 ControllerState *xemu_input_get_bound(int index);
 void xemu_input_bind(int index, ControllerState *state, int save);
+// Attach a simple USB HID device (usb-kbd / usb-mouse) directly to a player
+// port, in place of a controller. driver is DRIVER_KBD or DRIVER_MOUSE.
+void xemu_input_attach_hid(int index, const char *driver, int save);
+void xemu_input_detach_hid(int index, int save);
+bool xemu_input_port_has_hid(int index);
+// True if driver names a non-controller HID device that occupies a whole port.
+bool xemu_input_driver_is_hid(const char *driver);
+// True if any port currently emulates a relative USB mouse (usb-mouse). Used to
+// decide whether the display should capture the host cursor on click.
+bool xemu_input_relative_mouse_present(void);
+
+// Host-keyboard selection for the keyboard-as-controller. When a specific
+// keyboard is chosen, only that device drives the emulated controller and its
+// keys are withheld from the guest usb-kbd and the xemu UI hotkeys.
+// id == 0 means "all keyboards" (the default).
+SDL_KeyboardID xemu_input_get_controller_kbd_id(void);
+void xemu_input_set_controller_kbd_id(SDL_KeyboardID id, int save);
+// True if this key event belongs to a keyboard dedicated to the controller and
+// should therefore not be delivered to the guest / UI.
+bool xemu_input_key_is_controller_only(SDL_KeyboardID which);
+
+// Host-keyboard selection for the emulated guest usb-kbd. id == 0 means all
+// keyboards (except any dedicated to a controller).
+SDL_KeyboardID xemu_input_get_guest_kbd_id(void);
+void xemu_input_set_guest_kbd_id(SDL_KeyboardID id, int save);
+// True if this key event should be delivered to the guest usb-kbd.
+bool xemu_input_key_is_for_guest(SDL_KeyboardID which);
 bool xemu_input_bind_xmu(int player_index, int peripheral_port_index,
                          const char *filename, bool is_rebind);
 void xemu_input_rebind_xmu(int port);

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -207,6 +207,33 @@ static void show_cursor(struct xemu_console *scon)
 
 static void grab_start(struct xemu_console *scon)
 {
+    if (!scon || !qemu_console_is_graphic(scon->dcl.con)) {
+        return;
+    }
+
+    // Absolute pointers (e.g. usb-tablet) don't need grabbing: xemu's absolute
+    // path already forwards motion and buttons with a free cursor. Only a
+    // relative pointer (usb-mouse) needs to capture the host cursor to deliver
+    // relative motion and button events to the guest.
+    if (qemu_input_is_absolute(scon->dcl.con) || absolute_enabled) {
+        return;
+    }
+
+    // Only capture the host cursor when there is a relative mouse to feed.
+    // Otherwise (no mouse attached, the common case) a click would needlessly
+    // hide and trap the cursor.
+    if (!xemu_input_relative_mouse_present()) {
+        return;
+    }
+
+    // Don't enter grab state unless the window has input focus (SDL caveat).
+    if (!(SDL_GetWindowFlags(scon->real_window) & SDL_WINDOW_INPUT_FOCUS)) {
+        return;
+    }
+
+    hide_cursor(scon); // hides the host cursor and enables relative mouse mode
+    SDL_SetWindowMouseGrab(scon->real_window, true);
+    gui_grab = 1;
 }
 
 static void grab_end(struct xemu_console *scon)
@@ -331,6 +358,25 @@ int xemu_is_fullscreen(void)
     return gui_fullscreen;
 }
 
+int xemu_mouse_input_to_guest(void)
+{
+    struct xemu_console *scon = &scon_list[0];
+
+    // Absolute pointer (usb-tablet): the guest pointer tracks the host cursor
+    // whenever the window is focused, so host clicks belong to the guest.
+    if (qemu_input_is_absolute(scon->dcl.con) || absolute_enabled) {
+        return 1;
+    }
+
+    // Relative pointer (usb-mouse): the guest only receives input while the
+    // host cursor is grabbed.
+    if (gui_grab && xemu_input_relative_mouse_present()) {
+        return 1;
+    }
+
+    return 0;
+}
+
 static int get_mod_state(void)
 {
     SDL_Keymod mod = SDL_GetModState();
@@ -348,6 +394,11 @@ static int get_mod_state(void)
 static void process_key(struct xemu_console *scon, SDL_KeyboardEvent *ev)
 {
     int qcode;
+
+    // Only deliver to the guest usb-kbd if this keyboard is selected for it.
+    if (!xemu_input_key_is_for_guest(ev->which)) {
+        return;
+    }
 
     if (ev->scancode >= qemu_input_map_usb_to_qcode_len) {
         return;
@@ -901,10 +952,14 @@ static void poll_events(struct xemu_console *scon)
         switch (ev->type) {
         case SDL_EVENT_KEY_DOWN:
             if (kbd) break;
+            // A keyboard dedicated to the controller must not type into the
+            // guest or trigger UI hotkeys.
+            if (xemu_input_key_is_controller_only(ev->key.which)) break;
             handle_keydown(ev);
             break;
         case SDL_EVENT_KEY_UP:
             if (kbd) break;
+            if (xemu_input_key_is_controller_only(ev->key.which)) break;
             handle_keyup(ev);
             break;
         case SDL_EVENT_QUIT:

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -102,6 +102,75 @@ bool MainMenuInputView::IsInputRebinding()
     return m_rebinding != nullptr;
 }
 
+// Composite USB devices (e.g. gaming mice with macro keys) expose a keyboard
+// HID interface, so SDL_GetKeyboards() lists them too. Hide any "keyboard"
+// whose name also appears in SDL's mouse list so the picker shows real
+// keyboards only.
+static bool host_keyboard_is_really_a_mouse(const char *kbd_name)
+{
+    if (!kbd_name) {
+        return false;
+    }
+
+    int count = 0;
+    SDL_MouseID *mice = SDL_GetMice(&count);
+    bool match = false;
+    for (int i = 0; mice && i < count; i++) {
+        const char *mn = SDL_GetMouseNameForID(mice[i]);
+        if (mn && strcmp(mn, kbd_name) == 0) {
+            match = true;
+            break;
+        }
+    }
+    SDL_free(mice);
+    return match;
+}
+
+// Renders a combo listing the host keyboards reported by SDL (plus an
+// "All keyboards" entry). `current` is the selected keyboard id (0 == all) and
+// `on_select(id, save)` is invoked when the user picks one.
+static void DrawHostKeyboardCombo(const char *combo_id, SDL_KeyboardID current,
+                                  void (*on_select)(SDL_KeyboardID, int))
+{
+    const char *cur_name = "All keyboards";
+    if (current != 0) {
+        const char *n = SDL_GetKeyboardNameForID(current);
+        cur_name = n ? n : "Unknown keyboard";
+    }
+
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    if (ImGui::BeginCombo(combo_id, cur_name, ImGuiComboFlags_NoArrowButton)) {
+        if (ImGui::Selectable("All keyboards", current == 0)) {
+            on_select(0, 1);
+        }
+
+        int n_ids = 0;
+        SDL_KeyboardID *ids = SDL_GetKeyboards(&n_ids);
+        for (int i = 0; ids && i < n_ids; i++) {
+            const char *n = SDL_GetKeyboardNameForID(ids[i]);
+            // Skip devices that are really mice exposing a keyboard interface,
+            // unless it happens to be the currently-selected one.
+            if (ids[i] != current && host_keyboard_is_really_a_mouse(n)) {
+                continue;
+            }
+            char buf[128];
+            if (!n) {
+                snprintf(buf, sizeof(buf), "Keyboard %u", (unsigned)ids[i]);
+                n = buf;
+            }
+            ImGui::PushID((int)ids[i]);
+            if (ImGui::Selectable(n, current == ids[i])) {
+                on_select(ids[i], 1);
+            }
+            ImGui::PopID();
+        }
+        SDL_free(ids);
+
+        ImGui::EndCombo();
+    }
+    DrawComboChevron();
+}
+
 void MainMenuInputView::Draw()
 {
     SectionTitle("Controllers");
@@ -141,7 +210,8 @@ void MainMenuInputView::Draw()
     const int port_padding = 8;
     for (int i = 0; i < 4; i++) {
         bool is_selected = (i == active);
-        bool port_is_bound = (xemu_input_get_bound(i) != NULL);
+        bool port_is_bound = (xemu_input_get_bound(i) != NULL) ||
+                             xemu_input_port_has_hid(i);
 
         // Set an X offset to center the image button within the column
         ImGui::SetCursorPosX(
@@ -200,6 +270,12 @@ void MainMenuInputView::Draw()
         driver = DRIVER_DUKE_DISPLAY_NAME;
     else if (strcmp(driver, DRIVER_S) == 0)
         driver = DRIVER_S_DISPLAY_NAME;
+    else if (strcmp(driver, DRIVER_KBD) == 0)
+        driver = DRIVER_KBD_DISPLAY_NAME;
+    else if (strcmp(driver, DRIVER_MOUSE) == 0)
+        driver = DRIVER_MOUSE_DISPLAY_NAME;
+    else if (strcmp(driver, DRIVER_TABLET) == 0)
+        driver = DRIVER_TABLET_DISPLAY_NAME;
 
     ImGui::Columns(2, "", false);
     ImGui::SetColumnWidth(0, ImGui::GetWindowWidth()*0.25);
@@ -211,9 +287,14 @@ void MainMenuInputView::Draw()
     ImGui::SetNextItemWidth(-FLT_MIN);
     if (ImGui::BeginCombo("###InputDrivers", driver,
                           ImGuiComboFlags_NoArrowButton)) {
-        const char *available_drivers[] = { DRIVER_DUKE, DRIVER_S };
+        const char *available_drivers[] = { DRIVER_DUKE, DRIVER_S,
+                                             DRIVER_KBD, DRIVER_MOUSE,
+                                             DRIVER_TABLET };
         const char *driver_display_names[] = { DRIVER_DUKE_DISPLAY_NAME,
-                                               DRIVER_S_DISPLAY_NAME };
+                                               DRIVER_S_DISPLAY_NAME,
+                                               DRIVER_KBD_DISPLAY_NAME,
+                                               DRIVER_MOUSE_DISPLAY_NAME,
+                                               DRIVER_TABLET_DISPLAY_NAME };
         bool is_selected = false;
         int num_drivers = sizeof(driver_display_names) / sizeof(driver_display_names[0]);
         for (int i = 0; i < num_drivers; i++) {
@@ -221,11 +302,26 @@ void MainMenuInputView::Draw()
             is_selected = strcmp(driver, iter) == 0;
             ImGui::PushID(iter);
             if (ImGui::Selectable(iter, is_selected)) {
+                const char *selected_driver = bound_drivers[active];
                 for (int j = 0; j < num_drivers; j++) {
                     if (iter == driver_display_names[j])
-                        bound_drivers[active] = available_drivers[j];
+                        selected_driver = available_drivers[j];
                 }
-                xemu_input_bind(active, bound_controllers[active], 1);
+
+                if (xemu_input_driver_is_hid(selected_driver)) {
+                    // Emulate a USB keyboard or mouse on this port instead of a
+                    // controller.
+                    xemu_input_attach_hid(active, selected_driver, 1);
+                } else if (xemu_input_driver_is_hid(bound_drivers[active])) {
+                    // Switching away from a keyboard/mouse: remove it and record
+                    // the controller driver. User can then pick an input device.
+                    bound_drivers[active] = selected_driver;
+                    xemu_input_detach_hid(active, 1);
+                } else {
+                    // Switching between controller variants.
+                    bound_drivers[active] = selected_driver;
+                    xemu_input_bind(active, bound_controllers[active], 1);
+                }
             }
             if (is_selected) {
                 ImGui::SetItemDefaultFocus();
@@ -250,6 +346,11 @@ void MainMenuInputView::Draw()
     // List available input devices
     const char *not_connected = "Not Connected";
     ControllerState *bound_state = xemu_input_get_bound(active);
+    bool port_is_hid = xemu_input_port_has_hid(active);
+    bool hid_is_mouse = port_is_hid &&
+                        (strcmp(bound_drivers[active], DRIVER_MOUSE) == 0 ||
+                         strcmp(bound_drivers[active], DRIVER_TABLET) == 0);
+    bool hid_is_keyboard = port_is_hid && !hid_is_mouse;
 
     // Get current controller name
     const char *name;
@@ -259,6 +360,11 @@ void MainMenuInputView::Draw()
         name = bound_state->name;
     }
 
+    // A port emulating a USB keyboard/mouse has no separate host input device;
+    // the host keyboard/mouse drives it directly while the window is focused.
+    if (port_is_hid) {
+        ImGui::Text("%s", hid_is_mouse ? "Host mouse" : "Host keyboard");
+    } else {
     ImGui::SetNextItemWidth(-FLT_MIN);
     if (ImGui::BeginCombo("###InputDevices", name, ImGuiComboFlags_NoArrowButton))
     {
@@ -306,6 +412,35 @@ void MainMenuInputView::Draw()
         ImGui::EndCombo();
     }
     DrawComboChevron();
+    }
+
+    // When the input device is the emulated keyboard-controller, let the user
+    // pick which physical keyboard drives it. A dedicated keyboard is excluded
+    // from the guest usb-kbd, so a second keyboard can type into the guest.
+    if (bound_state && bound_state->type == INPUT_DEVICE_SDL_KEYBOARD) {
+        ImGui::NextColumn();
+        ImGui::Text("Host Keyboard");
+        ImGui::SameLine(0, 0);
+        ImGui::NextColumn();
+        DrawHostKeyboardCombo(
+            "###ControllerHostKeyboard",
+            xemu_input_get_controller_kbd_id(),
+            [](SDL_KeyboardID id, int save) {
+                xemu_input_set_controller_kbd_id(id, save);
+            });
+    } else if (hid_is_keyboard) {
+        // Same selector for the emulated guest keyboard, rendered here so it
+        // shares the column layout and menu font of the combos above.
+        ImGui::NextColumn();
+        ImGui::Text("Host Keyboard");
+        ImGui::SameLine(0, 0);
+        ImGui::NextColumn();
+        DrawHostKeyboardCombo(
+            "###GuestHostKeyboard", xemu_input_get_guest_kbd_id(),
+            [](SDL_KeyboardID id, int save) {
+                xemu_input_set_guest_kbd_id(id, save);
+            });
+    }
 
     ImGui::Columns(1);
 
@@ -313,6 +448,47 @@ void MainMenuInputView::Draw()
     // Add a separator between input selection and controller graphic
     //
     ImGui::Dummy(ImVec2(0.0f, ImGui::GetStyle().WindowPadding.y / 2));
+
+    //
+    // In keyboard/mouse mode there is no controller to render; show a short
+    // note explaining how the emulated device is driven, then stop.
+    //
+    if (port_is_hid) {
+        bool is_rel_mouse = strcmp(bound_drivers[active], DRIVER_MOUSE) == 0;
+        bool is_abs_mouse = strcmp(bound_drivers[active], DRIVER_TABLET) == 0;
+
+        controller_fbo->Restore();
+        ImGui::PopFont();
+
+        if (is_rel_mouse) {
+            ImGui::TextWrapped(
+                "A relative USB mouse is emulated on this port. Click inside the "
+                "emulator window (or press Ctrl+Alt+G) to capture your host "
+                "mouse; move and click while captured. Press Ctrl+Alt+G again to "
+                "release. Select a controller under \"Emulated Device\" to use a "
+                "gamepad on this port instead.");
+        } else if (is_abs_mouse) {
+            ImGui::TextWrapped(
+                "An absolute USB mouse (tablet) is emulated on this port. The "
+                "guest pointer tracks your host cursor while the emulator window "
+                "is focused - no capture needed. Select a controller under "
+                "\"Emulated Device\" to use a gamepad on this port instead.");
+        } else {
+            ImGui::TextWrapped(
+                "A USB keyboard is emulated on this port. Type using your host "
+                "keyboard while the emulator window is focused. Select a "
+                "controller under \"Emulated Device\" to use a gamepad on this "
+                "port instead.");
+        }
+
+        SectionTitle("Options");
+        Toggle("Auto-bind controllers", &g_config.input.auto_bind,
+               "Bind newly connected controllers to any open port");
+        Toggle("Background controller input capture",
+               &g_config.input.background_input_capture,
+               "Capture even if window is unfocused (requires restart)");
+        return;
+    }
 
     //
     // Render controller image

--- a/ui/xui/main.cc
+++ b/ui/xui/main.cc
@@ -291,9 +291,11 @@ void xemu_hud_update(void)
             g_scene_mgr.PushScene(g_popup_menu);
         } else if (menu_button ||
                    (ImGui::IsMouseClicked(ImGuiMouseButton_Right) &&
-                    !ImGui::IsAnyItemFocused() && !ImGui::IsAnyItemHovered())) {
+                    !ImGui::IsAnyItemFocused() && !ImGui::IsAnyItemHovered() &&
+                    !xemu_mouse_input_to_guest())) {
             g_scene_mgr.PushScene(g_popup_menu);
-        } else if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
+        } else if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) &&
+                   !xemu_mouse_input_to_guest()) {
             xemu_toggle_fullscreen();
         }
 

--- a/ui/xui/xemu-hud.h
+++ b/ui/xui/xemu-hud.h
@@ -33,6 +33,10 @@ extern "C" {
 // Implemented in xemu.c
 int xemu_is_fullscreen(void);
 void xemu_toggle_fullscreen(void);
+// Nonzero when the guest is actively receiving host mouse input (an absolute
+// tablet is attached, or a relative mouse is attached and currently grabbed).
+// The HUD uses this to avoid stealing clicks (e.g. right-click context menu).
+int xemu_mouse_input_to_guest(void);
 SDL_Window *xemu_get_window(void);
 void xemu_eject_disc(Error **errp);
 void xemu_load_disc(const char *path, Error **errp);


### PR DESCRIPTION
Adds a graphical way to attach the emulated USB HID peripherals that previously required the `device_add usb-kbd,port=1.x` monitor command, and lets a specific host keyboard be routed to the controller or guest.

Emulated Device dropdown (per port) now offers, alongside the Duke and Controller S:
  - Xbox Keyboard        (usb-kbd)
  - Xbox Mouse (Relative) (usb-mouse)
  - Xbox Mouse (Absolute) (usb-tablet)

These attach to the same daughterboard port a controller would use, so a HID device and a controller are mutually exclusive on one player slot. A generic attach/detach path (xemu_input_attach_hid/detach_hid) tracks the device and persists the choice via the existing portN_driver setting; all auto-bind paths are guarded so a hot-plugged gamepad can't hijack a HID port.

Mouse fixes:
  - grab_start() was an empty stub, so a relative usb-mouse only ever delivered the wheel. Implement it (relative pointers only; absolute tablet keeps its free-cursor path) and gate it on a relative mouse actually being present. Ctrl+Alt+G toggles capture.
  - While a guest mouse is active, the idle right-click popup menu and double-click fullscreen shortcuts stole guest clicks; suppress them via xemu_mouse_input_to_guest(). Open the UI with F1/F2 or the guide button.

Per-keyboard selection:
  - A "Host Keyboard" combo lets the keyboard-as-controller and the guest usb-kbd each be driven by a chosen physical keyboard (default: all). A keyboard dedicated to the controller is withheld from the guest and the UI hotkeys, so one keyboard can be a gamepad while another types.
  - Per-device state is tracked from key events by SDL keyboard id; on Windows this needs SDL_HINT_WINDOWS_RAW_KEYBOARD, which is enabled whenever a specific keyboard is selected. Selections persist by name.
  - Composite devices (e.g. gaming mice exposing a keyboard interface) are filtered out of the keyboard picker by cross-referencing SDL's mouse list.