### PR TITLE
nv2a/vk: Persist pipeline and SPIR-V caches to disk

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -19,6 +19,7 @@
 
 #include "qemu/osdep.h"
 #include "qemu/fast-hash.h"
+#include "ui/xemu-settings.h"
 #include "renderer.h"
 #include <math.h>
 
@@ -121,19 +122,71 @@ static bool pipeline_cache_entry_compare(Lru *lru, LruNode *node,
     return memcmp(&snode->key, key, sizeof(PipelineKey));
 }
 
+static char *get_pipeline_cache_path(void)
+{
+    const char *base = xemu_settings_get_base_path();
+    if (!base) {
+        return NULL;
+    }
+    return g_build_filename(base, "pipeline_cache.bin", NULL);
+}
+
+static bool pipeline_cache_saved;
+static void save_pipeline_cache(PGRAPHState *pg);
+
+static void save_pipeline_cache_atexit(void)
+{
+    if (g_nv2a) {
+        save_pipeline_cache(&g_nv2a->pgraph);
+    }
+}
+
 static void init_pipeline_cache(PGRAPHState *pg)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
 
+    void *cache_data = NULL;
+    size_t cache_size = 0;
+
+    char *cache_path =
+        g_config.perf.cache_shaders ? get_pipeline_cache_path() : NULL;
+    if (cache_path) {
+        FILE *f = fopen(cache_path, "rb");
+        if (f) {
+            fseek(f, 0, SEEK_END);
+            long file_size = ftell(f);
+            fseek(f, 0, SEEK_SET);
+            if (file_size > 16) {
+                cache_data = g_malloc(file_size);
+                if (fread(cache_data, 1, file_size, f) == (size_t)file_size) {
+                    cache_size = file_size;
+                } else {
+                    g_free(cache_data);
+                    cache_data = NULL;
+                }
+            }
+            fclose(f);
+        }
+        g_free(cache_path);
+    }
+
     VkPipelineCacheCreateInfo cache_info = {
         .sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
         .flags = 0,
-        .initialDataSize = 0,
-        .pInitialData = NULL,
+        .initialDataSize = cache_size,
+        .pInitialData = cache_data,
         .pNext = NULL,
     };
-    VK_CHECK(vkCreatePipelineCache(r->device, &cache_info, NULL,
-                                   &r->vk_pipeline_cache));
+    VkResult result = vkCreatePipelineCache(r->device, &cache_info, NULL,
+                                            &r->vk_pipeline_cache);
+    g_free(cache_data);
+
+    if (result != VK_SUCCESS) {
+        cache_info.initialDataSize = 0;
+        cache_info.pInitialData = NULL;
+        VK_CHECK(vkCreatePipelineCache(r->device, &cache_info, NULL,
+                                       &r->vk_pipeline_cache));
+    }
 
     const size_t pipeline_cache_size = 2048;
     lru_init(&r->pipeline_cache);
@@ -147,11 +200,52 @@ static void init_pipeline_cache(PGRAPHState *pg)
     r->pipeline_cache.init_node = pipeline_cache_entry_init;
     r->pipeline_cache.compare_nodes = pipeline_cache_entry_compare;
     r->pipeline_cache.post_node_evict = pipeline_cache_entry_post_evict;
+
+    if (!pipeline_cache_saved) {
+        atexit(save_pipeline_cache_atexit);
+    }
+}
+
+static void save_pipeline_cache(PGRAPHState *pg)
+{
+    if (pipeline_cache_saved || !g_config.perf.cache_shaders) {
+        return;
+    }
+
+    PGRAPHVkState *r = pg->vk_renderer_state;
+    if (!r || !r->device || !r->vk_pipeline_cache) {
+        return;
+    }
+
+    char *cache_path = get_pipeline_cache_path();
+    if (!cache_path) {
+        return;
+    }
+
+    size_t cache_size = 0;
+    VkResult result = vkGetPipelineCacheData(r->device, r->vk_pipeline_cache,
+                                             &cache_size, NULL);
+    if (result != VK_SUCCESS || cache_size <= 16) {
+        g_free(cache_path);
+        return;
+    }
+
+    void *cache_data = g_malloc(cache_size);
+    result = vkGetPipelineCacheData(r->device, r->vk_pipeline_cache,
+                                    &cache_size, cache_data);
+    if (result == VK_SUCCESS &&
+        g_file_set_contents(cache_path, cache_data, cache_size, NULL)) {
+        pipeline_cache_saved = true;
+    }
+    g_free(cache_data);
+    g_free(cache_path);
 }
 
 static void finalize_pipeline_cache(PGRAPHState *pg)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
+
+    save_pipeline_cache(pg);
 
     lru_flush(&r->pipeline_cache);
     g_free(r->pipeline_cache_entries);

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -132,6 +132,10 @@ static char *get_pipeline_cache_path(void)
 }
 
 static bool pipeline_cache_saved;
+/* Whether init ran with perf.cache_shaders enabled. Saving is gated on
+ * this so enabling the setting mid-session cannot overwrite a full
+ * on-disk cache with only this session's pipelines. */
+static bool pipeline_cache_loaded;
 static void save_pipeline_cache(PGRAPHState *pg);
 
 static void save_pipeline_cache_atexit(void)
@@ -148,6 +152,9 @@ static void init_pipeline_cache(PGRAPHState *pg)
     void *cache_data = NULL;
     size_t cache_size = 0;
 
+    if (g_config.perf.cache_shaders) {
+        pipeline_cache_loaded = true;
+    }
     char *cache_path =
         g_config.perf.cache_shaders ? get_pipeline_cache_path() : NULL;
     if (cache_path) {
@@ -208,7 +215,8 @@ static void init_pipeline_cache(PGRAPHState *pg)
 
 static void save_pipeline_cache(PGRAPHState *pg)
 {
-    if (pipeline_cache_saved || !g_config.perf.cache_shaders) {
+    if (pipeline_cache_saved || !pipeline_cache_loaded ||
+        !g_config.perf.cache_shaders) {
         return;
     }
 

--- a/hw/xbox/nv2a/pgraph/vk/glsl.c
+++ b/hw/xbox/nv2a/pgraph/vk/glsl.c
@@ -26,8 +26,9 @@
 #include <glslang/Include/glslang_c_interface.h>
 #include <stdio.h>
 
-#define SPIRV_CACHE_VERSION 1
+#define SPIRV_CACHE_VERSION 2
 #define SPIRV_CACHE_MAGIC   0x53505643 /* 'SPVC' */
+#define SPIRV_MAGIC_WORD    0x07230203
 
 typedef struct SpirvCacheEntry {
     uint64_t hash;
@@ -37,6 +38,13 @@ typedef struct SpirvCacheEntry {
 
 static GHashTable *spirv_cache;
 static bool spirv_cache_dirty;
+/* Whether load ran with perf.cache_shaders enabled. Saving is gated on
+ * this so enabling the setting mid-session cannot overwrite a full
+ * on-disk cache with only this session's entries. */
+static bool spirv_cache_loaded;
+/* Shader compilation runs on the render thread; the atexit save runs on
+ * the main thread while the render thread may still be compiling. */
+static GMutex spirv_cache_lock;
 
 static char *get_spirv_cache_path(void)
 {
@@ -61,6 +69,7 @@ static void load_spirv_cache(void)
     if (!g_config.perf.cache_shaders) {
         return;
     }
+    spirv_cache_loaded = true;
 
     char *path = get_spirv_cache_path();
     if (!path) {
@@ -81,12 +90,16 @@ static void load_spirv_cache(void)
         return;
     }
 
+    bool corrupt = false;
     for (uint32_t i = 0; i < count; i++) {
-        uint64_t hash;
+        uint64_t hash, payload_hash;
         uint32_t spirv_len;
         if (fread(&hash, 8, 1, f) != 1 ||
             fread(&spirv_len, 4, 1, f) != 1 ||
-            spirv_len == 0 || spirv_len > 1024 * 1024) {
+            fread(&payload_hash, 8, 1, f) != 1 ||
+            spirv_len == 0 || spirv_len > 1024 * 1024 ||
+            spirv_len % 4 != 0) {
+            corrupt = true;
             break;
         }
 
@@ -94,21 +107,37 @@ static void load_spirv_cache(void)
         entry->hash = hash;
         entry->spirv_len = spirv_len;
         entry->spirv_data = g_malloc(spirv_len);
-        if (fread(entry->spirv_data, 1, spirv_len, f) != spirv_len) {
+        if (fread(entry->spirv_data, 1, spirv_len, f) != spirv_len ||
+            fast_hash(entry->spirv_data, spirv_len) != payload_hash ||
+            *(uint32_t *)entry->spirv_data != SPIRV_MAGIC_WORD) {
             g_free(entry->spirv_data);
             g_free(entry);
+            corrupt = true;
             break;
         }
 
-        g_hash_table_insert(spirv_cache, &entry->hash, entry);
+        g_hash_table_replace(spirv_cache, &entry->hash, entry);
     }
 
     fclose(f);
+
+    if (corrupt) {
+        /* Self-heal: discard the damaged file (validated entries stay in
+         * memory) and rewrite it on exit rather than crashing every boot
+         * on the same bad blob. */
+        char *bad = get_spirv_cache_path();
+        if (bad) {
+            remove(bad);
+            g_free(bad);
+        }
+        spirv_cache_dirty = true;
+    }
 }
 
 static void save_spirv_cache(void)
 {
-    if (!spirv_cache || !spirv_cache_dirty || !g_config.perf.cache_shaders) {
+    if (!spirv_cache || !spirv_cache_dirty || !spirv_cache_loaded ||
+        !g_config.perf.cache_shaders) {
         return;
     }
 
@@ -116,6 +145,8 @@ static void save_spirv_cache(void)
     if (!path) {
         return;
     }
+
+    g_mutex_lock(&spirv_cache_lock);
 
     uint32_t magic = SPIRV_CACHE_MAGIC;
     uint32_t version = SPIRV_CACHE_VERSION;
@@ -131,8 +162,10 @@ static void save_spirv_cache(void)
     g_hash_table_iter_init(&iter, spirv_cache);
     while (g_hash_table_iter_next(&iter, &key, &value)) {
         SpirvCacheEntry *entry = value;
+        uint64_t payload_hash = fast_hash(entry->spirv_data, entry->spirv_len);
         g_byte_array_append(buf, (const uint8_t *)&entry->hash, 8);
         g_byte_array_append(buf, (const uint8_t *)&entry->spirv_len, 4);
+        g_byte_array_append(buf, (const uint8_t *)&payload_hash, 8);
         g_byte_array_append(buf, entry->spirv_data, entry->spirv_len);
     }
 
@@ -142,6 +175,8 @@ static void save_spirv_cache(void)
         spirv_cache_dirty = false;
     }
 
+    g_mutex_unlock(&spirv_cache_lock);
+
     g_byte_array_unref(buf);
     g_free(path);
 }
@@ -149,13 +184,15 @@ static void save_spirv_cache(void)
 static GByteArray *spirv_cache_lookup(const char *glsl)
 {
     uint64_t hash = fast_hash((const uint8_t *)glsl, strlen(glsl));
+    g_mutex_lock(&spirv_cache_lock);
     SpirvCacheEntry *entry = g_hash_table_lookup(spirv_cache, &hash);
+    GByteArray *arr = NULL;
     if (entry) {
-        GByteArray *arr = g_byte_array_sized_new(entry->spirv_len);
+        arr = g_byte_array_sized_new(entry->spirv_len);
         g_byte_array_append(arr, entry->spirv_data, entry->spirv_len);
-        return arr;
     }
-    return NULL;
+    g_mutex_unlock(&spirv_cache_lock);
+    return arr;
 }
 
 static void spirv_cache_insert(const char *glsl, GByteArray *spirv)
@@ -166,8 +203,10 @@ static void spirv_cache_insert(const char *glsl, GByteArray *spirv)
     entry->spirv_len = spirv->len;
     entry->spirv_data = g_malloc(spirv->len);
     memcpy(entry->spirv_data, spirv->data, spirv->len);
-    g_hash_table_insert(spirv_cache, &entry->hash, entry);
+    g_mutex_lock(&spirv_cache_lock);
+    g_hash_table_replace(spirv_cache, &entry->hash, entry);
     spirv_cache_dirty = true;
+    g_mutex_unlock(&spirv_cache_lock);
 }
 
 static const glslang_resource_t
@@ -291,10 +330,12 @@ void pgraph_vk_init_glsl_compiler(void)
 void pgraph_vk_finalize_glsl_compiler(void)
 {
     save_spirv_cache();
+    g_mutex_lock(&spirv_cache_lock);
     if (spirv_cache) {
         g_hash_table_destroy(spirv_cache);
         spirv_cache = NULL;
     }
+    g_mutex_unlock(&spirv_cache_lock);
     glslang_finalize_process();
 }
 

--- a/hw/xbox/nv2a/pgraph/vk/glsl.c
+++ b/hw/xbox/nv2a/pgraph/vk/glsl.c
@@ -17,12 +17,158 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "qemu/osdep.h"
+#include "qemu/fast-hash.h"
 #include "ui/xemu-settings.h"
 #include "renderer.h"
 
 #include <assert.h>
 #include <glslang/Include/glslang_c_interface.h>
 #include <stdio.h>
+
+#define SPIRV_CACHE_VERSION 1
+#define SPIRV_CACHE_MAGIC   0x53505643 /* 'SPVC' */
+
+typedef struct SpirvCacheEntry {
+    uint64_t hash;
+    uint32_t spirv_len;
+    uint8_t *spirv_data;
+} SpirvCacheEntry;
+
+static GHashTable *spirv_cache;
+static bool spirv_cache_dirty;
+
+static char *get_spirv_cache_path(void)
+{
+    const char *base = xemu_settings_get_base_path();
+    if (!base) {
+        return NULL;
+    }
+    return g_build_filename(base, "spirv_cache.bin", NULL);
+}
+
+static void spirv_cache_entry_free(gpointer data)
+{
+    SpirvCacheEntry *entry = data;
+    g_free(entry->spirv_data);
+    g_free(entry);
+}
+
+static void load_spirv_cache(void)
+{
+    spirv_cache = g_hash_table_new_full(g_int64_hash, g_int64_equal,
+                                        NULL, spirv_cache_entry_free);
+    if (!g_config.perf.cache_shaders) {
+        return;
+    }
+
+    char *path = get_spirv_cache_path();
+    if (!path) {
+        return;
+    }
+
+    FILE *f = fopen(path, "rb");
+    g_free(path);
+    if (!f) {
+        return;
+    }
+
+    uint32_t magic, version, count;
+    if (fread(&magic, 4, 1, f) != 1 || magic != SPIRV_CACHE_MAGIC ||
+        fread(&version, 4, 1, f) != 1 || version != SPIRV_CACHE_VERSION ||
+        fread(&count, 4, 1, f) != 1) {
+        fclose(f);
+        return;
+    }
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint64_t hash;
+        uint32_t spirv_len;
+        if (fread(&hash, 8, 1, f) != 1 ||
+            fread(&spirv_len, 4, 1, f) != 1 ||
+            spirv_len == 0 || spirv_len > 1024 * 1024) {
+            break;
+        }
+
+        SpirvCacheEntry *entry = g_malloc(sizeof(SpirvCacheEntry));
+        entry->hash = hash;
+        entry->spirv_len = spirv_len;
+        entry->spirv_data = g_malloc(spirv_len);
+        if (fread(entry->spirv_data, 1, spirv_len, f) != spirv_len) {
+            g_free(entry->spirv_data);
+            g_free(entry);
+            break;
+        }
+
+        g_hash_table_insert(spirv_cache, &entry->hash, entry);
+    }
+
+    fclose(f);
+}
+
+static void save_spirv_cache(void)
+{
+    if (!spirv_cache || !spirv_cache_dirty || !g_config.perf.cache_shaders) {
+        return;
+    }
+
+    char *path = get_spirv_cache_path();
+    if (!path) {
+        return;
+    }
+
+    uint32_t magic = SPIRV_CACHE_MAGIC;
+    uint32_t version = SPIRV_CACHE_VERSION;
+    uint32_t count = g_hash_table_size(spirv_cache);
+
+    GByteArray *buf = g_byte_array_new();
+    g_byte_array_append(buf, (const uint8_t *)&magic, 4);
+    g_byte_array_append(buf, (const uint8_t *)&version, 4);
+    g_byte_array_append(buf, (const uint8_t *)&count, 4);
+
+    GHashTableIter iter;
+    gpointer key, value;
+    g_hash_table_iter_init(&iter, spirv_cache);
+    while (g_hash_table_iter_next(&iter, &key, &value)) {
+        SpirvCacheEntry *entry = value;
+        g_byte_array_append(buf, (const uint8_t *)&entry->hash, 8);
+        g_byte_array_append(buf, (const uint8_t *)&entry->spirv_len, 4);
+        g_byte_array_append(buf, entry->spirv_data, entry->spirv_len);
+    }
+
+    /* Atomic write (temp file + rename) so a crash mid-save cannot
+     * clobber an existing good cache with a truncated one. */
+    if (g_file_set_contents(path, (const char *)buf->data, buf->len, NULL)) {
+        spirv_cache_dirty = false;
+    }
+
+    g_byte_array_unref(buf);
+    g_free(path);
+}
+
+static GByteArray *spirv_cache_lookup(const char *glsl)
+{
+    uint64_t hash = fast_hash((const uint8_t *)glsl, strlen(glsl));
+    SpirvCacheEntry *entry = g_hash_table_lookup(spirv_cache, &hash);
+    if (entry) {
+        GByteArray *arr = g_byte_array_sized_new(entry->spirv_len);
+        g_byte_array_append(arr, entry->spirv_data, entry->spirv_len);
+        return arr;
+    }
+    return NULL;
+}
+
+static void spirv_cache_insert(const char *glsl, GByteArray *spirv)
+{
+    uint64_t hash = fast_hash((const uint8_t *)glsl, strlen(glsl));
+    SpirvCacheEntry *entry = g_malloc(sizeof(SpirvCacheEntry));
+    entry->hash = hash;
+    entry->spirv_len = spirv->len;
+    entry->spirv_data = g_malloc(spirv->len);
+    memcpy(entry->spirv_data, spirv->data, spirv->len);
+    g_hash_table_insert(spirv_cache, &entry->hash, entry);
+    spirv_cache_dirty = true;
+}
 
 static const glslang_resource_t
     resource_limits = { .max_lights = 32,
@@ -130,13 +276,25 @@ static const glslang_resource_t
                             .general_constant_matrix_vector_indexing = 1,
                         } };
 
+static bool spirv_atexit_registered;
+
 void pgraph_vk_init_glsl_compiler(void)
 {
     glslang_initialize_process();
+    load_spirv_cache();
+    if (!spirv_atexit_registered) {
+        atexit(save_spirv_cache);
+        spirv_atexit_registered = true;
+    }
 }
 
 void pgraph_vk_finalize_glsl_compiler(void)
 {
+    save_spirv_cache();
+    if (spirv_cache) {
+        g_hash_table_destroy(spirv_cache);
+        spirv_cache = NULL;
+    }
     glslang_finalize_process();
 }
 
@@ -370,8 +528,12 @@ ShaderModuleInfo *pgraph_vk_create_shader_module_from_glsl(
     ShaderModuleInfo *info = g_malloc0(sizeof(*info));
     info->refcnt = 0;
     info->glsl = strdup(glsl);
-    info->spirv = pgraph_vk_compile_glsl_to_spv(
-        vk_shader_stage_to_glslang_stage(stage), glsl);
+    info->spirv = spirv_cache_lookup(glsl);
+    if (!info->spirv) {
+        info->spirv = pgraph_vk_compile_glsl_to_spv(
+            vk_shader_stage_to_glslang_stage(stage), glsl);
+        spirv_cache_insert(glsl, info->spirv);
+    }
     info->module = pgraph_vk_create_shader_module_from_spv(r, info->spirv);
     init_layout_from_spv(info);
     return info;


### PR DESCRIPTION
Carves the platform-neutral cache persistence out of #2799, as suggested there, so it can be reviewed independently of the macOS/MoltenVK work. Two commits:

- **Pipeline cache**: save `VkPipelineCache` contents to `pipeline_cache.bin` on exit and seed the cache from it on the next launch. Falls back to an empty cache if the driver rejects loaded data (e.g. after a driver update).
- **SPIR-V cache**: cache compiled SPIR-V keyed by `fast_hash` of the GLSL source in `spirv_cache.bin`, mirroring the GL shader cache approach.

Design notes, incorporating review feedback from #2799:

- Saves happen via `atexit`, not only `ops.finalize` — a normal quit exits without tearing the renderer down, so a finalize-only save never runs (confirmed independently by @jessedye on #2799).
- Writes are atomic (`g_file_set_contents`: temp file + rename), so a crash mid-save cannot clobber a good cache with a truncated one.
- Both caches are gated on the existing `perf.cache_shaders` setting, matching the GL cache's "Cache shaders to disk" toggle.

Measurements from #2799:

- Raspberry Pi 5 / Mesa V3DV (@jessedye): boot 20.5 → 43.7 fps with seeded caches; steady-state unchanged.
- M3 Ultra / MoltenVK (120 s Halo 2 boots): cold run spends ~557 ms in compile stalls (106 SPIR-V compiles, 124 pipeline creations); seeded run ~46 ms with zero SPIR-V compiles.

The win is confined to startup and first encounters of new shader/pipeline state — each cold miss is a hitch on the render path at the moment the state first appears.

Verified behaviors: caches written on normal quit; corrupt/truncated cache discarded on load; no files created when `cache_shaders` is off.