### PR TITLE
lru: visit active nodes without scanning every bin

### DIFF
--- a/include/qemu/lru.h
+++ b/include/qemu/lru.h
@@ -232,8 +232,8 @@ void lru_visit_active(Lru *lru, LruNodeVisitorFunc visitor_func, void *opaque)
 {
 	LruNode *iter, *iter_next;
 
-	for (unsigned int bin = 0; bin < LRU_NUM_BINS; bin++) {
-		QTAILQ_FOREACH_SAFE(iter, &lru->bins[bin], next_bin, iter_next) {
+	QTAILQ_FOREACH_SAFE(iter, &lru->global, next_global, iter_next) {
+		if (lru_is_node_in_use(lru, iter)) {
 			visitor_func(lru, iter, opaque);
 		}
 	}


### PR DESCRIPTION
lru_visit_active walks all `LRU_NUM_BINS` list heads to find the live nodes. `LRU_NUM_BINS` is `1<<16`, so every call reads 65536 heads spanning a megabyte of cache-cold memory whatever the occupancy. The texture cache holds 1024 nodes, so nearly every one of those reads finds an empty bin.

The `global` list already contains every node, and bin membership is exactly what marks a node active, so walking it and testing `lru_is_node_in_use` visits the same set in at most one iteration per node.

`pgraph_vk_bind_textures` reaches this on every dirty texture bind, via `check_texture_possibly_dirty` -> `pgraph_vk_mark_textures_possibly_dirty`. In a `perf` profile of Morrowind gameplay on a Raspberry Pi 5 it was **2.95% of process time**, the second hottest symbol in the emulator after the TCG block lookup. Measured on a gameplay snapshot, frame time improved from 70.1 ms to 67.3 ms with GPU counters unchanged, which is the signature of a CPU-side change.

The same function is also called from the GL texture cache and the GL shader cache, so the saving is not Vulkan specific.

**Visit order** changes from bin order to LRU order. No caller depends on it:

- `mark_textures_possibly_dirty_visitor` (GL and Vulkan) only sets a flag
- `evict_alias_visitor` removes nodes from their bin, not from the `global` list, so `QTAILQ_FOREACH_SAFE` over `global` stays valid
- `shader_write_lru_list_entry_to_disk` writes an LRU list to disk, where true LRU order is the more faithful one

`QTAILQ_REMOVE` clears `tqe_circ.tql_prev`, which is precisely what `QTAILQ_IN_USE` tests, so a node evicted during the walk is correctly reported as inactive.