### PR TITLE
nv2a/vk: keep occlusion queries inside the render pass

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1057,7 +1057,7 @@ static void bind_descriptor_sets(PGRAPHState *pg)
 static void begin_query(PGRAPHVkState *r)
 {
     assert(r->in_command_buffer);
-    assert(!r->in_render_pass);
+    assert(r->query_pool_reset || !r->in_render_pass);
     assert(!r->query_in_flight);
 
     // FIXME: We should handle this. Make the query buffer bigger, but at least
@@ -1065,8 +1065,10 @@ static void begin_query(PGRAPHVkState *r)
     assert(r->num_queries_in_flight < r->max_queries_in_flight);
 
     nv2a_profile_inc_counter(NV2A_PROF_QUERY);
-    vkCmdResetQueryPool(r->command_buffer, r->query_pool,
-                        r->num_queries_in_flight, 1);
+    if (!r->query_pool_reset) {
+        vkCmdResetQueryPool(r->command_buffer, r->query_pool,
+                            r->num_queries_in_flight, 1);
+    }
     vkCmdBeginQuery(r->command_buffer, r->query_pool, r->num_queries_in_flight,
                     VK_QUERY_CONTROL_PRECISE_BIT);
 
@@ -1078,7 +1080,7 @@ static void begin_query(PGRAPHVkState *r)
 static void end_query(PGRAPHVkState *r)
 {
     assert(r->in_command_buffer);
-    assert(!r->in_render_pass);
+    assert(r->query_pool_reset || !r->in_render_pass);
     assert(r->query_in_flight);
 
     vkCmdEndQuery(r->command_buffer, r->query_pool,
@@ -1193,6 +1195,9 @@ static void begin_render_pass(PGRAPHState *pg)
 static void end_render_pass(PGRAPHVkState *r)
 {
     if (r->in_render_pass) {
+        if (r->query_in_flight && r->query_pool_reset) {
+            end_query(r);
+        }
         vkCmdEndRenderPass(r->command_buffer);
         r->in_render_pass = false;
     }
@@ -1308,6 +1313,12 @@ void pgraph_vk_begin_command_buffer(PGRAPHState *pg)
                                   &command_buffer_begin_info));
     r->command_buffer_start_time = pg->draw_time;
     r->in_command_buffer = true;
+
+    r->query_pool_reset = r->num_queries_in_flight == 0;
+    if (r->query_pool_reset) {
+        vkCmdResetQueryPool(r->command_buffer, r->query_pool, 0,
+                            r->max_queries_in_flight);
+    }
 }
 
 // FIXME: Refactor below
@@ -1409,26 +1420,39 @@ static void begin_draw(PGRAPHState *pg)
 
     assert(r->in_command_buffer);
 
+    bool must_bind_pipeline = r->pipeline_binding_changed;
+    bool split_pass_for_query = !r->query_pool_reset;
+
+    if (!split_pass_for_query && !pg->clearing && pg->zpass_pixel_count_enable &&
+        !r->in_render_pass) {
+        begin_render_pass(pg);
+        must_bind_pipeline = true;
+    }
+
     // Visibility testing
     if (!pg->clearing && pg->zpass_pixel_count_enable) {
         if (r->new_query_needed && r->query_in_flight) {
-            end_render_pass(r);
+            if (split_pass_for_query) {
+                end_render_pass(r);
+            }
             end_query(r);
         }
         if (!r->query_in_flight) {
-            end_render_pass(r);
+            if (split_pass_for_query) {
+                end_render_pass(r);
+            }
             begin_query(r);
         }
     } else if (r->query_in_flight) {
-        end_render_pass(r);
+        if (split_pass_for_query) {
+            end_render_pass(r);
+        }
         end_query(r);
     }
 
     if (pg->clearing) {
         end_render_pass(r);
     }
-
-    bool must_bind_pipeline = r->pipeline_binding_changed;
 
     if (!r->in_render_pass) {
         begin_render_pass(pg);

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -419,6 +419,7 @@ typedef struct PGRAPHVkState {
     int num_queries_in_flight;
     bool new_query_needed;
     bool query_in_flight;
+    bool query_pool_reset;
     uint32_t zpass_pixel_count_result;
     QSIMPLEQ_HEAD(, QueryReport) report_queue; // FIXME: Statically allocate
 


### PR DESCRIPTION
Starting an occlusion query currently ends the render pass:

```c
if (!r->query_in_flight) {
    end_render_pass(r);
    begin_query(r);
}
```

The only reason for that is `vkCmdResetQueryPool`, which cannot be recorded inside a render pass. Resetting the whole pool once per command buffer removes the constraint, and the queries themselves are then free to begin and end inside a pass.

Titles that lean on occlusion queries pay close to one render pass per query without this. Halo's opening level issues 237 a frame:

| | render passes/frame | GPU time/frame | fps |
|---|---|---|---|
| before | 264.4 | 121.6 ms | 5.11 |
| after | 28.2 | 26.0 ms | 19.75 |

That is a Raspberry Pi 5 with V3D, where every pass boundary is a tile store and reload, so the effect is at its most extreme there — measured at ~0.40 ms per boundary, and 236 fewer boundaries accounts for 95.6 ms of the 95.6 ms saved. On an immediate-mode GPU the saving will be smaller, but 236 fewer render passes a frame is not nothing anywhere.

p99 improved alongside p50 (251.6 ms -> 82.2 ms), so there is no tail trade-off, and 1% low went 3.72 -> 11.11.

### Correctness

A query must begin and end in the same scope: both inside one render pass instance, or both outside. Two things keep that true:

- `begin_draw` opens the render pass before beginning the query, so a query never begins outside a pass that is about to be opened around it
- `end_render_pass` closes any query still in flight before ending the pass

Getting this wrong is quiet rather than loud: V3DV returns undefined visibility counts, and titles that gate drawing on the result silently drop geometry.

The pool can only be reset while no results are outstanding. When a command buffer begins with queries still pending, `query_pool_reset` stays false and the previous per-query reset and pass split are used, so that path is unchanged.

### Testing

Soaked on a Pi 5 across six gameplay snapshots (Halo, Halo 2, Morrowind, GTA San Andreas, THPS3, BloodRayne 2) for 3.5 minutes each: no errors, no aborts, no visual differences. Titles that issue no occlusion queries are unaffected — counters confirm `renderpasses` unchanged to within 0.7% on those.