### PR TITLE
nv2a/vk: size storage buffers from the device rather than fixed constants

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/buffer.c
+++ b/hw/xbox/nv2a/pgraph/vk/buffer.c
@@ -19,6 +19,40 @@
 
 #include "renderer.h"
 
+static VkDeviceSize clamp_buffer_size(PGRAPHVkState *r, VkDeviceSize desired,
+                                      bool storage)
+{
+    VkPhysicalDeviceProperties props;
+    vkGetPhysicalDeviceProperties(r->physical_device, &props);
+
+    VkPhysicalDeviceMemoryProperties mem_props;
+    vkGetPhysicalDeviceMemoryProperties(r->physical_device, &mem_props);
+
+    VkDeviceSize largest_heap = 0;
+    for (uint32_t i = 0; i < mem_props.memoryHeapCount; i++) {
+        if (mem_props.memoryHeaps[i].size > largest_heap) {
+            largest_heap = mem_props.memoryHeaps[i].size;
+        }
+    }
+
+    VkDeviceSize limit = desired;
+    if (storage && limit > (VkDeviceSize)props.limits.maxStorageBufferRange) {
+        limit = (VkDeviceSize)props.limits.maxStorageBufferRange;
+    }
+
+    VkDeviceSize budget = largest_heap / 16;
+    if (budget && limit > budget) {
+        limit = budget;
+    }
+
+    VkDeviceSize floor = 8 * 1024 * 1024;
+    if (limit < floor) {
+        limit = desired < floor ? desired : floor;
+    }
+
+    return limit;
+}
+
 static void create_buffer(PGRAPHState *pg, StorageBuffer *buffer)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
@@ -63,7 +97,7 @@ void pgraph_vk_init_buffers(NV2AState *d)
     r->storage_buffers[BUFFER_STAGING_DST] = (StorageBuffer){
         .alloc_info = host_alloc_create_info,
         .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-        .buffer_size = 4096 * 4096 * 4,
+        .buffer_size = clamp_buffer_size(r, 4096 * 4096 * 4, false),
     };
 
     r->storage_buffers[BUFFER_STAGING_SRC] = (StorageBuffer){
@@ -76,7 +110,8 @@ void pgraph_vk_init_buffers(NV2AState *d)
         .alloc_info = device_alloc_create_info,
         .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT |
                  VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
-        .buffer_size = (1024 * 10) * (1024 * 10) * 8,
+        .buffer_size = clamp_buffer_size(r, (VkDeviceSize)(1024 * 10) * (1024 * 10) * 8,
+                                         true),
     };
 
     r->storage_buffers[BUFFER_COMPUTE_SRC] = (StorageBuffer){
@@ -90,7 +125,8 @@ void pgraph_vk_init_buffers(NV2AState *d)
         .alloc_info = device_alloc_create_info,
         .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT |
                  VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
-        .buffer_size = sizeof(pg->inline_elements) * 100,
+        .buffer_size =
+            clamp_buffer_size(r, sizeof(pg->inline_elements) * 100, false),
     };
 
     r->storage_buffers[BUFFER_INDEX_STAGING] = (StorageBuffer){


### PR DESCRIPTION
The storage buffers are sized at build time, and the compute pair asks for 800 MB each:

```c
.buffer_size = (1024 * 10) * (1024 * 10) * 8,   // BUFFER_COMPUTE_DST, and again for _SRC
.buffer_size = 4096 * 4096 * 4,                 // BUFFER_STAGING_DST, and again for _SRC
```

On a discrete GPU with its own VRAM that is satisfiable. Where the heap is system memory shared with everything else, `vmaCreateBuffer` fails and the `VK_CHECK` in `create_buffer` aborts before the renderer ever starts:

```
xemu: ../hw/xbox/nv2a/pgraph/vk/buffer.c:32 create_buffer:
      Assertion `vk_result == VK_SUCCESS && "vk check failed"' failed
```

Mesa V3D on a Raspberry Pi 5 fails this way **regardless of how much RAM the board has** — the constraint is the reported heap size and `maxStorageBufferRange`, not physical memory, so an 8 GB Pi aborts the same as a 2 GB one.

### What this does

Clamps the three buffers whose requests are large and arbitrary to what the device reports:

- storage buffers to `maxStorageBufferRange`, which V3D reports far below the 800 MB request
- all of them to a fraction of the largest heap, so the remainder stays available for surfaces and textures
- a floor, so a small heap still gets something usable

The staging halves continue to derive from their counterparts, so each pair stays the same size.

**Hosts that can satisfy the original requests are unaffected.** On those the desired size is below both limits and `clamp_buffer_size` returns it unchanged, so the allocation is byte-for-byte what it is today.

### Testing

With this plus the GLSL fixes in #2979, a Raspberry Pi 5 (V3D 7.1.10.2, Mesa, 2 GB) goes from aborting at startup to playable under the Vulkan renderer. Measured in real gameplay: Halo 1 ~19-21 fps, Halo 2 ~12, Morrowind ~15-17, THPS3 ~45, GTA San Andreas and BloodRayne 2 at their 30 fps cap. Soaked across six gameplay snapshots with no errors or aborts.

Fixes the Vulkan half of #2918.

Related Pi 5 work: #2979 (GL probe and GUI shaders), #2977, #2980, #2981, #2988, #2994, #2995.