### PR TITLE
nv2a/vk: speed up the remapped vertex copy

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1973,7 +1973,7 @@ static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
 
 #define COPY_REMAPPED_ATTRS(n)                                    \
     do {                                                          \
-        for (uint32_t vertex_id = 0; vertex_id < num_vertices;    \
+        for (uint32_t vertex_id = 0; vertex_id < copy_count;      \
              vertex_id++) {                                       \
             memcpy(out_ptr, in_ptr, (n));                         \
             out_ptr += (n);                                       \
@@ -1999,8 +1999,6 @@ static void copy_remapped_attributes_to_inline_buffer(PGRAPHState *pg,
 
     // FIXME: SIMD memcpy
     // FIXME: Caching
-    // FIXME: Account for only what is drawn
-    assert(start_vertex == 0);
     assert(buffer->mapped);
 
     // Copy vertex data
@@ -2012,11 +2010,14 @@ static void copy_remapped_attributes_to_inline_buffer(PGRAPHState *pg,
         VkDeviceSize attr_buffer_offset =
             buffer->buffer_offset + remap.map[attr_id].offset;
 
-        uint8_t *out_ptr = buffer->mapped + attr_buffer_offset;
-        uint8_t *in_ptr = d->vram_ptr + r->vertex_attribute_offsets[attr_id];
-
         size_t new_stride = remap.map[attr_id].new_stride;
         size_t old_stride = remap.map[attr_id].old_stride;
+        uint32_t copy_count = num_vertices - start_vertex;
+
+        uint8_t *out_ptr = buffer->mapped + attr_buffer_offset +
+                           (size_t)start_vertex * new_stride;
+        uint8_t *in_ptr = d->vram_ptr + r->vertex_attribute_offsets[attr_id] +
+                          (size_t)start_vertex * old_stride;
 
         switch (new_stride) {
         case 4:
@@ -2032,7 +2033,7 @@ static void copy_remapped_attributes_to_inline_buffer(PGRAPHState *pg,
             COPY_REMAPPED_ATTRS(16);
             break;
         default:
-            for (uint32_t vertex_id = 0; vertex_id < num_vertices; vertex_id++) {
+            for (uint32_t vertex_id = 0; vertex_id < copy_count; vertex_id++) {
                 memcpy(out_ptr, in_ptr, new_stride);
                 out_ptr += new_stride;
                 in_ptr += old_stride;
@@ -2080,7 +2081,8 @@ void pgraph_vk_flush_draw(NV2AState *d)
         VertexBufferRemap remap = remap_unaligned_attributes(pg, max_element);
 
         begin_pre_draw(pg);
-        copy_remapped_attributes_to_inline_buffer(pg, remap, 0, max_element);
+        copy_remapped_attributes_to_inline_buffer(pg, remap, min_element,
+                                                  max_element);
         pgraph_vk_begin_debug_marker(r, r->command_buffer, RGBA_BLUE,
                                      "Draw Arrays");
         begin_draw(pg);
@@ -2120,7 +2122,8 @@ void pgraph_vk_flush_draw(NV2AState *d)
         VertexBufferRemap remap = remap_unaligned_attributes(pg, max_element + 1);
 
         begin_pre_draw(pg);
-        copy_remapped_attributes_to_inline_buffer(pg, remap, 0, max_element + 1);
+        copy_remapped_attributes_to_inline_buffer(pg, remap, min_element,
+                                                  max_element + 1);
         VkDeviceSize buffer_offset = pgraph_vk_update_index_buffer(
             pg, pg->inline_elements, index_data_size);
         pgraph_vk_begin_debug_marker(r, r->command_buffer, RGBA_BLUE,

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1971,6 +1971,16 @@ static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
     return remap;
 }
 
+#define COPY_REMAPPED_ATTRS(n)                                    \
+    do {                                                          \
+        for (uint32_t vertex_id = 0; vertex_id < num_vertices;    \
+             vertex_id++) {                                       \
+            memcpy(out_ptr, in_ptr, (n));                         \
+            out_ptr += (n);                                       \
+            in_ptr += old_stride;                                 \
+        }                                                         \
+    } while (0)
+
 static void copy_remapped_attributes_to_inline_buffer(PGRAPHState *pg,
                                                       VertexBufferRemap remap,
                                                       uint32_t start_vertex,
@@ -2005,10 +2015,29 @@ static void copy_remapped_attributes_to_inline_buffer(PGRAPHState *pg,
         uint8_t *out_ptr = buffer->mapped + attr_buffer_offset;
         uint8_t *in_ptr = d->vram_ptr + r->vertex_attribute_offsets[attr_id];
 
-        for (int vertex_id = 0; vertex_id < num_vertices; vertex_id++) {
-            memcpy(out_ptr, in_ptr, remap.map[attr_id].new_stride);
-            out_ptr += remap.map[attr_id].new_stride;
-            in_ptr += remap.map[attr_id].old_stride;
+        size_t new_stride = remap.map[attr_id].new_stride;
+        size_t old_stride = remap.map[attr_id].old_stride;
+
+        switch (new_stride) {
+        case 4:
+            COPY_REMAPPED_ATTRS(4);
+            break;
+        case 8:
+            COPY_REMAPPED_ATTRS(8);
+            break;
+        case 12:
+            COPY_REMAPPED_ATTRS(12);
+            break;
+        case 16:
+            COPY_REMAPPED_ATTRS(16);
+            break;
+        default:
+            for (uint32_t vertex_id = 0; vertex_id < num_vertices; vertex_id++) {
+                memcpy(out_ptr, in_ptr, new_stride);
+                out_ptr += new_stride;
+                in_ptr += old_stride;
+            }
+            break;
         }
 
         r->vertex_attribute_offsets[attr_id] = attr_buffer_offset;


### PR DESCRIPTION
`copy_remapped_attributes_to_inline_buffer` mirrors misaligned vertex attributes into the inline ring. Two things about it are expensive, and both are visible in a profile of Halo 2 gameplay on a Raspberry Pi 5 (aarch64, V3DV), where the function started at 12.18% of process time.

**Specialise the copy on its stride.** The inner loop calls `memcpy` once per vertex for between 4 and 16 bytes, tens of thousands of times a frame, with the size known only at run time. Dispatching once on the stride gives the loop a compile-time size; anything outside the short list of known widths keeps the original loop. The function drops from 12.18% to 5.79% inclusive, and `__memcpy_generic` from 6.53% to 2.07% — the call and the size dispatch cost more than moving the bytes.

**Copy only what the draw reads.** The copy always started at vertex 0 even when the draw began much later. Both call sites already compute the lowest element drawn, and the function already takes a `start_vertex` it asserted was zero, so this passes it through. Space for the whole range stays reserved and the bound offset is unchanged, so attributes that were not remapped keep indexing exactly as before; only the leading vertices that nothing reads go unwritten.

Share of the copy that was never drawn, per frame:

| title | copied | read | wasted |
|---|---|---|---|
| Halo 2 | 845477 | 477036 | 43.6% |
| GTA San Andreas | 161516 | 69546 | 56.9% |
| Morrowind | 73805 | 73805 | 0% |

After both, the function is 2.99% inclusive and its caller `pgraph_vk_flush_draw` goes from 6.39% to 3.81%.

Together this addresses the `FIXME: Account for only what is drawn` above the function.

Tested on aarch64/V3DV across six gameplay snapshots (Halo, Halo 2, BloodRayne 2, Morrowind, GTA San Andreas, Tony Hawk's Pro Skater 3) — no rendering differences, and Morrowind, whose measured waste is 0%, renders bit-identically to before. Also built and run on x86-64 with the Khronos validation layer enabled, which reports the same messages as master.