### PR TITLE
nv2a/vk: derive uniform dirtiness from the copy instead of rehashing

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/glsl.h
+++ b/hw/xbox/nv2a/pgraph/vk/glsl.h
@@ -120,7 +120,7 @@ void *uniform_ptr(ShaderUniformLayout *layout, int idx)
     return (char *)layout->allocation + layout->uniforms[idx - 1].offset;
 }
 
-static inline void uniform_copy(ShaderUniformLayout *layout, int idx,
+static inline bool uniform_copy(ShaderUniformLayout *layout, int idx,
                                 void *values, size_t value_size, size_t count)
 {
     assert(idx > 0 && "invalid uniform index");
@@ -133,16 +133,22 @@ static inline void uniform_copy(ShaderUniformLayout *layout, int idx,
     char *p_max = p_out + layout->total_size;
     char *p_in = (char *)values;
 
+    bool changed = false;
     int index = 0;
     while (bytes_remaining) {
         assert((p_out + element_size) <= p_max);
         assert(index < u->dim_a);
-        memcpy(p_out, p_in, element_size);
+        if (memcmp(p_out, p_in, element_size)) {
+            memcpy(p_out, p_in, element_size);
+            changed = true;
+        }
         bytes_remaining -= element_size;
         p_out += u->stride;
         p_in += element_size;
         index += 1;
     }
+
+    return changed;
 }
 
 static inline

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -410,7 +410,6 @@ typedef struct PGRAPHVkState {
     ShaderModuleCacheEntry *shader_module_cache_entries;
 
     // FIXME: Merge these into a structure
-    uint64_t uniform_buffer_hashes[2];
     size_t uniform_buffer_offsets[2];
     bool uniforms_changed;
 

--- a/hw/xbox/nv2a/pgraph/vk/shaders.c
+++ b/hw/xbox/nv2a/pgraph/vk/shaders.c
@@ -425,19 +425,23 @@ static ShaderBinding *get_shader_binding_for_state(PGRAPHVkState *r,
     return binding;
 }
 
-static void apply_uniform_updates(ShaderUniformLayout *layout,
+static bool apply_uniform_updates(ShaderUniformLayout *layout,
                                   const UniformInfo *info, int *locs,
                                   void *values, size_t count)
 {
+    bool changed = false;
+
     for (int i = 0; i < count; i++) {
         if (locs[i] != -1) {
-            uniform_copy(layout, locs[i], (char*)values + info[i].val_offs,
-                         4, (info[i].size * info[i].count) / 4);
+            changed |= uniform_copy(layout, locs[i],
+                                    (char *)values + info[i].val_offs, 4,
+                                    (info[i].size * info[i].count) / 4);
         }
     }
+
+    return changed;
 }
 
-// FIXME: Dirty tracking
 static void update_shader_uniforms(PGRAPHState *pg)
 {
     NV2A_VK_DGROUP_BEGIN("%s", __func__);
@@ -447,15 +451,13 @@ static void update_shader_uniforms(PGRAPHState *pg)
 
     assert(r->shader_binding);
     ShaderBinding *binding = r->shader_binding;
-    ShaderUniformLayout *layouts[] = { &binding->vsh.module_info->uniforms,
-                                       &binding->psh.module_info->uniforms };
 
     VshUniformValues vsh_values;
     pgraph_glsl_set_vsh_uniform_values(pg, &binding->state.vsh,
                                   binding->vsh.uniform_locs, &vsh_values);
-    apply_uniform_updates(&binding->vsh.module_info->uniforms, VshUniformInfo,
-                          binding->vsh.uniform_locs, &vsh_values,
-                          VshUniform__COUNT);
+    bool changed = apply_uniform_updates(&binding->vsh.module_info->uniforms,
+                                        VshUniformInfo, binding->vsh.uniform_locs,
+                                        &vsh_values, VshUniform__COUNT);
 
     PshUniformValues psh_values;
     pgraph_glsl_set_psh_uniform_values(pg, binding->psh.uniform_locs,
@@ -474,16 +476,11 @@ static void update_shader_uniforms(PGRAPHState *pg)
 
         psh_values.texScale[i] = scale;
     }
-    apply_uniform_updates(&binding->psh.module_info->uniforms, PshUniformInfo,
-                          binding->psh.uniform_locs, &psh_values,
-                          PshUniform__COUNT);
+    changed |= apply_uniform_updates(&binding->psh.module_info->uniforms,
+                                    PshUniformInfo, binding->psh.uniform_locs,
+                                    &psh_values, PshUniform__COUNT);
 
-    for (int i = 0; i < ARRAY_SIZE(layouts); i++) {
-        uint64_t hash =
-            fast_hash(layouts[i]->allocation, layouts[i]->total_size);
-        r->uniforms_changed |= (hash != r->uniform_buffer_hashes[i]);
-        r->uniform_buffer_hashes[i] = hash;
-    }
+    r->uniforms_changed |= changed || r->shader_bindings_changed;
 
     nv2a_profile_inc_counter(r->uniforms_changed ?
                                  NV2A_PROF_SHADER_UBO_DIRTY :


### PR DESCRIPTION
`update_shader_uniforms` writes both uniform blocks and then hashes each one in full to decide whether the UBO needs re-uploading. That is two passes over every byte, every draw, with the vertex constant table making up most of the bytes.

The copy already visits exactly the bytes that can change, so this has it report whether it changed any, and skips the store when it did not. The hash and `uniform_buffer_hashes` then go away.

A binding switch is kept dirty explicitly. The hash caught that case only as a side effect of a different allocation hashing differently, and comparing a block against its own previous contents would not — a binding whose values happen to match what it last held would otherwise be considered clean while the staging buffer still holds a different binding's data.

Padding between std140 elements is no longer part of the comparison. It is never written, so it cannot differ.

This is the dirty tracking the `FIXME: Dirty tracking` above the function asks for.

On the size of it: measured on a Raspberry Pi 5 during Halo 2 gameplay, `XXH3_hashLong_64b_internal` goes from 0.74% to 0.48% of process time and `__memcpy_generic` from 1.56% to 1.21%, with `apply_uniform_updates` picking up 0.10% for the comparison — about 0.15 points net on that hardware. That is below what frame rate can resolve there, so I would not claim a speedup for it; the case is that it is one pass instead of two and resolves the FIXME.

Tested on aarch64/V3DV across six gameplay snapshots with no rendering differences (Morrowind renders bit-identically), and built and run on x86-64 under the Khronos validation layer, which reports the same messages as master.