### PR TITLE
nv2a/vk: enable the features and usage the renderer already relies on

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/buffer.c
+++ b/hw/xbox/nv2a/pgraph/vk/buffer.c
@@ -75,6 +75,7 @@ void pgraph_vk_init_buffers(NV2AState *d)
     r->storage_buffers[BUFFER_COMPUTE_DST] = (StorageBuffer){
         .alloc_info = device_alloc_create_info,
         .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT |
+                 VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
                  VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
         .buffer_size = (1024 * 10) * (1024 * 10) * 8,
     };

--- a/hw/xbox/nv2a/pgraph/vk/instance.c
+++ b/hw/xbox/nv2a/pgraph/vk/instance.c
@@ -331,6 +331,10 @@ static void add_optional_device_extension_names(
     r->memory_budget_extension_enabled = add_extension_if_available(
         available_extensions, enabled_extension_names,
         VK_EXT_MEMORY_BUDGET_EXTENSION_NAME);
+
+    r->demote_to_helper_extension_enabled = add_extension_if_available(
+        available_extensions, enabled_extension_names,
+        VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_EXTENSION_NAME);
 }
 
 static bool check_device_support_required_extensions(VkPhysicalDevice device)
@@ -527,6 +531,31 @@ static bool create_logical_device(PGRAPHState *pg, Error **errp)
             .pNext = next_struct,
         };
         next_struct = &custom_border_features;
+    }
+
+    VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures demote_features;
+    if (r->device_props.apiVersion >= VK_API_VERSION_1_3 ||
+        r->demote_to_helper_extension_enabled) {
+        VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures supported = {
+            .sType =
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES,
+        };
+        VkPhysicalDeviceFeatures2 features2 = {
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2,
+            .pNext = &supported,
+        };
+
+        vkGetPhysicalDeviceFeatures2(r->physical_device, &features2);
+        if (supported.shaderDemoteToHelperInvocation) {
+            demote_features =
+                (VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures){
+                    .sType =
+                        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES,
+                    .shaderDemoteToHelperInvocation = VK_TRUE,
+                    .pNext = next_struct,
+                };
+            next_struct = &demote_features;
+        }
     }
 
     VkDeviceCreateInfo device_create_info = {

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -327,6 +327,7 @@ typedef struct PGRAPHVkState {
     bool debug_utils_extension_enabled;
     bool custom_border_color_extension_enabled;
     bool memory_budget_extension_enabled;
+    bool demote_to_helper_extension_enabled;
 
     VkPhysicalDevice physical_device;
     VkPhysicalDeviceFeatures enabled_physical_device_features;


### PR DESCRIPTION
Running the Khronos validation layer against a dashboard boot reports 20 errors on master. They are two distinct bugs, and both are a capability being used without the thing that permits it.

**`shaderDemoteToHelperInvocation` is never enabled.** Shaders are compiled for Vulkan 1.3 and SPIR-V 1.6 (`glsl.c`), where glslang lowers `discard` to `OpDemoteToHelperInvocation`. That capability requires the `shaderDemoteToHelperInvocation` feature, but the device is created with only core 1.0 `pEnabledFeatures` and no `pNext` chain, so nothing enables it — `VUID-VkShaderModuleCreateInfo-pCode-08740`, ten times per run.

This queries the feature and enables it, either as the core feature on a 1.3 device or through `VK_EXT_shader_demote_to_helper_invocation` where the device is older. The extension path is not hypothetical: V3DV on the Raspberry Pi 5 reports device apiVersion 1.2 and offers only the EXT form, so a core-only fix would miss it.

**`BUFFER_COMPUTE_DST` lacks `TRANSFER_SRC`.** It is the source of a `vkCmdCopyBufferToImage` after the depth-stencil unpack compute shader writes into it, but is created with only `TRANSFER_DST | STORAGE_BUFFER` — `VUID-vkCmdCopyBufferToImage-srcBuffer-00174`, ten times per run.

Booting the dashboard for 45 s with the layer enabled: **20 errors before, 0 after.**

Testing:

- x86-64 / NVIDIA, validation layer enabled — 20 errors before, 0 after, no other change in reported messages.
- aarch64 / V3DV on a Raspberry Pi 5, which takes the extension path rather than the core one. Master does not currently start there: `ui/xemu.c` asks for a GL 4.0 context and rejects anything reporting less than 4.0, while V3DV offers 3.1. The Pi testing was therefore done with this applied over the branch I run there, which lowers that request and carries #2979, which makes the GL renderer and GUI shaders work at that level. No rendering differences; Morrowind renders bit-identically.
