### PR TITLE
nv2a/vk: compile SPIR-V for the version the device supports

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/glsl.c
+++ b/hw/xbox/nv2a/pgraph/vk/glsl.c
@@ -130,6 +130,25 @@ static const glslang_resource_t
                             .general_constant_matrix_vector_indexing = 1,
                         } };
 
+static glslang_target_client_version_t g_client_version =
+    GLSLANG_TARGET_VULKAN_1_1;
+static glslang_target_language_version_t g_target_spv =
+    GLSLANG_TARGET_SPV_1_3;
+
+void pgraph_vk_set_glsl_target(uint32_t device_api_version)
+{
+    if (device_api_version >= VK_API_VERSION_1_3) {
+        g_client_version = GLSLANG_TARGET_VULKAN_1_3;
+        g_target_spv = GLSLANG_TARGET_SPV_1_6;
+    } else if (device_api_version >= VK_API_VERSION_1_2) {
+        g_client_version = GLSLANG_TARGET_VULKAN_1_2;
+        g_target_spv = GLSLANG_TARGET_SPV_1_5;
+    } else {
+        g_client_version = GLSLANG_TARGET_VULKAN_1_1;
+        g_target_spv = GLSLANG_TARGET_SPV_1_3;
+    }
+}
+
 void pgraph_vk_init_glsl_compiler(void)
 {
     glslang_initialize_process();
@@ -147,9 +166,9 @@ GByteArray *pgraph_vk_compile_glsl_to_spv(glslang_stage_t stage,
         .language = GLSLANG_SOURCE_GLSL,
         .stage = stage,
         .client = GLSLANG_CLIENT_VULKAN,
-        .client_version = GLSLANG_TARGET_VULKAN_1_3,
+        .client_version = g_client_version,
         .target_language = GLSLANG_TARGET_SPV,
-        .target_language_version = GLSLANG_TARGET_SPV_1_6,
+        .target_language_version = g_target_spv,
         .code = glsl_source,
         .default_version = 460,
         .default_profile = GLSLANG_NO_PROFILE,

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -456,6 +456,7 @@ uint32_t pgraph_vk_get_memory_type(PGRAPHState *pg, uint32_t type_bits,
                                    VkMemoryPropertyFlags properties);
 
 // glsl.c
+void pgraph_vk_set_glsl_target(uint32_t device_api_version);
 void pgraph_vk_init_glsl_compiler(void);
 void pgraph_vk_finalize_glsl_compiler(void);
 GByteArray *pgraph_vk_compile_glsl_to_spv(glslang_stage_t stage,

--- a/hw/xbox/nv2a/pgraph/vk/shaders.c
+++ b/hw/xbox/nv2a/pgraph/vk/shaders.c
@@ -521,6 +521,7 @@ void pgraph_vk_init_shaders(PGRAPHState *pg)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
 
+    pgraph_vk_set_glsl_target(r->device_props.apiVersion);
     pgraph_vk_init_glsl_compiler();
     create_descriptor_pool(pg);
     create_descriptor_set_layout(pg);


### PR DESCRIPTION
`pgraph_vk_compile_glsl_to_spv` asks glslang for Vulkan 1.3 and SPIR-V 1.6 regardless of what the physical device reports. On anything older that produces a module the driver is not required to accept. The validation layer is blunt about it:

```
SPIR-V module not valid: Invalid SPIR-V binary version 1.6 for target environment
```

once for every shader the renderer builds.

This is not hypothetical hardware. V3DV on the Raspberry Pi 5 reports device apiVersion 1.2, so every shader compiled there today is out of spec.

Select the client and SPIR-V versions from the device's own `apiVersion`. `pgraph_vk_init_instance` runs before `pgraph_vk_init_shaders`, so the value is known by the time the compiler is initialised.

A side effect worth noting: at SPIR-V 1.5 glslang no longer lowers `discard` to `OpDemoteToHelperInvocation`, so this also removes the `DemoteToHelperInvocation` capability errors on those devices. #2999 remains the right fix for 1.3 devices, where SPIR-V 1.6 is targeted and the capability genuinely is used — the two are complementary.

Testing on aarch64 / V3DV (a 1.2 device, so it takes the changed path), across six gameplay snapshots — Halo, Halo 2, BloodRayne 2, Morrowind, GTA San Andreas, Tony Hawk's Pro Skater 3:

- Halo 2 gameplay under the validation layer: `VUID-VkShaderModuleCreateInfo-pCode-01091` goes from 416 occurrences to none, and the "Invalid SPIR-V binary version" errors with it.
- No rendering differences on any snapshot. Morrowind renders bit-identically to before despite every shader being recompiled at a different SPIR-V version.

Master does not currently start on that hardware: `ui/xemu.c` asks for a GL 4.0 context and rejects anything reporting less than 4.0, while V3DV offers 3.1. The Pi testing was therefore done with this change applied over the branch I run there, which lowers that request (and carries #2979, which makes the GL renderer and GUI shaders work at that level). Also built on x86-64.