### PR TITLE
nv2a/vk: use a standard border colour where the colour is standard

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/texture.c
+++ b/hw/xbox/nv2a/pgraph/vk/texture.c
@@ -1266,7 +1266,27 @@ static void create_texture(PGRAPHState *pg, int texture_idx)
 
     bool is_integer_type = vkf.vk_format == VK_FORMAT_R32_UINT;
 
-    if (r->custom_border_color_extension_enabled) {
+    bool standard_border_color = true;
+    switch (border_color_pack32) {
+    case 0x00000000:
+        vk_border_color = is_integer_type ?
+                              VK_BORDER_COLOR_INT_TRANSPARENT_BLACK :
+                              VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+        break;
+    case 0xff000000:
+        vk_border_color = is_integer_type ? VK_BORDER_COLOR_INT_OPAQUE_BLACK :
+                                            VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
+        break;
+    case 0xffffffff:
+        vk_border_color = is_integer_type ? VK_BORDER_COLOR_INT_OPAQUE_WHITE :
+                                            VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+        break;
+    default:
+        standard_border_color = false;
+        break;
+    }
+
+    if (!standard_border_color && r->custom_border_color_extension_enabled) {
         vk_border_color = is_integer_type ? VK_BORDER_COLOR_INT_CUSTOM_EXT :
                                             VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
         custom_border_color_create_info =
@@ -1291,15 +1311,8 @@ static void create_texture(PGRAPHState *pg, int texture_idx)
         sampler_next_struct = &custom_border_color_create_info;
     } else {
         // FIXME: Handle custom color in shader
-        if (is_integer_type) {
-            vk_border_color = VK_BORDER_COLOR_INT_TRANSPARENT_BLACK;
-        } else if (border_color_pack32 == 0x00000000) {
-            vk_border_color = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
-        } else if (border_color_pack32 == 0xff000000) {
-            vk_border_color = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
-        } else {
-            vk_border_color = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
-        }
+        vk_border_color = is_integer_type ? VK_BORDER_COLOR_INT_TRANSPARENT_BLACK :
+                                            VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
     }
 
     if (filter & NV_PGRAPH_TEXFILTER0_ASIGNED)


### PR DESCRIPTION
Every sampler asks for a custom border colour whenever `VK_EXT_custom_border_color` is available, including when the colour requested is one Vulkan already has an enumerant for.

Custom border colours are a limited resource. `maxCustomBorderColorSamplers` is **24** on V3DV, while the texture cache holds up to 1024 entries, so the limit is exceeded by orders of magnitude. Under the validation layer, 60 s of Halo 2 gameplay produces **5142** `VUID-VkSamplerCreateInfo-None-04012` reports.

Transparent black, opaque black and opaque white are exactly the three colours Vulkan enumerates. Matching them first and falling back to a custom colour only for the rest takes that count to **zero** — every border colour Halo 2 asks for is one of the three, so the custom path was being spent on nothing.

The fallback used when the extension is unavailable loses its own checks for those three values, which are now handled before it and unreachable there.

Testing on aarch64 / V3DV across six gameplay snapshots — Halo, Halo 2, BloodRayne 2, Morrowind, GTA San Andreas, Tony Hawk's Pro Skater 3:

- Halo 2 under the validation layer: 5142 sampler reports before, none after. Total reports for the run drop from 2914 to 359, the remainder being two unrelated issues.
- No rendering differences on any snapshot. Border colour affects sampling at texture edges, so each frame was compared against a reference and inspected; Morrowind renders bit-identically.

Master does not currently start on that hardware: `ui/xemu.c` asks for a GL 4.0 context and rejects anything reporting less than 4.0, while V3DV offers 3.1. The Pi testing was therefore done with this change applied over the branch I run there, which lowers that request (and carries #2979, which makes the GL renderer and GUI shaders work at that level). Also built on x86-64.