### PR TITLE
nv2a/vk: convert vertex attributes the device cannot consume

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1896,6 +1896,13 @@ static void get_size_and_count_for_format(VkFormat fmt, size_t *size, size_t *co
     *count = table[fmt].count;
 }
 
+enum VertexConvert {
+    VTX_CONVERT_NONE,
+    VTX_CONVERT_WIDEN3_U8,
+    VTX_CONVERT_WIDEN3_S16,
+    VTX_CONVERT_S16_TO_F32,
+};
+
 typedef struct VertexBufferRemap {
     uint16_t attributes;
     size_t buffer_space_required;
@@ -1903,8 +1910,46 @@ typedef struct VertexBufferRemap {
         VkDeviceAddress offset;
         VkDeviceSize old_stride;
         VkDeviceSize new_stride;
+        VkDeviceSize read_size;
+        enum VertexConvert convert;
     } map[NV2A_VERTEXSHADER_ATTRIBUTES];
 } VertexBufferRemap;
+
+static bool format_supported_for_vertex_buffer(PGRAPHVkState *r, VkFormat fmt)
+{
+    VkFormatProperties props;
+
+    vkGetPhysicalDeviceFormatProperties(r->physical_device, fmt, &props);
+    return (props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) != 0;
+}
+
+static VkFormat substitute_vertex_format(VkFormat fmt,
+                                         enum VertexConvert *convert)
+{
+    switch (fmt) {
+    case VK_FORMAT_R8G8B8_UNORM:
+        *convert = VTX_CONVERT_WIDEN3_U8;
+        return VK_FORMAT_R8G8B8A8_UNORM;
+    case VK_FORMAT_R16G16B16_SNORM:
+        *convert = VTX_CONVERT_WIDEN3_S16;
+        return VK_FORMAT_R16G16B16A16_SNORM;
+    case VK_FORMAT_R16_SSCALED:
+        *convert = VTX_CONVERT_S16_TO_F32;
+        return VK_FORMAT_R32_SFLOAT;
+    case VK_FORMAT_R16G16_SSCALED:
+        *convert = VTX_CONVERT_S16_TO_F32;
+        return VK_FORMAT_R32G32_SFLOAT;
+    case VK_FORMAT_R16G16B16_SSCALED:
+        *convert = VTX_CONVERT_S16_TO_F32;
+        return VK_FORMAT_R32G32B32_SFLOAT;
+    case VK_FORMAT_R16G16B16A16_SSCALED:
+        *convert = VTX_CONVERT_S16_TO_F32;
+        return VK_FORMAT_R32G32B32A32_SFLOAT;
+    default:
+        *convert = VTX_CONVERT_NONE;
+        return VK_FORMAT_UNDEFINED;
+    }
+}
 
 static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
                                                     uint32_t num_vertices)
@@ -1933,14 +1978,35 @@ static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
             (r->vertex_attribute_offsets[attr_id] % element_size == 0);
         bool stride_valid = (desc->stride % element_size == 0);
 
-        if (offset_valid && stride_valid) {
+        enum VertexConvert convert = VTX_CONVERT_NONE;
+        VkFormat substitute = VK_FORMAT_UNDEFINED;
+
+        if (!format_supported_for_vertex_buffer(r, attr->format)) {
+            substitute = substitute_vertex_format(attr->format, &convert);
+        }
+
+        if (offset_valid && stride_valid && substitute == VK_FORMAT_UNDEFINED) {
             continue;
+        }
+
+        size_t read_size = element_size * element_count;
+        size_t write_size = read_size;
+
+        if (substitute != VK_FORMAT_UNDEFINED) {
+            size_t sub_size, sub_count;
+
+            get_size_and_count_for_format(substitute, &sub_size, &sub_count);
+            write_size = sub_size * sub_count;
+            element_size = sub_size;
+            attr->format = substitute;
         }
 
         remap.attributes |= 1 << attr_id;
         remap.map[attr_id].offset = ROUND_UP(output_offset, element_size);
         remap.map[attr_id].old_stride = desc->stride;
-        remap.map[attr_id].new_stride = element_size * element_count;
+        remap.map[attr_id].new_stride = write_size;
+        remap.map[attr_id].read_size = read_size;
+        remap.map[attr_id].convert = convert;
 
         // fprintf(stderr,
         //         "attr %02d remapped: "
@@ -2018,6 +2084,42 @@ static void copy_remapped_attributes_to_inline_buffer(PGRAPHState *pg,
                            (size_t)start_vertex * new_stride;
         uint8_t *in_ptr = d->vram_ptr + r->vertex_attribute_offsets[attr_id] +
                           (size_t)start_vertex * old_stride;
+
+        if (remap.map[attr_id].convert != VTX_CONVERT_NONE) {
+            size_t read_size = remap.map[attr_id].read_size;
+
+            for (uint32_t vertex_id = 0; vertex_id < copy_count; vertex_id++) {
+                switch (remap.map[attr_id].convert) {
+                case VTX_CONVERT_WIDEN3_U8:
+                    memcpy(out_ptr, in_ptr, 3);
+                    out_ptr[3] = 0xff;
+                    break;
+                case VTX_CONVERT_WIDEN3_S16: {
+                    int16_t w = INT16_MAX;
+
+                    memcpy(out_ptr, in_ptr, 6);
+                    memcpy(out_ptr + 6, &w, sizeof(w));
+                    break;
+                }
+                case VTX_CONVERT_S16_TO_F32:
+                    for (size_t i = 0; i < read_size / 2; i++) {
+                        int16_t v;
+                        float f;
+
+                        memcpy(&v, in_ptr + i * 2, sizeof(v));
+                        f = (float)v;
+                        memcpy(out_ptr + i * 4, &f, sizeof(f));
+                    }
+                    break;
+                default:
+                    break;
+                }
+                out_ptr += new_stride;
+                in_ptr += old_stride;
+            }
+            r->vertex_attribute_offsets[attr_id] = attr_buffer_offset;
+            continue;
+        }
 
         switch (new_stride) {
         case 4:

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1973,7 +1973,7 @@ static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
 
 #define COPY_REMAPPED_ATTRS(n)                                    \
     do {                                                          \
-        for (uint32_t vertex_id = 0; vertex_id < num_vertices;    \
+        for (uint32_t vertex_id = 0; vertex_id < copy_count;      \
              vertex_id++) {                                       \
             memcpy(out_ptr, in_ptr, (n));                         \
             out_ptr += (n);                                       \
@@ -1999,8 +1999,6 @@ static void copy_remapped_attributes_to_inline_buffer(PGRAPHState *pg,
 
     // FIXME: SIMD memcpy
     // FIXME: Caching
-    // FIXME: Account for only what is drawn
-    assert(start_vertex == 0);
     assert(buffer->mapped);
 
     // Copy vertex data
@@ -2012,11 +2010,14 @@ static void copy_remapped_attributes_to_inline_buffer(PGRAPHState *pg,
         VkDeviceSize attr_buffer_offset =
             buffer->buffer_offset + remap.map[attr_id].offset;
 
-        uint8_t *out_ptr = buffer->mapped + attr_buffer_offset;
-        uint8_t *in_ptr = d->vram_ptr + r->vertex_attribute_offsets[attr_id];
-
         size_t new_stride = remap.map[attr_id].new_stride;
         size_t old_stride = remap.map[attr_id].old_stride;
+        uint32_t copy_count = num_vertices - start_vertex;
+
+        uint8_t *out_ptr = buffer->mapped + attr_buffer_offset +
+                           (size_t)start_vertex * new_stride;
+        uint8_t *in_ptr = d->vram_ptr + r->vertex_attribute_offsets[attr_id] +
+                          (size_t)start_vertex * old_stride;
 
         switch (new_stride) {
         case 4:
@@ -2032,7 +2033,7 @@ static void copy_remapped_attributes_to_inline_buffer(PGRAPHState *pg,
             COPY_REMAPPED_ATTRS(16);
             break;
         default:
-            for (uint32_t vertex_id = 0; vertex_id < num_vertices; vertex_id++) {
+            for (uint32_t vertex_id = 0; vertex_id < copy_count; vertex_id++) {
                 memcpy(out_ptr, in_ptr, new_stride);
                 out_ptr += new_stride;
                 in_ptr += old_stride;
@@ -2080,7 +2081,8 @@ void pgraph_vk_flush_draw(NV2AState *d)
         VertexBufferRemap remap = remap_unaligned_attributes(pg, max_element);
 
         begin_pre_draw(pg);
-        copy_remapped_attributes_to_inline_buffer(pg, remap, 0, max_element);
+        copy_remapped_attributes_to_inline_buffer(pg, remap, min_element,
+                                                  max_element);
         pgraph_vk_begin_debug_marker(r, r->command_buffer, RGBA_BLUE,
                                      "Draw Arrays");
         begin_draw(pg);
@@ -2120,7 +2122,8 @@ void pgraph_vk_flush_draw(NV2AState *d)
         VertexBufferRemap remap = remap_unaligned_attributes(pg, max_element + 1);
 
         begin_pre_draw(pg);
-        copy_remapped_attributes_to_inline_buffer(pg, remap, 0, max_element + 1);
+        copy_remapped_attributes_to_inline_buffer(pg, remap, min_element,
+                                                  max_element + 1);
         VkDeviceSize buffer_offset = pgraph_vk_update_index_buffer(
             pg, pg->inline_elements, index_data_size);
         pgraph_vk_begin_debug_marker(r, r->command_buffer, RGBA_BLUE,

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1971,6 +1971,16 @@ static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
     return remap;
 }
 
+#define COPY_REMAPPED_ATTRS(n)                                    \
+    do {                                                          \
+        for (uint32_t vertex_id = 0; vertex_id < num_vertices;    \
+             vertex_id++) {                                       \
+            memcpy(out_ptr, in_ptr, (n));                         \
+            out_ptr += (n);                                       \
+            in_ptr += old_stride;                                 \
+        }                                                         \
+    } while (0)
+
 static void copy_remapped_attributes_to_inline_buffer(PGRAPHState *pg,
                                                       VertexBufferRemap remap,
                                                       uint32_t start_vertex,
@@ -2005,10 +2015,29 @@ static void copy_remapped_attributes_to_inline_buffer(PGRAPHState *pg,
         uint8_t *out_ptr = buffer->mapped + attr_buffer_offset;
         uint8_t *in_ptr = d->vram_ptr + r->vertex_attribute_offsets[attr_id];
 
-        for (int vertex_id = 0; vertex_id < num_vertices; vertex_id++) {
-            memcpy(out_ptr, in_ptr, remap.map[attr_id].new_stride);
-            out_ptr += remap.map[attr_id].new_stride;
-            in_ptr += remap.map[attr_id].old_stride;
+        size_t new_stride = remap.map[attr_id].new_stride;
+        size_t old_stride = remap.map[attr_id].old_stride;
+
+        switch (new_stride) {
+        case 4:
+            COPY_REMAPPED_ATTRS(4);
+            break;
+        case 8:
+            COPY_REMAPPED_ATTRS(8);
+            break;
+        case 12:
+            COPY_REMAPPED_ATTRS(12);
+            break;
+        case 16:
+            COPY_REMAPPED_ATTRS(16);
+            break;
+        default:
+            for (uint32_t vertex_id = 0; vertex_id < num_vertices; vertex_id++) {
+                memcpy(out_ptr, in_ptr, new_stride);
+                out_ptr += new_stride;
+                in_ptr += old_stride;
+            }
+            break;
         }
 
         r->vertex_attribute_offsets[attr_id] = attr_buffer_offset;


### PR DESCRIPTION
Depends on #2997, which touches the same copy loop.

Vertex formats are chosen from the guest's attribute format alone, without asking whether the device accepts them as vertex buffer formats. Querying every format reachable here against V3DV on a Raspberry Pi 5:

| format | V3DV |
|---|---|
| `R8G8B8_UNORM` | not supported |
| `R16G16B16_SNORM` | not supported |
| `R16_SSCALED` | not supported |
| `R16G16_SSCALED` | not supported |
| `R16G16B16_SSCALED` | not supported |
| `R16G16B16A16_SSCALED` | not supported |

Pipelines are created with them regardless, which the validation layer reports as `VUID-VkVertexInputAttributeDescription-format-00623`. Three-component formats are widely unsupported for vertex buffers, and the whole SSCALED family is the Xbox S32K vertex type.

`remap_unaligned_attributes` already exists to rewrite attributes the device cannot read directly, so this routes unsupported formats through it too and converts while copying: three-component formats widen to four with w at one, and SSCALED becomes SFLOAT, which is the value the shader would have received anyway. Where the device accepts the format the query short-circuits and nothing changes.

**Scope.** In 60 s of Halo 2 gameplay the reports drop from 274 to 14. What remains is `R16G16B16A16_SSCALED` reaching the inline-array path, which does not go through the remap at all and needs its data converted at a different site. I have not attempted that here — this covers the vertex-array and inline-element paths, and does not make the inline case any worse.

Testing on aarch64 / V3DV across six gameplay snapshots — Halo, Halo 2, BloodRayne 2, Morrowind, GTA San Andreas, Tony Hawk's Pro Skater 3. Halo 2 is the title that exercises this, using `R16G16B16_SNORM` 87 times and `R8G8B8_UNORM` 40 times per run; both go to zero and its geometry is unchanged. Morrowind renders bit-identically.

Note this path cannot be exercised on a desktop GPU, where all these formats are supported and the query short-circuits, so the testing that matters is on V3DV. Master does not currently start there: `ui/xemu.c` asks for a GL 4.0 context and rejects anything reporting less than 4.0, while V3DV offers 3.1. The Pi testing was therefore done with this applied over the branch I run there, which lowers that request and carries #2979, which makes the GL renderer and GUI shaders work at that level. Also built on x86-64.
