### PR TITLE
ui: fall back to a GL 3.1 context when 4.0 is unavailable

### DIFF
--- a/hw/xbox/nv2a/pgraph/thirdparty/gloffscreen/sdl.c
+++ b/hw/xbox/nv2a/pgraph/thirdparty/gloffscreen/sdl.c
@@ -48,28 +48,48 @@ GloContext *glo_context_create(void)
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 
-    // Initialize rendering context
-    SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
-    SDL_GL_SetAttribute(
-        SDL_GL_CONTEXT_PROFILE_MASK,
-        SDL_GL_CONTEXT_PROFILE_CORE);
+    static const struct {
+        int major, minor;
+    } versions[] = { { 4, 0 }, { 3, 1 } };
 
-    // Create main window
-    context->window = SDL_CreateWindow(
-        "SDL Offscreen Window",
-        640, 480,
-        SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
+    context->window = NULL;
+    context->gl_context = NULL;
+
+    for (unsigned i = 0; i < sizeof(versions) / sizeof(versions[0]); i++) {
+        SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, versions[i].major);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, versions[i].minor);
+        SDL_GL_SetAttribute(
+            SDL_GL_CONTEXT_PROFILE_MASK,
+            SDL_GL_CONTEXT_PROFILE_CORE);
+
+        context->window = SDL_CreateWindow(
+            "SDL Offscreen Window",
+            640, 480,
+            SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
+        if (context->window == NULL) {
+            continue;
+        }
+
+        context->gl_context = SDL_GL_CreateContext(context->window);
+        if (context->gl_context != NULL) {
+            break;
+        }
+
+        SDL_DestroyWindow(context->window);
+        context->window = NULL;
+    }
+
     if (context->window == NULL) {
-        fprintf(stderr, "%s: Failed to create window\n", __func__);
+        fprintf(stderr, "%s: Failed to create window: %s\n", __func__,
+                SDL_GetError());
         SDL_Quit();
         exit(1);
     }
 
-    context->gl_context = SDL_GL_CreateContext(context->window);
     if (context->gl_context == NULL) {
-        fprintf(stderr, "%s: Failed to create GL context\n", __func__);
+        fprintf(stderr, "%s: Failed to create GL context: %s\n", __func__,
+                SDL_GetError());
         SDL_DestroyWindow(context->window);
         SDL_Quit();
         exit(1);

--- a/ui/shader/xemu-logo.frag
+++ b/ui/shader/xemu-logo.frag
@@ -1,4 +1,4 @@
-#version 330
+#version 140
 uniform sampler2D tex;
 uniform vec4 in_ColorPrimary;
 uniform vec4 in_ColorFill;

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -1050,10 +1050,22 @@ static void display_very_early_init(DisplayOptions *o)
     }
 
     if (m_context == NULL) {
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+        m_context = SDL_GL_CreateContext(m_window);
+
+        if (m_context != NULL && epoxy_gl_version() < 31) {
+            SDL_GL_MakeCurrent(NULL, NULL);
+            SDL_GL_DestroyContext(m_context);
+            m_context = NULL;
+        }
+    }
+
+    if (m_context == NULL) {
         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
             "Unable to create OpenGL context",
             "Unable to create OpenGL context. This usually means the\r\n"
-            "graphics device on this system does not support OpenGL 4.0.\r\n"
+            "graphics device on this system does not support OpenGL 3.1.\r\n"
             "\r\n"
             "xemu cannot continue and will now exit.",
             m_window);

--- a/ui/xui/main.cc
+++ b/ui/xui/main.cc
@@ -145,7 +145,8 @@ void xemu_hud_init(SDL_Window* window, void* sdl_gl_context)
 
     // Setup Platform/Renderer bindings
     ImGui_ImplSDL3_InitForOpenGL(window, sdl_gl_context);
-    ImGui_ImplOpenGL3_Init("#version 150");
+    ImGui_ImplOpenGL3_Init(epoxy_gl_version() >= 32 ? "#version 150" :
+                                                     "#version 140");
     ImPlot::CreateContext();
 
 #if defined(_WIN32)


### PR DESCRIPTION
xemu asks for a GL 4.0 context and exits when it does not get one, in two places: the main window in `ui/xemu.c` and the offscreen context in `gloffscreen/sdl.c`. The window only composites a textured quad and the interface, and the offscreen context exists for display interop, so neither needs 4.0. A device that tops out earlier is turned away even when the Vulkan renderer is selected and fully supported.

V3DV on the Raspberry Pi 5 reports GL 3.1, so xemu cannot start there at all — the first thing a user sees is "graphics device on this system does not support OpenGL 4.0. xemu cannot continue and will now exit."

This asks for 4.0 first and keeps it wherever it is offered, so nothing changes for devices that have it, and retries at 3.1 only when it is not. In `gloffscreen/sdl.c` the window is recreated for the retry, because the GL attributes bind to the window when it is created and setting them afterwards has no effect on an existing one. Both failure paths now report `SDL_GetError()`, which is what made this diagnosable.

`ui/shader/xemu-logo.frag` is lowered to `#version 140` alongside, since it is the one interface shader still asking for 330 and a 3.1 context is useless while it fails to compile.

Testing:

- x86-64 / NVIDIA: still reports `GL_VERSION: 4.0.0`, so the 4.0 path is taken unchanged.
- aarch64 / V3DV on a Raspberry Pi 5: both contexts are now created at 3.1 (`GL_VERSION: 3.1 Mesa 24.2.8`) and startup proceeds past the interface into renderer initialisation, where master previously exited at the message box.

This removes the GL barrier but is not on its own sufficient for that hardware — with #2979 and #2996 also applied, startup now reaches Vulkan buffer creation and fails there with `VK_ERROR_OUT_OF_DEVICE_MEMORY`, which is a separate issue I am still looking at. Submitting this on its own because refusing to start on a 3.1 device is wrong regardless of what comes after it.