### PR TITLE
nv2a/vk: retry a smaller buffer when the device is short of memory

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/buffer.c
+++ b/hw/xbox/nv2a/pgraph/vk/buffer.c
@@ -19,6 +19,40 @@
 
 #include "renderer.h"
 
+static VkDeviceSize clamp_buffer_size(PGRAPHVkState *r, VkDeviceSize desired,
+                                      bool storage)
+{
+    VkPhysicalDeviceProperties props;
+    vkGetPhysicalDeviceProperties(r->physical_device, &props);
+
+    VkPhysicalDeviceMemoryProperties mem_props;
+    vkGetPhysicalDeviceMemoryProperties(r->physical_device, &mem_props);
+
+    VkDeviceSize largest_heap = 0;
+    for (uint32_t i = 0; i < mem_props.memoryHeapCount; i++) {
+        if (mem_props.memoryHeaps[i].size > largest_heap) {
+            largest_heap = mem_props.memoryHeaps[i].size;
+        }
+    }
+
+    VkDeviceSize limit = desired;
+    if (storage && limit > (VkDeviceSize)props.limits.maxStorageBufferRange) {
+        limit = (VkDeviceSize)props.limits.maxStorageBufferRange;
+    }
+
+    VkDeviceSize budget = largest_heap / 16;
+    if (budget && limit > budget) {
+        limit = budget;
+    }
+
+    VkDeviceSize floor = 8 * 1024 * 1024;
+    if (limit < floor) {
+        limit = desired < floor ? desired : floor;
+    }
+
+    return limit;
+}
+
 static void create_buffer(PGRAPHState *pg, StorageBuffer *buffer)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
@@ -63,7 +97,7 @@ void pgraph_vk_init_buffers(NV2AState *d)
     r->storage_buffers[BUFFER_STAGING_DST] = (StorageBuffer){
         .alloc_info = host_alloc_create_info,
         .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-        .buffer_size = 4096 * 4096 * 4,
+        .buffer_size = clamp_buffer_size(r, 4096 * 4096 * 4, false),
     };
 
     r->storage_buffers[BUFFER_STAGING_SRC] = (StorageBuffer){
@@ -76,7 +110,8 @@ void pgraph_vk_init_buffers(NV2AState *d)
         .alloc_info = device_alloc_create_info,
         .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT |
                  VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
-        .buffer_size = (1024 * 10) * (1024 * 10) * 8,
+        .buffer_size = clamp_buffer_size(r, (VkDeviceSize)(1024 * 10) * (1024 * 10) * 8,
+                                         true),
     };
 
     r->storage_buffers[BUFFER_COMPUTE_SRC] = (StorageBuffer){
@@ -90,7 +125,8 @@ void pgraph_vk_init_buffers(NV2AState *d)
         .alloc_info = device_alloc_create_info,
         .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT |
                  VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
-        .buffer_size = sizeof(pg->inline_elements) * 100,
+        .buffer_size =
+            clamp_buffer_size(r, sizeof(pg->inline_elements) * 100, false),
     };
 
     r->storage_buffers[BUFFER_INDEX_STAGING] = (StorageBuffer){

--- a/hw/xbox/nv2a/pgraph/vk/buffer.c
+++ b/hw/xbox/nv2a/pgraph/vk/buffer.c
@@ -57,15 +57,46 @@ static void create_buffer(PGRAPHState *pg, StorageBuffer *buffer)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
 
-    VkBufferCreateInfo buffer_create_info = {
-        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-        .size = buffer->buffer_size,
-        .usage = buffer->usage,
-        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
-    };
-    VK_CHECK(vmaCreateBuffer(r->allocator, &buffer_create_info,
-                             &buffer->alloc_info, &buffer->buffer,
-                             &buffer->allocation, NULL));
+    const VkDeviceSize min_size = 8 * 1024 * 1024;
+    VkDeviceSize size = buffer->buffer_size;
+    VkResult result;
+
+    for (;;) {
+        VkBufferCreateInfo buffer_create_info = {
+            .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+            .size = size,
+            .usage = buffer->usage,
+            .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        };
+
+        result = vmaCreateBuffer(r->allocator, &buffer_create_info,
+                                 &buffer->alloc_info, &buffer->buffer,
+                                 &buffer->allocation, NULL);
+        if (result == VK_SUCCESS) {
+            buffer->buffer_size = size;
+            break;
+        }
+        if (result != VK_ERROR_OUT_OF_DEVICE_MEMORY &&
+            result != VK_ERROR_OUT_OF_HOST_MEMORY) {
+            break;
+        }
+        if (size <= min_size) {
+            break;
+        }
+
+        size /= 2;
+        fprintf(stderr,
+                "Buffer allocation (usage 0x%x) short of memory, retrying at "
+                "%zu MiB\n",
+                buffer->usage, (size_t)(size / (1024 * 1024)));
+    }
+
+    if (result != VK_SUCCESS) {
+        fprintf(stderr,
+                "Failed to allocate %zu MiB buffer (usage 0x%x): vk_result %d\n",
+                (size_t)(size / (1024 * 1024)), buffer->usage, result);
+    }
+    VK_CHECK(result);
 }
 
 static void destroy_buffer(PGRAPHState *pg, StorageBuffer *buffer)


### PR DESCRIPTION
Builds on #2996.

#2996 derives the storage buffer sizes from the largest device heap rather than fixed constants, which is the right basis, but a heap reports its *capacity* rather than what is free. On a unified memory device the display server and everything else on the system draw from the same pool, so a request sized from the heap can still be refused — and `create_buffer` asserts, so startup ends there.

This halves the request until it is accepted, down to a floor of 8 MiB, and records the size actually obtained so the rest of the renderer works from it. Where the first request succeeds nothing changes.

On a Raspberry Pi 5 with V3DV this is the difference between starting and not:

```
Buffer allocation (usage 0x82) short of memory, retrying at 639 MiB
Buffer allocation (usage 0x82) short of memory, retrying at 319 MiB
Buffer allocation (usage 0x1) short of memory, retrying at 639 MiB
Buffer allocation (usage 0x1) short of memory, retrying at 319 MiB
```

after which initialisation continues normally. Without it the same board stops at `create_buffer` with `VK_ERROR_OUT_OF_DEVICE_MEMORY`, which is the failure reported in #2918.

Tested on aarch64 / V3DV, and built on x86-64 where the first request is always accepted and the loop does not run.