### PR TITLE
apu: Disable DSP JIT by default for first release

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -316,7 +316,7 @@ audio:
   use_dsp: bool
   use_dsp_jit:
     type: bool
-    default: true
+    default: false
   hrtf:
     type: bool
     default: true


### PR DESCRIPTION
It's working well, but we have some remaining issues to work out. For now let's have it be opt-in.