### PR TITLE
nv2a/gl: cut texture-streaming cost (native S3TC upload + GL object recycle)

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/renderer.h
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.h
@@ -81,7 +81,22 @@ typedef struct TextureBinding {
     bool border_color_set;
     GLenum gl_target;
     GLuint gl_texture;
+    uint64_t storage_sig; /* recycle pool key: gl_target/format/dims/levels */
 } TextureBinding;
+
+/*
+ * Recycled GL texture objects. When a title streams new content it destroys
+ * and re-creates hundreds of same-sized textures per frame; freeing and
+ * re-allocating the GL object each time is a large per-frame cost. Keep a
+ * bounded pool of destroyed objects keyed by their storage signature and
+ * reuse a matching one, so the driver can respecify it in place rather than
+ * reallocate. Accessed only from the single pfifo/pgraph thread; no lock.
+ */
+#define NV2A_GL_TEX_POOL_SIZE 256
+typedef struct TexPoolEntry {
+    uint64_t sig;
+    GLuint gl_texture;
+} TexPoolEntry;
 
 typedef struct ShaderModuleCacheKey {
     GLenum kind;
@@ -193,6 +208,9 @@ typedef struct PGRAPHGLState {
     TextureBinding *texture_binding[NV2A_MAX_TEXTURES];
     Lru texture_cache;
     TextureLruNode *texture_cache_entries;
+
+    TexPoolEntry tex_pool[NV2A_GL_TEX_POOL_SIZE];
+    unsigned int tex_pool_count;
 
     Lru shader_cache;
     ShaderBinding *shader_cache_entries;

--- a/hw/xbox/nv2a/pgraph/gl/texture.c
+++ b/hw/xbox/nv2a/pgraph/gl/texture.c
@@ -671,15 +671,65 @@ static void upload_gl_texture(GLenum gl_target,
     }
 }
 
+/*
+ * Signature identifying a GL texture's storage layout, used to recycle a
+ * matching object from the pool so the driver can respecify it in place
+ * instead of reallocating. Only affects performance: generate_texture always
+ * fully respecifies every level, so a mismatched (or absent) object is still
+ * correct - the driver just reallocates as before.
+ */
+static uint64_t tex_storage_sig(GLenum gl_target, const TextureShape *s,
+                                const ColorFormatInfo *f)
+{
+    uint64_t sig = 1469598103934665603ULL; /* FNV-1a offset basis */
+#define TEX_SIG_MIX(v) \
+    do { \
+        sig = (sig ^ (uint64_t)(v)) * 1099511628211ULL; \
+    } while (0)
+    TEX_SIG_MIX(gl_target);
+    TEX_SIG_MIX(f->gl_internal_format);
+    TEX_SIG_MIX(f->gl_format);
+    TEX_SIG_MIX(f->gl_type);
+    TEX_SIG_MIX(s->width);
+    TEX_SIG_MIX(s->height);
+    TEX_SIG_MIX(s->depth);
+    TEX_SIG_MIX(s->levels);
+    TEX_SIG_MIX(s->cubemap);
+    TEX_SIG_MIX(s->border);
+    TEX_SIG_MIX(s->dimensionality);
+#undef TEX_SIG_MIX
+    return sig;
+}
+
+static GLuint tex_pool_get(PGRAPHGLState *r, uint64_t sig)
+{
+    for (unsigned int i = 0; i < r->tex_pool_count; i++) {
+        if (r->tex_pool[i].sig == sig) {
+            GLuint t = r->tex_pool[i].gl_texture;
+            r->tex_pool[i] = r->tex_pool[--r->tex_pool_count];
+            return t;
+        }
+    }
+    return 0;
+}
+
+static void tex_pool_put(PGRAPHGLState *r, uint64_t sig, GLuint tex)
+{
+    if (r->tex_pool_count < NV2A_GL_TEX_POOL_SIZE) {
+        r->tex_pool[r->tex_pool_count].sig = sig;
+        r->tex_pool[r->tex_pool_count].gl_texture = tex;
+        r->tex_pool_count++;
+    } else {
+        glDeleteTextures(1, &tex);
+    }
+}
+
 static TextureBinding* generate_texture(const TextureShape s,
                                         const uint8_t *texture_data,
                                         const uint8_t *palette_data)
 {
     ColorFormatInfo f = kelvin_color_format_gl_map[s.color_format];
-
-    /* Create a new opengl texture */
-    GLuint gl_texture;
-    glGenTextures(1, &gl_texture);
+    PGRAPHGLState *r = g_nv2a->pgraph.gl_renderer_state;
 
     GLenum gl_target;
     if (s.cubemap) {
@@ -701,6 +751,17 @@ static TextureBinding* generate_texture(const TextureShape s,
                 break;
             }
         }
+    }
+
+    /*
+     * Reuse a previously destroyed object with the same storage layout if one
+     * is available, so the driver can respecify it in place instead of
+     * allocating new storage. Otherwise create a new one.
+     */
+    uint64_t storage_sig = tex_storage_sig(gl_target, &s, &f);
+    GLuint gl_texture = tex_pool_get(r, storage_sig);
+    if (!gl_texture) {
+        glGenTextures(1, &gl_texture);
     }
 
     glBindTexture(gl_target, gl_texture);
@@ -786,6 +847,7 @@ static TextureBinding* generate_texture(const TextureShape s,
     ret->addrv = 0xFFFFFFFF;
     ret->addrp = 0xFFFFFFFF;
     ret->border_color_set = false;
+    ret->storage_sig = storage_sig;
     return ret;
 }
 
@@ -795,7 +857,8 @@ static void texture_binding_destroy(gpointer data)
     assert(binding->refcnt > 0);
     binding->refcnt--;
     if (binding->refcnt == 0) {
-        glDeleteTextures(1, &binding->gl_texture);
+        PGRAPHGLState *r = g_nv2a->pgraph.gl_renderer_state;
+        tex_pool_put(r, binding->storage_sig, binding->gl_texture);
         g_free(binding);
     }
 }
@@ -854,6 +917,16 @@ void pgraph_gl_finalize_textures(PGRAPHState *pg)
     }
 
     lru_flush(&r->texture_cache);
+
+    /*
+     * Flushing the cache recycled its objects into the pool rather than
+     * deleting them, so drain it here while the context is still current.
+     */
+    for (unsigned int i = 0; i < r->tex_pool_count; i++) {
+        glDeleteTextures(1, &r->tex_pool[i].gl_texture);
+    }
+    r->tex_pool_count = 0;
+
     free(r->texture_cache_entries);
 
     r->texture_cache_entries = NULL;

--- a/hw/xbox/nv2a/pgraph/gl/texture.c
+++ b/hw/xbox/nv2a/pgraph/gl/texture.c
@@ -488,6 +488,38 @@ static void upload_gl_texture(GLenum gl_target,
                         8 : 16;
                 unsigned int physical_width = (width + 3) & ~3,
                              physical_height = (height + 3) & ~3;
+
+                /*
+                 * The host is required to support S3TC (asserted at renderer
+                 * init), so hand the DXT blocks straight to GL when no border
+                 * fixup is needed. This skips the CPU decompress entirely and
+                 * uploads 4-8x less data, which matters a great deal when a
+                 * title streams in many textures in one frame.
+                 *
+                 * This must not be decided per level: mixing compressed and
+                 * uncompressed internal formats across the mip chain makes
+                 * the texture incomplete and it samples as black. The border
+                 * fixup depends only on the texture, not the level, so either
+                 * every level takes this path or none does. Levels smaller
+                 * than a 4x4 block are fine to upload compressed; imageSize
+                 * is computed from the block-aligned size.
+                 */
+                bool needs_border_fixup =
+                    s.cubemap && adjusted_width != s.width;
+                if (!needs_border_fixup) {
+                    unsigned int image_size = (physical_width / 4) *
+                                              (physical_height / 4) *
+                                              block_size;
+                    glCompressedTexImage2D(gl_target, level,
+                                           f.gl_internal_format,
+                                           width, height, 0,
+                                           image_size, texture_data);
+                    texture_data += image_size;
+                    width /= 2;
+                    height /= 2;
+                    continue;
+                }
+
                 uint8_t *converted = s3tc_decompress_2d(
                     gl_internal_format_to_s3tc_enum(f.gl_internal_format),
                     texture_data, width, height);


### PR DESCRIPTION
# nv2a/gl: cut texture-streaming cost (native S3TC upload + GL object recycle)

## The problem

In PGR2, driving through certain sections of some tracks (e.g. Sydney Dawes
Point) spikes frame time hard, up to ~80ms/frame. That's where the game
streams in a lot of new textures in a single frame, and the texture upload
path is doing more work than it needs to:

1. Every S3TC/DXT texture gets decompressed on the CPU before upload, even
   though the renderer already requires `GL_EXT_texture_compression_s3tc`
   on the host (asserted at renderer init in `renderer.c`).
2. Every texture create/destroy does a fresh `glGenTextures` /
   `glDeleteTextures`, so the driver reallocates storage from scratch even
   when a same-sized texture was freed a moment ago.

I believe there's a general performance improvement too, though that's more
subjective currently.

## What I did

- Upload S3TC textures straight to `glCompressedTexImage2D` instead of
  decompressing on the CPU first. The renderer already asserts
  `GL_EXT_texture_compression_s3tc` is present at init; before this change
  we were just decompressing something we'd already confirmed the host
  could take compressed.
- Keep a small pool (256) of just-destroyed GL texture objects, keyed by
  their storage layout, and reuse a match on create so the driver can
  respecify in place instead of reallocating. `generate_texture` still
  writes every level regardless, so a mismatched or missing entry is always
  safe — the pool is purely a perf win, never a correctness dependency.

One gotcha worth flagging for review: the S3TC path has to be all-or-nothing
per texture, not per mip level — mixing compressed and uncompressed formats
across the mip chain leaves the texture incomplete and it renders black.

## How I tested it

The worst texture-burst frame I could find in PGR2 (vsync off, ~385 textures
in one frame): 82.8ms → 34.1ms, 12fps → 29fps.

I also profiled this branch against an unmodified master build on the same
scene: on heavy frames (2500+ draw calls) it's ~25% faster on average, and
the tail drops from 33ms to 14ms (p95) — the streaming stalls are basically
gone, and light frames are unchanged.

## How you can test it

Boot PGR2 and drive through Sydney Dawes Point — there's a certain corner
you'll come across which lags badly. Frame time should be noticeably
smoother with this patch.

I haven't tested other titles; this should be safe generally (the pool only
helps when a matching freed texture exists; otherwise it behaves exactly as
before), but PGR2 is the only thing I've actually driven through.

Full disclosure — I investigated this with Claude Code, and it also wrote
the patch.
