### PR TITLE
XID-Cached-Input-Cleanup

### DIFF
--- a/hw/xbox/xid.c
+++ b/hw/xbox/xid.c
@@ -61,7 +61,7 @@ void update_input(USBXIDGamepadState *s)
 
     ControllerState *state = xemu_input_get_bound(s->device_index);
     assert(state);
-    xemu_input_update_controller(state);
+
 
     const int button_map_analog[6][2] = {
         { GAMEPAD_A,     CONTROLLER_BUTTON_A     },

--- a/ui/xemu-input.c
+++ b/ui/xemu-input.c
@@ -479,8 +479,208 @@ void xemu_input_process_sdl_events(const SDL_Event *event)
     }
 }
 
+typedef struct XemuInputHostPollEntry {
+    ControllerState *state;
+    SDL_Gamepad *sdl_gamepad;
+    SDL_JoystickID sdl_joystick_id;
+
+    SDL_GamepadButton button_mapping[15];
+    SDL_GamepadAxis axis_mapping[CONTROLLER_AXIS__COUNT];
+    bool invert_axis[CONTROLLER_AXIS__COUNT];
+
+    uint16_t buttons;
+    int16_t axis[CONTROLLER_AXIS__COUNT];
+    int64_t sampled_ts;
+    bool sampled;
+} XemuInputHostPollEntry;
+
+struct XemuInputHostPollBatch {
+    size_t count;
+    XemuInputHostPollEntry entries[];
+};
+
+static void xemu_input_host_poll_copy_mapping(XemuInputHostPollEntry *entry,
+                                               ControllerState *state)
+{
+    entry->button_mapping[0] = state->controller_map->controller_mapping.a;
+    entry->button_mapping[1] = state->controller_map->controller_mapping.b;
+    entry->button_mapping[2] = state->controller_map->controller_mapping.x;
+    entry->button_mapping[3] = state->controller_map->controller_mapping.y;
+    entry->button_mapping[4] =
+        state->controller_map->controller_mapping.dpad_left;
+    entry->button_mapping[5] =
+        state->controller_map->controller_mapping.dpad_up;
+    entry->button_mapping[6] =
+        state->controller_map->controller_mapping.dpad_right;
+    entry->button_mapping[7] =
+        state->controller_map->controller_mapping.dpad_down;
+    entry->button_mapping[8] = state->controller_map->controller_mapping.back;
+    entry->button_mapping[9] = state->controller_map->controller_mapping.start;
+    entry->button_mapping[10] =
+        state->controller_map->controller_mapping.lshoulder;
+    entry->button_mapping[11] =
+        state->controller_map->controller_mapping.rshoulder;
+    entry->button_mapping[12] =
+        state->controller_map->controller_mapping.lstick_btn;
+    entry->button_mapping[13] =
+        state->controller_map->controller_mapping.rstick_btn;
+    entry->button_mapping[14] = state->controller_map->controller_mapping.guide;
+
+    entry->axis_mapping[CONTROLLER_AXIS_LTRIG] =
+        state->controller_map->controller_mapping.axis_trigger_left;
+    entry->axis_mapping[CONTROLLER_AXIS_RTRIG] =
+        state->controller_map->controller_mapping.axis_trigger_right;
+    entry->axis_mapping[CONTROLLER_AXIS_LSTICK_X] =
+        state->controller_map->controller_mapping.axis_left_x;
+    entry->axis_mapping[CONTROLLER_AXIS_LSTICK_Y] =
+        state->controller_map->controller_mapping.axis_left_y;
+    entry->axis_mapping[CONTROLLER_AXIS_RSTICK_X] =
+        state->controller_map->controller_mapping.axis_right_x;
+    entry->axis_mapping[CONTROLLER_AXIS_RSTICK_Y] =
+        state->controller_map->controller_mapping.axis_right_y;
+
+    entry->invert_axis[CONTROLLER_AXIS_LSTICK_X] =
+        state->controller_map->controller_mapping.invert_axis_left_x;
+    entry->invert_axis[CONTROLLER_AXIS_LSTICK_Y] =
+        !state->controller_map->controller_mapping.invert_axis_left_y;
+    entry->invert_axis[CONTROLLER_AXIS_RSTICK_X] =
+        state->controller_map->controller_mapping.invert_axis_right_x;
+    entry->invert_axis[CONTROLLER_AXIS_RSTICK_Y] =
+        !state->controller_map->controller_mapping.invert_axis_right_y;
+}
+
+XemuInputHostPollBatch *xemu_input_host_poll_prepare(void)
+{
+    const int64_t now = qemu_clock_get_us(QEMU_CLOCK_REALTIME);
+    size_t count = 0;
+    ControllerState *iter;
+
+    QTAILQ_FOREACH(iter, &available_controllers, entry) {
+        if (iter->type != INPUT_DEVICE_SDL_GAMEPAD ||
+            iter->sdl_gamepad == NULL || iter->controller_map == NULL) {
+            continue;
+        }
+        if (ABS(now - iter->last_input_updated_ts) <
+            XEMU_INPUT_MIN_INPUT_UPDATE_INTERVAL_US) {
+            continue;
+        }
+        count++;
+    }
+
+    XemuInputHostPollBatch *batch = g_malloc0(
+        sizeof(*batch) + count * sizeof(batch->entries[0]));
+    batch->count = count;
+
+    size_t index = 0;
+    QTAILQ_FOREACH(iter, &available_controllers, entry) {
+        if (iter->type != INPUT_DEVICE_SDL_GAMEPAD ||
+            iter->sdl_gamepad == NULL || iter->controller_map == NULL) {
+            continue;
+        }
+        if (ABS(now - iter->last_input_updated_ts) <
+            XEMU_INPUT_MIN_INPUT_UPDATE_INTERVAL_US) {
+            continue;
+        }
+
+        XemuInputHostPollEntry *entry = &batch->entries[index++];
+        entry->state = iter;
+        entry->sdl_gamepad = iter->sdl_gamepad;
+        entry->sdl_joystick_id = iter->sdl_joystick_id;
+        xemu_input_host_poll_copy_mapping(entry, iter);
+    }
+    assert(index == count);
+    return batch;
+}
+
+void xemu_input_host_poll_sample(XemuInputHostPollBatch *batch)
+{
+    if (batch == NULL) {
+        return;
+    }
+
+    for (size_t i = 0; i < batch->count; i++) {
+        XemuInputHostPollEntry *entry = &batch->entries[i];
+        uint16_t buttons = 0;
+        int16_t axis[CONTROLLER_AXIS__COUNT] = { 0 };
+
+        for (int button = 0; button < 15; button++) {
+            if (SDL_GetGamepadButton(entry->sdl_gamepad,
+                                     entry->button_mapping[button])) {
+                buttons |= (uint16_t)(1u << button);
+            }
+        }
+        for (int axis_index = 0; axis_index < CONTROLLER_AXIS__COUNT;
+             axis_index++) {
+            axis[axis_index] = SDL_GetGamepadAxis(
+                entry->sdl_gamepad, entry->axis_mapping[axis_index]);
+        }
+
+        for (int axis_index = CONTROLLER_AXIS_LSTICK_X;
+             axis_index <= CONTROLLER_AXIS_RSTICK_Y; axis_index++) {
+            if (entry->invert_axis[axis_index]) {
+                axis[axis_index] = -1 - axis[axis_index];
+            }
+        }
+
+        entry->buttons = buttons;
+        memcpy(entry->axis, axis, sizeof(entry->axis));
+        entry->sampled_ts = qemu_clock_get_us(QEMU_CLOCK_REALTIME);
+        entry->sampled = true;
+    }
+}
+
+static ControllerState *xemu_input_host_poll_find_live_state(
+    const XemuInputHostPollEntry *entry)
+{
+    ControllerState *iter;
+    QTAILQ_FOREACH(iter, &available_controllers, entry) {
+        if (iter != entry->state) {
+            continue;
+        }
+        if (iter->type != INPUT_DEVICE_SDL_GAMEPAD ||
+            iter->sdl_gamepad != entry->sdl_gamepad ||
+            iter->sdl_joystick_id != entry->sdl_joystick_id) {
+            return NULL;
+        }
+        return iter;
+    }
+    return NULL;
+}
+
+void xemu_input_host_poll_commit(XemuInputHostPollBatch *batch)
+{
+    if (batch == NULL) {
+        return;
+    }
+
+    for (size_t i = 0; i < batch->count; i++) {
+        XemuInputHostPollEntry *entry = &batch->entries[i];
+        if (!entry->sampled) {
+            continue;
+        }
+
+        ControllerState *state = xemu_input_host_poll_find_live_state(entry);
+        if (state == NULL) {
+            continue;
+        }
+
+        state->buttons = entry->buttons;
+        memcpy(state->axis, entry->axis, sizeof(state->axis));
+        state->last_input_updated_ts = entry->sampled_ts;
+    }
+}
+
+void xemu_input_host_poll_free(XemuInputHostPollBatch *batch)
+{
+    g_free(batch);
+}
+
 void xemu_input_update_controller(ControllerState *state)
 {
+    if (state->type == INPUT_DEVICE_SDL_GAMEPAD) {
+        return;
+    }
+
     int64_t now = qemu_clock_get_us(QEMU_CLOCK_REALTIME);
     if (ABS(now - state->last_input_updated_ts) <
         XEMU_INPUT_MIN_INPUT_UPDATE_INTERVAL_US) {
@@ -489,8 +689,6 @@ void xemu_input_update_controller(ControllerState *state)
 
     if (state->type == INPUT_DEVICE_SDL_KEYBOARD) {
         xemu_input_update_sdl_kbd_controller_state(state);
-    } else if (state->type == INPUT_DEVICE_SDL_GAMEPAD) {
-        xemu_input_update_sdl_controller_state(state);
     }
 
     state->last_input_updated_ts = qemu_clock_get_us(QEMU_CLOCK_REALTIME);
@@ -556,74 +754,6 @@ void xemu_input_update_sdl_kbd_controller_state(ControllerState *state)
         state->axis[CONTROLLER_AXIS_RTRIG] = 32767;
 
 #undef KBD_STATE
-}
-
-void xemu_input_update_sdl_controller_state(ControllerState *state)
-{
-    state->buttons = 0;
-    memset(state->axis, 0, sizeof(state->axis));
-
-#define SDL_MASK_BUTTON(state, btn, idx)                  \
-    (SDL_GetGamepadButton(                                \
-         (state)->sdl_gamepad,                            \
-         (state)->controller_map->controller_mapping.btn) \
-     << idx)
-
-    state->buttons |= SDL_MASK_BUTTON(state, a, 0);
-    state->buttons |= SDL_MASK_BUTTON(state, b, 1);
-    state->buttons |= SDL_MASK_BUTTON(state, x, 2);
-    state->buttons |= SDL_MASK_BUTTON(state, y, 3);
-    state->buttons |= SDL_MASK_BUTTON(state, dpad_left, 4);
-    state->buttons |= SDL_MASK_BUTTON(state, dpad_up, 5);
-    state->buttons |= SDL_MASK_BUTTON(state, dpad_right, 6);
-    state->buttons |= SDL_MASK_BUTTON(state, dpad_down, 7);
-    state->buttons |= SDL_MASK_BUTTON(state, back, 8);
-    state->buttons |= SDL_MASK_BUTTON(state, start, 9);
-    state->buttons |= SDL_MASK_BUTTON(state, lshoulder, 10);
-    state->buttons |= SDL_MASK_BUTTON(state, rshoulder, 11);
-    state->buttons |= SDL_MASK_BUTTON(state, lstick_btn, 12);
-    state->buttons |= SDL_MASK_BUTTON(state, rstick_btn, 13);
-    state->buttons |= SDL_MASK_BUTTON(state, guide, 14);
-
-#undef SDL_MASK_BUTTON
-
-#define SDL_GET_AXIS(state, axis)    \
-    SDL_GetGamepadAxis(              \
-        (state)->sdl_gamepad,        \
-        (state)->controller_map->controller_mapping.axis)
-
-    state->axis[0] = SDL_GET_AXIS(state, axis_trigger_left);
-    state->axis[1] = SDL_GET_AXIS(state, axis_trigger_right);
-    state->axis[2] = SDL_GET_AXIS(state, axis_left_x);
-    state->axis[3] = SDL_GET_AXIS(state, axis_left_y);
-    state->axis[4] = SDL_GET_AXIS(state, axis_right_x);
-    state->axis[5] = SDL_GET_AXIS(state, axis_right_y);
-
-#undef SDL_GET_AXIS
-
-// FIXME: Check range
-#define INVERT_AXIS(controller_axis) \
-    state->axis[controller_axis] = -1 - state->axis[controller_axis]
-
-    if (state->controller_map->controller_mapping.invert_axis_left_x) {
-        INVERT_AXIS(CONTROLLER_AXIS_LSTICK_X);
-    }
-
-    if (!state->controller_map->controller_mapping.invert_axis_left_y) {
-        INVERT_AXIS(CONTROLLER_AXIS_LSTICK_Y);
-    }
-
-    if (state->controller_map->controller_mapping.invert_axis_right_x) {
-        INVERT_AXIS(CONTROLLER_AXIS_RSTICK_X);
-    }
-
-    if (!state->controller_map->controller_mapping.invert_axis_right_y) {
-        INVERT_AXIS(CONTROLLER_AXIS_RSTICK_Y);
-    }
-
-#undef INVERT_AXIS
-
-    // xemu_input_print_controller_state(state);
 }
 
 void xemu_input_update_rumble(ControllerState *state)

--- a/ui/xemu-input.h
+++ b/ui/xemu-input.h
@@ -126,10 +126,18 @@ extern int *g_keyboard_scancode_map[25];
 
 void xemu_input_init(void);
 void xemu_input_process_sdl_events(const SDL_Event *event); // SDL_EVENT_GAMEPAD_ADDED, SDL_EVENT_GAMEPAD_REMOVED
+
+typedef struct XemuInputHostPollBatch XemuInputHostPollBatch;
+
+/* prepare/commit require BQL; sample must run without it. */
+XemuInputHostPollBatch *xemu_input_host_poll_prepare(void);
+void xemu_input_host_poll_sample(XemuInputHostPollBatch *batch);
+void xemu_input_host_poll_commit(XemuInputHostPollBatch *batch);
+void xemu_input_host_poll_free(XemuInputHostPollBatch *batch);
+
 void xemu_input_update_controllers(void);
 void xemu_input_update_controller(ControllerState *state);
 void xemu_input_update_sdl_kbd_controller_state(ControllerState *state);
-void xemu_input_update_sdl_controller_state(ControllerState *state);
 void xemu_input_update_rumble(ControllerState *state);
 ControllerState *xemu_input_get_bound(int index);
 void xemu_input_bind(int index, ControllerState *state, int save);

--- a/ui/xemu.c
+++ b/ui/xemu.c
@@ -940,8 +940,18 @@ static void poll_events(struct xemu_console *scon)
     }
 
     xemu_main_loop_lock();
+    XemuInputHostPollBatch *host_input_batch =
+        xemu_input_host_poll_prepare();
+    xemu_main_loop_unlock();
+
+    xemu_input_host_poll_sample(host_input_batch);
+
+    xemu_main_loop_lock();
+    xemu_input_host_poll_commit(host_input_batch);
     xemu_input_update_controllers();
     xemu_main_loop_unlock();
+
+    xemu_input_host_poll_free(host_input_batch);
 }
 
 static void display_very_early_init(DisplayOptions *o)


### PR DESCRIPTION
Fixes controller input stalls by polling the gamepad outside Xemu’s main lock and using cached input during Xbox USB processing. This prevents controller checks from briefly freezing the game and fixes the Def Jam: Fight for NY issue where controls could stop working after disconnecting and reconnecting the controller.