### PR TITLE
nv2a/vk: fold color downloads into producer submission

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/surface.c
+++ b/hw/xbox/nv2a/pgraph/vk/surface.c
@@ -169,14 +169,15 @@ static void download_surface_to_buffer(NV2AState *d, SurfaceBinding *surface,
     bool compute_needs_finish = (use_compute_to_convert_depth_stencil_format &&
                                  pgraph_vk_compute_needs_finish(r));
 
-    bool active_command_buffer_producer =
+    bool legacy_finish_required =
         r->in_command_buffer &&
         surface->draw_time >= r->command_buffer_start_time;
     bool fold_into_active_command_buffer =
-        active_command_buffer_producer && surface->color &&
+        r->in_command_buffer &&
+        surface->draw_time > r->command_buffer_start_time && surface->color &&
         !use_compute_to_convert_depth_stencil_format;
 
-    if (active_command_buffer_producer &&
+    if (legacy_finish_required &&
         !fold_into_active_command_buffer) {
         pgraph_vk_finish(pg, VK_FINISH_REASON_SURFACE_DOWN);
     } else if (!fold_into_active_command_buffer && compute_needs_finish) {

--- a/hw/xbox/nv2a/pgraph/vk/surface.c
+++ b/hw/xbox/nv2a/pgraph/vk/surface.c
@@ -169,10 +169,17 @@ static void download_surface_to_buffer(NV2AState *d, SurfaceBinding *surface,
     bool compute_needs_finish = (use_compute_to_convert_depth_stencil_format &&
                                  pgraph_vk_compute_needs_finish(r));
 
-    if (r->in_command_buffer &&
-        surface->draw_time >= r->command_buffer_start_time) {
+    bool active_command_buffer_producer =
+        r->in_command_buffer &&
+        surface->draw_time >= r->command_buffer_start_time;
+    bool fold_into_active_command_buffer =
+        active_command_buffer_producer && surface->color &&
+        !use_compute_to_convert_depth_stencil_format;
+
+    if (active_command_buffer_producer &&
+        !fold_into_active_command_buffer) {
         pgraph_vk_finish(pg, VK_FINISH_REASON_SURFACE_DOWN);
-    } else if (compute_needs_finish) {
+    } else if (!fold_into_active_command_buffer && compute_needs_finish) {
         pgraph_vk_finish(pg, VK_FINISH_REASON_NEED_BUFFER_SPACE);
     }
 
@@ -199,7 +206,11 @@ static void download_surface_to_buffer(NV2AState *d, SurfaceBinding *surface,
                  scaled_height = surface->height;
     pgraph_apply_scaling_factor(pg, &scaled_width, &scaled_height);
 
-    VkCommandBuffer cmd = pgraph_vk_begin_single_time_commands(pg);
+    VkCommandBuffer cmd = fold_into_active_command_buffer ?
+                              pgraph_vk_begin_nondraw_commands(pg) :
+                              pgraph_vk_begin_single_time_commands(pg);
+    assert(!fold_into_active_command_buffer ||
+           (r->in_command_buffer && cmd == r->command_buffer));
     pgraph_vk_begin_debug_marker(r, cmd, RGBA_RED, __func__);
 
     pgraph_vk_transition_image_layout(
@@ -444,7 +455,14 @@ static void download_surface_to_buffer(NV2AState *d, SurfaceBinding *surface,
 
     nv2a_profile_inc_counter(NV2A_PROF_QUEUE_SUBMIT_1);
     pgraph_vk_end_debug_marker(r, cmd);
-    pgraph_vk_end_single_time_commands(pg, cmd);
+    if (fold_into_active_command_buffer) {
+        pgraph_vk_end_nondraw_commands(pg, cmd);
+        assert(r->in_command_buffer);
+        pgraph_vk_finish(pg, VK_FINISH_REASON_SURFACE_DOWN);
+    } else {
+        assert(cmd == r->aux_command_buffer);
+        pgraph_vk_end_single_time_commands(pg, cmd);
+    }
 
     void *mapped_memory_ptr = NULL;
     VK_CHECK(vmaMapMemory(r->allocator,


### PR DESCRIPTION
## Summary

Reduce Vulkan CPU/GPU synchronization overhead when downloading an eligible color surface to Xbox RAM.

The old path completed the command buffer that produced the surface, created a second command buffer for the download, submitted that work, and waited again. The new path records the barrier and image-to-buffer copy in the command buffer that already produces the surface.

### Previous flow

```text
Render color surface
        │
        ▼
Submit producer command buffer
        │
        ▼
Wait for producer
        │
        ▼
Create auxiliary download command buffer
        │
        ▼
Record barrier and image-to-buffer copy
        │
        ▼
Submit auxiliary command buffer
        │
        ▼
Wait for download
```

This places two submission/wait boundaries on a CPU-visible surface readback.

### New flow

```text
Render color surface in active command buffer
        │
        ▼
Prove active command buffer produced the surface
        │
        ├── No  ─► Existing auxiliary fallback
        │
        └── Yes
              │
              ▼
        Append barrier and copy
              │
              ▼
        Submit producer plus download together
              │
              ▼
        Wait once
```

The optimization applies only to directly downloadable color surfaces produced by the current command buffer. Depth/stencil conversion, surfaces produced by an earlier submission, and any unsupported state retain the existing path.

## Performance effect

The focused surface-download workload improved by approximately 4.9%. The removed work is one auxiliary command-buffer lifecycle and one extra submit/wait sequence per eligible readback. Games that do not perform CPU-visible color readbacks are unaffected.

## Design rationale

Eligibility requires:

```text
surface.draw_time > command_buffer_start_time
```

The strict comparison proves that the current command buffer produced the surface. Equality is rejected because it can describe a surface left by the previous submission. This is an identity/order proof, not a tuned numeric threshold.

## Test statistics

- Isolated focused result: surface-download workload approximately 4.9% faster.
- Combined-train dedicated-rig result: Vulkan surface-download median improved 27.57% at 1x and 23.72% at 4x.
- Combined correctness: 1,008/1,008 matrix records completed; no assert, crash, or hang. These train-head percentages include dependent PRs and are confirmation, not isolated attribution.

## Validation

The strict-producer revision passed the four-cell synthetic matrix with exact hashes. The final stacked Release configuration compiles on Linux. The 1,008-record result is cumulative-stack validation; the 4.9% focused result is the direct timing attribution for this PR.

## Related issues

- Related: [xemu-project/xemu#2302](https://github.com/xemu-project/xemu/issues/2302). That report identifies unusually high surface-download activity as part of a renderer-era performance regression. This PR removes one submit/wait cycle only for eligible current-command-buffer color downloads; it does not claim to resolve every title or backend covered by the issue.

## Dependencies

None. This submission is isolated from the internal validation stack for upstream review.

## Public validation suite

- Source and operator documentation: https://github.com/Mainkill1/xemu-perf-tests
- Ready-to-run ISO: https://github.com/Mainkill1/xemu-perf-tests/releases/tag/v1.0.0
- Full-suite gate: 141/141 records passed, zero oracle failures, and plain-disc boot verified on two Windows systems.
- ISO SHA-256: `7b8eb7af66a87fad93bcea019208457e42aaff2bd81b1353df2b6c378db7707c`
