### PR TITLE
nv2a/vk: revalidate bound texture memory

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/texture.c
+++ b/hw/xbox/nv2a/pgraph/vk/texture.c
@@ -1400,6 +1400,34 @@ static bool check_textures_dirty(PGRAPHState *pg)
     return false;
 }
 
+static bool check_bound_texture_memory_dirty(NV2AState *d)
+{
+    PGRAPHState *pg = &d->pgraph;
+    PGRAPHVkState *r = pg->vk_renderer_state;
+
+    for (int i = 0; i < NV2A_MAX_TEXTURES; i++) {
+        if (!pgraph_is_texture_enabled(pg, i)) {
+            continue;
+        }
+
+        TextureBinding *binding = r->texture_bindings[i];
+        if (!binding || binding == &r->dummy_texture) {
+            continue;
+        }
+
+        if (binding->possibly_dirty ||
+            check_texture_possibly_dirty(
+                d, binding->key.texture_vram_offset,
+                binding->key.texture_length,
+                binding->key.palette_vram_offset,
+                binding->key.palette_length)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static void update_timestamps(PGRAPHVkState *r)
 {
     for (int i = 0; i < ARRAY_SIZE(r->texture_bindings); i++) {
@@ -1416,12 +1444,12 @@ void pgraph_vk_bind_textures(NV2AState *d)
     PGRAPHState *pg = &d->pgraph;
     PGRAPHVkState *r = pg->vk_renderer_state;
 
-    // FIXME: Check for modifications on bind fastpath (CPU hook)
     // FIXME: Mark textures that are sourced from surfaces so we can track them
 
     r->texture_bindings_changed = false;
 
-    if (!check_textures_dirty(pg)) {
+    if (!check_textures_dirty(pg) &&
+        !check_bound_texture_memory_dirty(d)) {
         NV2A_VK_DPRINTF("Not dirty");
         NV2A_VK_DGROUP_END();
         update_timestamps(r);


### PR DESCRIPTION
## Summary

Prevent Vulkan from reusing a cached texture after the Xbox CPU changes the guest memory backing that texture.

The previous fast path checked texture binding/register identity. That is insufficient for unified Xbox memory because the address and texture state may remain unchanged while the CPU replaces texture or palette bytes.

### Previous flow

```text
Bind texture
        │
        ▼
Do registers and address match cached binding?
        │
        ├── Yes ─► Reuse host image immediately
        │
        └── No  ─► Validate/hash/upload texture
```

An in-place CPU write could therefore leave Vulkan sampling stale host data.

### New flow

```text
Bind texture
        │
        ▼
Do registers and address match cached binding?
        │
        ├── No  ─► Existing validation/upload path
        │
        └── Yes
              │
              ▼
        Are bound texture/palette ranges clean?
              │
              ├── Yes ─► Reuse host image
              │
              └── No
                    │
                    ▼
              Existing hash/upload path
                    │
                    ├── Bytes equal ─► Keep image
                    └── Bytes changed ─► Refresh image
```

The dirty check does not force recreation. It only prevents the early return and lets the renderer's existing content validation decide whether an upload is necessary.

## Performance effect

This is a correctness repair for texture streaming and aliasing. Clean bindings retain the inexpensive early return. Work is added only when QEMU dirty tracking reports a write to the exact texture or palette range. Focused timing moved by about 0.4%, which is treated as noise rather than a speed claim.

The correction prevents stale materials and missing texture updates, allowing later cache optimizations to rely on a valid memory-coherence decision.

## Design rationale

The proof is guest dirty-page state over the exact bound ranges. The loop is bounded by the hardware-defined maximum enabled NV2A texture stages. There is no cache-age, byte-count, frame-count, or polling threshold.

## Test statistics

- Isolated focused timing: approximately 0.4% movement, treated as noise; this PR makes a correctness claim.
- Combined Vulkan overwrite oracle: upstream failed 13/16 source-precision tiles in both S3TC and RGBA8 same-address tests; train head passed 16/16 for both at 1x and 4x.
- Combined matrix: 1,008/1,008 records completed. OpenGL retained 126/126 upstream hashes at both scales.

## Validation

The then-current OpenGL/Vulkan 1x/4x matrix completed with exact hashes and no new Vulkan validation error. The final stacked Release configuration compiles on Linux. The 1,008-record result is cumulative-stack validation; the dirty-memory and overwrite checks above are the direct attribution for this PR.

## Dependencies

None. This submission is isolated from the internal validation stack for upstream review.

## Public validation suite

- Source and operator documentation: https://github.com/Mainkill1/xemu-perf-tests
- Ready-to-run ISO: https://github.com/Mainkill1/xemu-perf-tests/releases/tag/v1.0.0
- Full-suite gate: 141/141 records passed, zero oracle failures, and plain-disc boot verified on two Windows systems.
- ISO SHA-256: `7b8eb7af66a87fad93bcea019208457e42aaff2bd81b1353df2b6c378db7707c`
