### PR TITLE
nv2a/vk: emit blend constants only when required

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/blend-constants-cache.h
+++ b/hw/xbox/nv2a/pgraph/vk/blend-constants-cache.h
@@ -18,6 +18,13 @@ static inline void pgraph_vk_blend_constants_cache_invalidate(
     cache->valid = false;
 }
 
+/* A graphics pipeline bind invalidates all cached dynamic-state assumptions. */
+static inline void pgraph_vk_blend_constants_cache_pipeline_bound(
+    PGRAPHVkBlendConstantsCache *cache)
+{
+    pgraph_vk_blend_constants_cache_invalidate(cache);
+}
+
 /* Returns true exactly when the caller must emit vkCmdSetBlendConstants. */
 static inline bool pgraph_vk_blend_constants_cache_update(
     PGRAPHVkBlendConstantsCache *cache, uint32_t guest_color)

--- a/hw/xbox/nv2a/pgraph/vk/blend-constants-cache.h
+++ b/hw/xbox/nv2a/pgraph/vk/blend-constants-cache.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * Vulkan dynamic blend-constant command cache.
+ */
+
+#ifndef HW_XBOX_NV2A_PGRAPH_VK_BLEND_CONSTANTS_CACHE_H
+#define HW_XBOX_NV2A_PGRAPH_VK_BLEND_CONSTANTS_CACHE_H
+
+typedef struct PGRAPHVkBlendConstantsCache {
+    uint32_t guest_color;
+    bool valid;
+} PGRAPHVkBlendConstantsCache;
+
+static inline void pgraph_vk_blend_constants_cache_invalidate(
+    PGRAPHVkBlendConstantsCache *cache)
+{
+    cache->valid = false;
+}
+
+/* Returns true exactly when the caller must emit vkCmdSetBlendConstants. */
+static inline bool pgraph_vk_blend_constants_cache_update(
+    PGRAPHVkBlendConstantsCache *cache, uint32_t guest_color)
+{
+    if (cache->valid && cache->guest_color == guest_color) {
+        return false;
+    }
+
+    cache->guest_color = guest_color;
+    cache->valid = true;
+    return true;
+}
+
+#endif

--- a/hw/xbox/nv2a/pgraph/vk/blend-constants-cache.h
+++ b/hw/xbox/nv2a/pgraph/vk/blend-constants-cache.h
@@ -8,33 +8,56 @@
 #define HW_XBOX_NV2A_PGRAPH_VK_BLEND_CONSTANTS_CACHE_H
 
 typedef struct PGRAPHVkBlendConstantsCache {
-    uint32_t guest_color;
-    bool valid;
+    uint32_t command_guest_color;
+    uint32_t packed_guest_color;
+    float packed_color[4];
+    bool command_valid;
+    bool packed_valid;
 } PGRAPHVkBlendConstantsCache;
 
 static inline void pgraph_vk_blend_constants_cache_invalidate(
     PGRAPHVkBlendConstantsCache *cache)
 {
-    cache->valid = false;
+    cache->command_valid = false;
 }
 
-/* A graphics pipeline bind invalidates all cached dynamic-state assumptions. */
+/* Static state invalidates blend constants; dynamic-to-dynamic binds retain it. */
 static inline void pgraph_vk_blend_constants_cache_pipeline_bound(
-    PGRAPHVkBlendConstantsCache *cache)
+    PGRAPHVkBlendConstantsCache *cache, bool uses_dynamic_blend_constants)
 {
-    pgraph_vk_blend_constants_cache_invalidate(cache);
+    if (!uses_dynamic_blend_constants) {
+        pgraph_vk_blend_constants_cache_invalidate(cache);
+    }
 }
 
 /* Returns true exactly when the caller must emit vkCmdSetBlendConstants. */
 static inline bool pgraph_vk_blend_constants_cache_update(
-    PGRAPHVkBlendConstantsCache *cache, uint32_t guest_color)
+    PGRAPHVkBlendConstantsCache *cache, uint32_t guest_color,
+    uint32_t relevant_component_mask)
 {
-    if (cache->valid && cache->guest_color == guest_color) {
+    assert(relevant_component_mask != 0);
+
+    if (cache->command_valid &&
+        ((cache->command_guest_color ^ guest_color) &
+         relevant_component_mask) == 0) {
         return false;
     }
 
-    cache->guest_color = guest_color;
-    cache->valid = true;
+    cache->command_guest_color = guest_color;
+    cache->command_valid = true;
+    return true;
+}
+
+/* Packed values survive command-state invalidation and pipeline changes. */
+static inline bool pgraph_vk_blend_constants_cache_needs_pack(
+    PGRAPHVkBlendConstantsCache *cache, uint32_t guest_color)
+{
+    if (cache->packed_valid && cache->packed_guest_color == guest_color) {
+        return false;
+    }
+
+    cache->packed_guest_color = guest_color;
+    cache->packed_valid = true;
     return true;
 }
 

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -623,6 +623,29 @@ static bool check_render_pass_dirty(PGRAPHState *pg)
                   sizeof(state)) != 0;
 }
 
+static bool blend_factor_uses_constant(VkBlendFactor factor)
+{
+    return factor == VK_BLEND_FACTOR_CONSTANT_COLOR ||
+           factor == VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR ||
+           factor == VK_BLEND_FACTOR_CONSTANT_ALPHA ||
+           factor == VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA;
+}
+
+static bool pipeline_uses_dynamic_blend_constants(PGRAPHState *pg)
+{
+    uint32_t blend = pgraph_reg_r(pg, NV_PGRAPH_BLEND);
+    if (!(blend & NV_PGRAPH_BLEND_EN)) {
+        return false;
+    }
+
+    uint32_t sfactor = GET_MASK(blend, NV_PGRAPH_BLEND_SFACTOR);
+    uint32_t dfactor = GET_MASK(blend, NV_PGRAPH_BLEND_DFACTOR);
+    assert(sfactor < ARRAY_SIZE(pgraph_blend_factor_vk_map));
+    assert(dfactor < ARRAY_SIZE(pgraph_blend_factor_vk_map));
+    return blend_factor_uses_constant(pgraph_blend_factor_vk_map[sfactor]) ||
+           blend_factor_uses_constant(pgraph_blend_factor_vk_map[dfactor]);
+}
+
 // Quickly check for any state changes that would require more analysis
 static bool check_pipeline_dirty(PGRAPHState *pg)
 {
@@ -634,9 +657,9 @@ static bool check_pipeline_dirty(PGRAPHState *pg)
     }
 
     const unsigned int regs[] = {
-        NV_PGRAPH_BLEND,       NV_PGRAPH_BLENDCOLOR,  NV_PGRAPH_CONTROL_0,
-        NV_PGRAPH_CONTROL_1,   NV_PGRAPH_CONTROL_2,   NV_PGRAPH_CONTROL_3,
-        NV_PGRAPH_SETUPRASTER, NV_PGRAPH_ZOFFSETBIAS, NV_PGRAPH_ZOFFSETFACTOR,
+        NV_PGRAPH_BLEND,       NV_PGRAPH_CONTROL_0,   NV_PGRAPH_CONTROL_1,
+        NV_PGRAPH_CONTROL_2,   NV_PGRAPH_CONTROL_3,   NV_PGRAPH_SETUPRASTER,
+        NV_PGRAPH_ZOFFSETBIAS, NV_PGRAPH_ZOFFSETFACTOR,
     };
 
     for (int i = 0; i < ARRAY_SIZE(regs); i++) {
@@ -679,11 +702,10 @@ static void init_pipeline_key(PGRAPHState *pg, PipelineKey *key)
     // FIXME: Register masking
     // FIXME: Use more dynamic state updates
     const int regs[] = {
-        NV_PGRAPH_BLEND,       NV_PGRAPH_BLENDCOLOR,  NV_PGRAPH_CONTROL_0,
-        NV_PGRAPH_CONTROL_1,   NV_PGRAPH_CONTROL_2,   NV_PGRAPH_CONTROL_3,
-        NV_PGRAPH_SETUPRASTER, NV_PGRAPH_ZOFFSETBIAS, NV_PGRAPH_ZOFFSETFACTOR,
+        NV_PGRAPH_BLEND,       NV_PGRAPH_CONTROL_0,   NV_PGRAPH_CONTROL_1,
+        NV_PGRAPH_CONTROL_2,   NV_PGRAPH_CONTROL_3,   NV_PGRAPH_SETUPRASTER,
+        NV_PGRAPH_ZOFFSETBIAS, NV_PGRAPH_ZOFFSETFACTOR,
     };
-    assert(ARRAY_SIZE(regs) == ARRAY_SIZE(key->regs));
     for (int i = 0; i < ARRAY_SIZE(regs); i++) {
         key->regs[i] = pgraph_reg_r(pg, regs[i]);
     }
@@ -878,7 +900,7 @@ static void create_pipeline(PGRAPHState *pg)
         .colorWriteMask = write_mask,
     };
 
-    float blend_constant[4] = { 0, 0, 0, 0 };
+    bool has_dynamic_blend_constants = false;
 
     if (pgraph_reg_r(pg, NV_PGRAPH_BLEND) & NV_PGRAPH_BLEND_EN) {
         color_blend_attachment.blendEnable = VK_TRUE;
@@ -907,8 +929,7 @@ static void create_pipeline(PGRAPHState *pg)
         color_blend_attachment.alphaBlendOp =
             pgraph_blend_equation_vk_map[equation];
 
-        uint32_t blend_color = pgraph_reg_r(pg, NV_PGRAPH_BLENDCOLOR);
-        pgraph_argb_pack32_to_rgba_float(blend_color, blend_constant);
+        has_dynamic_blend_constants = pipeline_uses_dynamic_blend_constants(pg);
     }
 
     VkPipelineColorBlendStateCreateInfo color_blending = {
@@ -917,15 +938,14 @@ static void create_pipeline(PGRAPHState *pg)
         .logicOp = VK_LOGIC_OP_COPY,
         .attachmentCount = r->color_binding ? 1 : 0,
         .pAttachments = r->color_binding ? &color_blend_attachment : NULL,
-        .blendConstants[0] = blend_constant[0],
-        .blendConstants[1] = blend_constant[1],
-        .blendConstants[2] = blend_constant[2],
-        .blendConstants[3] = blend_constant[3],
     };
 
-    VkDynamicState dynamic_states[3] = { VK_DYNAMIC_STATE_VIEWPORT,
+    VkDynamicState dynamic_states[4] = { VK_DYNAMIC_STATE_VIEWPORT,
                                          VK_DYNAMIC_STATE_SCISSOR };
     int num_dynamic_states = 2;
+    if (has_dynamic_blend_constants) {
+        dynamic_states[num_dynamic_states++] = VK_DYNAMIC_STATE_BLEND_CONSTANTS;
+    }
 
     snode->has_dynamic_line_width =
         (r->enabled_physical_device_features.wideLines == VK_TRUE) &&
@@ -1012,6 +1032,7 @@ static void create_pipeline(PGRAPHState *pg)
     snode->layout = layout;
     snode->render_pass = pipeline_create_info.renderPass;
     snode->draw_time = pg->draw_time;
+    snode->has_dynamic_blend_constants = has_dynamic_blend_constants;
 
     r->pipeline_binding = snode;
     r->pipeline_binding_changed = true;
@@ -1480,6 +1501,13 @@ static void begin_draw(PGRAPHState *pg)
                 clamp_line_width_to_device_limits(pg, pg->surface_scale_factor);
             vkCmdSetLineWidth(r->command_buffer, line_width);
         }
+    }
+
+    if (r->pipeline_binding->has_dynamic_blend_constants) {
+        float blend_constants[4];
+        uint32_t blend_color = pgraph_reg_r(pg, NV_PGRAPH_BLENDCOLOR);
+        pgraph_argb_pack32_to_rgba_float(blend_color, blend_constants);
+        vkCmdSetBlendConstants(r->command_buffer, blend_constants);
     }
 
     if (!pg->clearing) {

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1327,6 +1327,7 @@ void pgraph_vk_begin_command_buffer(PGRAPHState *pg)
     };
     VK_CHECK(vkBeginCommandBuffer(r->command_buffer,
                                   &command_buffer_begin_info));
+    pgraph_vk_invalidate_blend_constants(pg);
     r->command_buffer_start_time = pg->draw_time;
     r->in_command_buffer = true;
 }
@@ -1424,6 +1425,28 @@ static float clamp_line_width_to_device_limits(PGRAPHState *pg, float width)
     return fminf(fmaxf(min_width, width), max_width);
 }
 
+void pgraph_vk_invalidate_blend_constants(PGRAPHState *pg)
+{
+    PGRAPHVkState *r = pg->vk_renderer_state;
+
+    pgraph_vk_blend_constants_cache_invalidate(&r->blend_constants);
+}
+
+static void update_blend_constants(PGRAPHState *pg)
+{
+    PGRAPHVkState *r = pg->vk_renderer_state;
+    uint32_t guest_color = pgraph_reg_r(pg, NV_PGRAPH_BLENDCOLOR);
+
+    if (!pgraph_vk_blend_constants_cache_update(&r->blend_constants,
+                                                guest_color)) {
+        return;
+    }
+
+    float blend_constants[4];
+    pgraph_argb_pack32_to_rgba_float(guest_color, blend_constants);
+    vkCmdSetBlendConstants(r->command_buffer, blend_constants);
+}
+
 static void begin_draw(PGRAPHState *pg)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
@@ -1503,14 +1526,14 @@ static void begin_draw(PGRAPHState *pg)
         }
     }
 
-    if (r->pipeline_binding->has_dynamic_blend_constants) {
-        float blend_constants[4];
-        uint32_t blend_color = pgraph_reg_r(pg, NV_PGRAPH_BLENDCOLOR);
-        pgraph_argb_pack32_to_rgba_float(blend_color, blend_constants);
-        vkCmdSetBlendConstants(r->command_buffer, blend_constants);
-    }
-
     if (!pg->clearing) {
+        /*
+         * Blend color is dynamic and may change without a pipeline bind.
+         * The cache is scoped to this command buffer and invalidated by the
+         * partial-clear path when it overwrites the Vulkan dynamic state.
+         */
+        update_blend_constants(pg);
+
         bind_descriptor_sets(pg);
         push_vertex_attr_values(pg);
     }
@@ -1758,6 +1781,7 @@ void pgraph_vk_clear_surface(NV2AState *d, uint32_t parameter)
             pgraph_get_clear_color(pg, blend_constants);
             vkCmdSetScissor(r->command_buffer, 0, 1, &clear_rect.rect);
             vkCmdSetBlendConstants(r->command_buffer, blend_constants);
+            pgraph_vk_invalidate_blend_constants(pg);
             vkCmdDraw(r->command_buffer, 3, 1, 0, 0);
         }
     }

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -623,27 +623,34 @@ static bool check_render_pass_dirty(PGRAPHState *pg)
                   sizeof(state)) != 0;
 }
 
-static bool blend_factor_uses_constant(VkBlendFactor factor)
+static uint32_t blend_factor_constant_component_mask(VkBlendFactor factor)
 {
-    return factor == VK_BLEND_FACTOR_CONSTANT_COLOR ||
-           factor == VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR ||
-           factor == VK_BLEND_FACTOR_CONSTANT_ALPHA ||
-           factor == VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA;
+    if (factor == VK_BLEND_FACTOR_CONSTANT_COLOR ||
+        factor == VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR) {
+        return UINT32_MAX;
+    }
+    if (factor == VK_BLEND_FACTOR_CONSTANT_ALPHA ||
+        factor == VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA) {
+        return 0xff000000;
+    }
+    return 0;
 }
 
-static bool pipeline_uses_dynamic_blend_constants(PGRAPHState *pg)
+static uint32_t pipeline_dynamic_blend_constant_mask(PGRAPHState *pg)
 {
     uint32_t blend = pgraph_reg_r(pg, NV_PGRAPH_BLEND);
     if (!(blend & NV_PGRAPH_BLEND_EN)) {
-        return false;
+        return 0;
     }
 
     uint32_t sfactor = GET_MASK(blend, NV_PGRAPH_BLEND_SFACTOR);
     uint32_t dfactor = GET_MASK(blend, NV_PGRAPH_BLEND_DFACTOR);
     assert(sfactor < ARRAY_SIZE(pgraph_blend_factor_vk_map));
     assert(dfactor < ARRAY_SIZE(pgraph_blend_factor_vk_map));
-    return blend_factor_uses_constant(pgraph_blend_factor_vk_map[sfactor]) ||
-           blend_factor_uses_constant(pgraph_blend_factor_vk_map[dfactor]);
+    return blend_factor_constant_component_mask(
+               pgraph_blend_factor_vk_map[sfactor]) |
+           blend_factor_constant_component_mask(
+               pgraph_blend_factor_vk_map[dfactor]);
 }
 
 // Quickly check for any state changes that would require more analysis
@@ -707,6 +714,7 @@ static void init_pipeline_key(PGRAPHState *pg, PipelineKey *key)
         NV_PGRAPH_CONTROL_2,   NV_PGRAPH_CONTROL_3,   NV_PGRAPH_SETUPRASTER,
         NV_PGRAPH_ZOFFSETBIAS, NV_PGRAPH_ZOFFSETFACTOR,
     };
+    assert(ARRAY_SIZE(regs) == ARRAY_SIZE(key->regs));
     for (int i = 0; i < ARRAY_SIZE(regs); i++) {
         key->regs[i] = pgraph_reg_r(pg, regs[i]);
     }
@@ -901,7 +909,7 @@ static void create_pipeline(PGRAPHState *pg)
         .colorWriteMask = write_mask,
     };
 
-    bool has_dynamic_blend_constants = false;
+    uint32_t dynamic_blend_constant_mask = 0;
 
     if (pgraph_reg_r(pg, NV_PGRAPH_BLEND) & NV_PGRAPH_BLEND_EN) {
         color_blend_attachment.blendEnable = VK_TRUE;
@@ -930,7 +938,10 @@ static void create_pipeline(PGRAPHState *pg)
         color_blend_attachment.alphaBlendOp =
             pgraph_blend_equation_vk_map[equation];
 
-        has_dynamic_blend_constants = pipeline_uses_dynamic_blend_constants(pg);
+        if (r->color_binding) {
+            dynamic_blend_constant_mask =
+                pipeline_dynamic_blend_constant_mask(pg);
+        }
     }
 
     VkPipelineColorBlendStateCreateInfo color_blending = {
@@ -944,7 +955,7 @@ static void create_pipeline(PGRAPHState *pg)
     VkDynamicState dynamic_states[4] = { VK_DYNAMIC_STATE_VIEWPORT,
                                          VK_DYNAMIC_STATE_SCISSOR };
     int num_dynamic_states = 2;
-    if (has_dynamic_blend_constants) {
+    if (dynamic_blend_constant_mask != 0) {
         dynamic_states[num_dynamic_states++] = VK_DYNAMIC_STATE_BLEND_CONSTANTS;
     }
 
@@ -1033,7 +1044,7 @@ static void create_pipeline(PGRAPHState *pg)
     snode->layout = layout;
     snode->render_pass = pipeline_create_info.renderPass;
     snode->draw_time = pg->draw_time;
-    snode->has_dynamic_blend_constants = has_dynamic_blend_constants;
+    snode->dynamic_blend_constant_mask = dynamic_blend_constant_mask;
 
     r->pipeline_binding = snode;
     r->pipeline_binding_changed = true;
@@ -1433,19 +1444,24 @@ void pgraph_vk_invalidate_blend_constants(PGRAPHState *pg)
     pgraph_vk_blend_constants_cache_invalidate(&r->blend_constants);
 }
 
-static void update_blend_constants(PGRAPHState *pg)
+static void update_blend_constants(PGRAPHState *pg,
+                                   uint32_t relevant_component_mask)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
     uint32_t guest_color = pgraph_reg_r(pg, NV_PGRAPH_BLENDCOLOR);
 
-    if (!pgraph_vk_blend_constants_cache_update(&r->blend_constants,
-                                                guest_color)) {
+    if (!pgraph_vk_blend_constants_cache_update(
+            &r->blend_constants, guest_color, relevant_component_mask)) {
         return;
     }
 
-    float blend_constants[4];
-    pgraph_argb_pack32_to_rgba_float(guest_color, blend_constants);
-    vkCmdSetBlendConstants(r->command_buffer, blend_constants);
+    if (pgraph_vk_blend_constants_cache_needs_pack(&r->blend_constants,
+                                                   guest_color)) {
+        pgraph_argb_pack32_to_rgba_float(
+            guest_color, r->blend_constants.packed_color);
+    }
+    vkCmdSetBlendConstants(r->command_buffer,
+                           r->blend_constants.packed_color);
 }
 
 static void begin_draw(PGRAPHState *pg)
@@ -1484,7 +1500,9 @@ static void begin_draw(PGRAPHState *pg)
         nv2a_profile_inc_counter(NV2A_PROF_PIPELINE_BIND);
         vkCmdBindPipeline(r->command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
                           r->pipeline_binding->pipeline);
-        pgraph_vk_blend_constants_cache_pipeline_bound(&r->blend_constants);
+        pgraph_vk_blend_constants_cache_pipeline_bound(
+            &r->blend_constants,
+            r->pipeline_binding->dynamic_blend_constant_mask != 0);
         r->pipeline_binding->draw_time = pg->draw_time;
 
         unsigned int vp_width = pg->surface_binding_dim.width,
@@ -1534,8 +1552,9 @@ static void begin_draw(PGRAPHState *pg)
          * The cache is scoped to this command buffer and invalidated by the
          * partial-clear path when it overwrites the Vulkan dynamic state.
          */
-        if (r->pipeline_binding->has_dynamic_blend_constants) {
-            update_blend_constants(pg);
+        if (r->pipeline_binding->dynamic_blend_constant_mask != 0) {
+            update_blend_constants(
+                pg, r->pipeline_binding->dynamic_blend_constant_mask);
         }
 
         bind_descriptor_sets(pg);

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1484,6 +1484,7 @@ static void begin_draw(PGRAPHState *pg)
         nv2a_profile_inc_counter(NV2A_PROF_PIPELINE_BIND);
         vkCmdBindPipeline(r->command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
                           r->pipeline_binding->pipeline);
+        pgraph_vk_blend_constants_cache_pipeline_bound(&r->blend_constants);
         r->pipeline_binding->draw_time = pg->draw_time;
 
         unsigned int vp_width = pg->surface_binding_dim.width,
@@ -1533,7 +1534,9 @@ static void begin_draw(PGRAPHState *pg)
          * The cache is scoped to this command buffer and invalidated by the
          * partial-clear path when it overwrites the Vulkan dynamic state.
          */
-        update_blend_constants(pg);
+        if (r->pipeline_binding->has_dynamic_blend_constants) {
+            update_blend_constants(pg);
+        }
 
         bind_descriptor_sets(pg);
         push_vertex_attr_values(pg);

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -651,7 +651,8 @@ static bool check_pipeline_dirty(PGRAPHState *pg)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
 
-    if (!r->pipeline_binding || r->shader_bindings_changed ||
+    if (!r->pipeline_binding || r->pipeline_binding->key.clear ||
+        r->shader_bindings_changed ||
         r->texture_bindings_changed || check_render_pass_dirty(pg)) {
         return true;
     }

--- a/hw/xbox/nv2a/pgraph/vk/renderer.c
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.c
@@ -90,6 +90,7 @@ static void pgraph_vk_flush(NV2AState *d)
     PGRAPHState *pg = &d->pgraph;
 
     pgraph_vk_finish(pg, VK_FINISH_REASON_FLUSH);
+    pgraph_vk_invalidate_blend_constants(pg);
     pgraph_vk_surface_flush(d);
     pgraph_vk_mark_textures_possibly_dirty(d, 0, memory_region_size(d->vram));
     pgraph_vk_update_vertex_ram_buffer(&d->pgraph, 0, d->vram_ptr,

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -37,6 +37,7 @@
 #include <spirv_reflect.h>
 #include <vk_mem_alloc.h>
 
+#include "blend-constants-cache.h"
 #include "debug.h"
 #include "constants.h"
 #include "glsl.h"
@@ -346,6 +347,7 @@ typedef struct PGRAPHVkState {
     unsigned int command_buffer_start_time;
     bool in_command_buffer;
     uint32_t submit_count;
+    PGRAPHVkBlendConstantsCache blend_constants;
 
     VkCommandBuffer aux_command_buffer;
     bool in_aux_command_buffer;
@@ -585,6 +587,7 @@ void pgraph_vk_draw_begin(NV2AState *d);
 void pgraph_vk_draw_end(NV2AState *d);
 void pgraph_vk_finish(PGRAPHState *pg, FinishReason why);
 void pgraph_vk_flush_draw(NV2AState *d);
+void pgraph_vk_invalidate_blend_constants(PGRAPHState *pg);
 void pgraph_vk_begin_command_buffer(PGRAPHState *pg);
 void pgraph_vk_ensure_command_buffer(PGRAPHState *pg);
 void pgraph_vk_ensure_not_in_render_pass(PGRAPHState *pg);

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -78,6 +78,7 @@ typedef struct PipelineBinding {
     VkRenderPass render_pass;
     unsigned int draw_time;
     bool has_dynamic_line_width;
+    bool has_dynamic_blend_constants;
 } PipelineBinding;
 
 enum Buffer {

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -66,7 +66,7 @@ typedef struct PipelineKey {
     bool clear;
     RenderPassState render_pass_state;
     ShaderState shader_state;
-    uint32_t regs[9];
+    uint32_t regs[8];
     VkVertexInputBindingDescription binding_descriptions[NV2A_VERTEXSHADER_ATTRIBUTES];
     VkVertexInputAttributeDescription attribute_descriptions[NV2A_VERTEXSHADER_ATTRIBUTES];
 } PipelineKey;
@@ -79,7 +79,7 @@ typedef struct PipelineBinding {
     VkRenderPass render_pass;
     unsigned int draw_time;
     bool has_dynamic_line_width;
-    bool has_dynamic_blend_constants;
+    uint32_t dynamic_blend_constant_mask;
 } PipelineBinding;
 
 enum Buffer {

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -20,6 +20,7 @@ tests = {
   'test-string-output-visitor': [testqapi],
   'test-visitor-serialization': [testqapi],
   'test-bitmap': [],
+  'test-xbox-vk-blend-constants': [],
   'test-resv-mem': [],
   # all code tested by test-x86-topo is inside topology.h
   'test-x86-topo': [],

--- a/tests/unit/test-xbox-vk-blend-constants.c
+++ b/tests/unit/test-xbox-vk-blend-constants.c
@@ -9,55 +9,112 @@ static void test_first_value_emits(void)
 {
     PGRAPHVkBlendConstantsCache cache = {0};
 
-    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0));
-    g_assert_true(cache.valid);
-    g_assert_cmphex(cache.guest_color, ==, 0);
+    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0,
+                                                         UINT32_MAX));
+    g_assert_true(cache.command_valid);
+    g_assert_cmphex(cache.command_guest_color, ==, 0);
 }
 
 static void test_identical_value_skips(void)
 {
     PGRAPHVkBlendConstantsCache cache = {0};
 
-    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x12345678));
-    g_assert_false(pgraph_vk_blend_constants_cache_update(&cache, 0x12345678));
-    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x12345679));
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x12345678, UINT32_MAX));
+    g_assert_false(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x12345678, UINT32_MAX));
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x12345679, UINT32_MAX));
 }
 
 static void test_invalidation_forces_emit(void)
 {
     PGRAPHVkBlendConstantsCache cache = {0};
 
-    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x89abcdef));
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x89abcdef, UINT32_MAX));
     pgraph_vk_blend_constants_cache_invalidate(&cache);
-    g_assert_false(cache.valid);
-    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x89abcdef));
+    g_assert_false(cache.command_valid);
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x89abcdef, UINT32_MAX));
+}
+
+static void test_dynamic_dynamic_transition(void)
+{
+    PGRAPHVkBlendConstantsCache cache = {0};
+
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache, true);
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x10203040, UINT32_MAX));
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache, true);
+    g_assert_false(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x10203040, UINT32_MAX));
 }
 
 static void test_dynamic_static_dynamic_transition(void)
 {
     PGRAPHVkBlendConstantsCache cache = {0};
 
-    pgraph_vk_blend_constants_cache_pipeline_bound(&cache);
-    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x10203040));
-    g_assert_false(pgraph_vk_blend_constants_cache_update(&cache, 0x10203040));
-
     /* Bind a static-state pipeline, then return to a dynamic-state pipeline. */
-    pgraph_vk_blend_constants_cache_pipeline_bound(&cache);
-    pgraph_vk_blend_constants_cache_pipeline_bound(&cache);
-    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x10203040));
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache, true);
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x10203040, UINT32_MAX));
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache, false);
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache, true);
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x10203040, UINT32_MAX));
 }
 
 static void test_dynamic_clear_dynamic_transition(void)
 {
     PGRAPHVkBlendConstantsCache cache = {0};
 
-    pgraph_vk_blend_constants_cache_pipeline_bound(&cache);
-    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x50607080));
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache, true);
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x50607080, UINT32_MAX));
 
     /* Full/depth clear binds a pipeline without setting blend constants. */
-    pgraph_vk_blend_constants_cache_pipeline_bound(&cache);
-    pgraph_vk_blend_constants_cache_pipeline_bound(&cache);
-    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x50607080));
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache, false);
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache, true);
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x50607080, UINT32_MAX));
+}
+
+static void test_alpha_only_ignores_rgb(void)
+{
+    PGRAPHVkBlendConstantsCache cache = {0};
+
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x12345678, 0xff000000));
+    g_assert_false(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x12abcdef, 0xff000000));
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x13abcdef, 0xff000000));
+}
+
+static void test_expanded_component_mask_forces_emit(void)
+{
+    PGRAPHVkBlendConstantsCache cache = {0};
+
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x12345678, 0xff000000));
+    g_assert_false(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x12abcdef, 0xff000000));
+    g_assert_true(pgraph_vk_blend_constants_cache_update(
+        &cache, 0x12abcdef, UINT32_MAX));
+}
+
+static void test_packed_value_survives_command_invalidation(void)
+{
+    PGRAPHVkBlendConstantsCache cache = {0};
+
+    g_assert_true(pgraph_vk_blend_constants_cache_needs_pack(
+        &cache, 0x12345678));
+    g_assert_false(pgraph_vk_blend_constants_cache_needs_pack(
+        &cache, 0x12345678));
+    pgraph_vk_blend_constants_cache_invalidate(&cache);
+    g_assert_false(pgraph_vk_blend_constants_cache_needs_pack(
+        &cache, 0x12345678));
 }
 
 int main(int argc, char **argv)
@@ -69,10 +126,18 @@ int main(int argc, char **argv)
                     test_identical_value_skips);
     g_test_add_func("/xbox/vulkan/blend-constants/invalidation",
                     test_invalidation_forces_emit);
+    g_test_add_func("/xbox/vulkan/blend-constants/dynamic-dynamic",
+                    test_dynamic_dynamic_transition);
     g_test_add_func("/xbox/vulkan/blend-constants/dynamic-static-dynamic",
                     test_dynamic_static_dynamic_transition);
     g_test_add_func("/xbox/vulkan/blend-constants/dynamic-clear-dynamic",
                     test_dynamic_clear_dynamic_transition);
+    g_test_add_func("/xbox/vulkan/blend-constants/alpha-only",
+                    test_alpha_only_ignores_rgb);
+    g_test_add_func("/xbox/vulkan/blend-constants/expanded-mask",
+                    test_expanded_component_mask_forces_emit);
+    g_test_add_func("/xbox/vulkan/blend-constants/packed-value",
+                    test_packed_value_survives_command_invalidation);
 
     return g_test_run();
 }

--- a/tests/unit/test-xbox-vk-blend-constants.c
+++ b/tests/unit/test-xbox-vk-blend-constants.c
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qemu/osdep.h"
+#include "hw/xbox/nv2a/pgraph/vk/blend-constants-cache.h"
+
+static void test_first_value_emits(void)
+{
+    PGRAPHVkBlendConstantsCache cache = {0};
+
+    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0));
+    g_assert_true(cache.valid);
+    g_assert_cmphex(cache.guest_color, ==, 0);
+}
+
+static void test_identical_value_skips(void)
+{
+    PGRAPHVkBlendConstantsCache cache = {0};
+
+    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x12345678));
+    g_assert_false(pgraph_vk_blend_constants_cache_update(&cache, 0x12345678));
+    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x12345679));
+}
+
+static void test_invalidation_forces_emit(void)
+{
+    PGRAPHVkBlendConstantsCache cache = {0};
+
+    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x89abcdef));
+    pgraph_vk_blend_constants_cache_invalidate(&cache);
+    g_assert_false(cache.valid);
+    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x89abcdef));
+}
+
+int main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/xbox/vulkan/blend-constants/first-value",
+                    test_first_value_emits);
+    g_test_add_func("/xbox/vulkan/blend-constants/identical-value",
+                    test_identical_value_skips);
+    g_test_add_func("/xbox/vulkan/blend-constants/invalidation",
+                    test_invalidation_forces_emit);
+
+    return g_test_run();
+}

--- a/tests/unit/test-xbox-vk-blend-constants.c
+++ b/tests/unit/test-xbox-vk-blend-constants.c
@@ -33,6 +33,33 @@ static void test_invalidation_forces_emit(void)
     g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x89abcdef));
 }
 
+static void test_dynamic_static_dynamic_transition(void)
+{
+    PGRAPHVkBlendConstantsCache cache = {0};
+
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache);
+    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x10203040));
+    g_assert_false(pgraph_vk_blend_constants_cache_update(&cache, 0x10203040));
+
+    /* Bind a static-state pipeline, then return to a dynamic-state pipeline. */
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache);
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache);
+    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x10203040));
+}
+
+static void test_dynamic_clear_dynamic_transition(void)
+{
+    PGRAPHVkBlendConstantsCache cache = {0};
+
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache);
+    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x50607080));
+
+    /* Full/depth clear binds a pipeline without setting blend constants. */
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache);
+    pgraph_vk_blend_constants_cache_pipeline_bound(&cache);
+    g_assert_true(pgraph_vk_blend_constants_cache_update(&cache, 0x50607080));
+}
+
 int main(int argc, char **argv)
 {
     g_test_init(&argc, &argv, NULL);
@@ -42,6 +69,10 @@ int main(int argc, char **argv)
                     test_identical_value_skips);
     g_test_add_func("/xbox/vulkan/blend-constants/invalidation",
                     test_invalidation_forces_emit);
+    g_test_add_func("/xbox/vulkan/blend-constants/dynamic-static-dynamic",
+                    test_dynamic_static_dynamic_transition);
+    g_test_add_func("/xbox/vulkan/blend-constants/dynamic-clear-dynamic",
+                    test_dynamic_clear_dynamic_transition);
 
     return g_test_run();
 }


### PR DESCRIPTION
## Summary

Avoid Vulkan pipeline creation and dynamic-state commands caused by blend-constant changes that cannot affect the active blend equation.

Blend constants are dynamic Vulkan state. They do not need to be part of pipeline identity, and they need to be emitted only when an active source or destination factor actually reads constant color or constant alpha.

### Previous flow

```text
Xbox blend color changes
        │
        ▼
Invalidate blend command state
        │
        ▼
Blend color participates in pipeline identity
        │
        ▼
Resolve/create another pipeline
        │
        ▼
Convert packed Xbox color to floats
        │
        ▼
Emit Vulkan blend constants
```

This could repeat even when blending was disabled, factors did not consume constants, an alpha-only factor ignored RGB, or the same packed value had already been converted.

### New flow

```text
Xbox blend color changes
        │
        ▼
Pipeline identity remains unchanged
        │
        ▼
Do active blend factors consume constants?
        │
        ├── No  ─► Emit nothing
        │
        └── Yes
              │
              ▼
        Which components are consumed?
              │
              ├── Alpha only ─► Ignore RGB-only changes
              └── Color       ─► Compare required RGBA components
                              │
                              ▼
                   Reuse packed conversion when valid
                              │
                              ▼
                   Emit only if command state differs
```

Compatible dynamic-to-dynamic pipeline changes preserve the cached command state. Command-buffer start, static blend state, and partial clear invalidate only the state they can replace.

## Performance effect

In the corrected sustained workload, identical fixed work generated 786,432 blend updates per run:

```text
Vulkan blend-constant commands: 49,152 -> 768  (-98.44%)
packed-color conversions:       49,152 -> 0
```

Ten A/B pairs produced exact hashes. Whole-stage median was 0.44% faster on a noisy shared host, so the defensible claim is the measured path reduction, not a global FPS percentage.

## Design rationale

The cache retains the original 32-bit Xbox color. Component relevance is derived from the active hardware blend factors, and equality is checked before float conversion. There is no cache capacity, age, lifetime, or update-frequency threshold.

## Test statistics

- Ten isolated A/B pairs, 786,432 blend updates per run.
- Vulkan blend-constant commands: 49,152 to 768 (-98.44%); packed-color conversions: 49,152 to 0.
- Whole-stage isolated median: 0.44% faster, treated as host noise rather than an FPS claim.
- Combined matrix: 1,008/1,008 records completed across both backends and scales.

## Validation

Blend-cache tests pass 9/9. The earlier OpenGL/Vulkan 1x/4x suite passed 456/456 records with exact hashes and zero Vulkan VUIDs. The final stacked Release configuration compiles on Linux. The 1,008-record result is cumulative-stack validation; the command and conversion counts above are the direct attribution for this PR.

## Dependencies

None. This submission is isolated from the internal validation stack for upstream review.

## Public validation suite

- Source and operator documentation: https://github.com/Mainkill1/xemu-perf-tests
- Ready-to-run ISO: https://github.com/Mainkill1/xemu-perf-tests/releases/tag/v1.0.0
- Full-suite gate: 141/141 records passed, zero oracle failures, and plain-disc boot verified on two Windows systems.
- ISO SHA-256: `7b8eb7af66a87fad93bcea019208457e42aaff2bd81b1353df2b6c378db7707c`
