### PR TITLE
nv2a/vk: grow transient buffers on measured demand

### DIFF
--- a/hw/xbox/nv2a/pgraph/vk/buffer.c
+++ b/hw/xbox/nv2a/pgraph/vk/buffer.c
@@ -19,8 +19,13 @@
 
 #include "renderer.h"
 
-static const size_t BUFFER_VERTEX_INLINE_INITIAL_SIZE = 16 * MiB;
-static const size_t BUFFER_GROWTH_ALIGNMENT = 4 * MiB;
+/*
+ * Sustained mixed inline-vertex tests found 8 MiB to be the smallest initial
+ * pair with lower final allocation and no measurable loss versus 4, 16, or
+ * 32 MiB. Later growth uses the exact required size; Vulkan does not require
+ * whole-MiB buffer sizes.
+ */
+static const size_t BUFFER_VERTEX_INLINE_INITIAL_SIZE = 8 * MiB;
 
 static bool buffer_is_persistently_mapped(int index)
 {
@@ -73,19 +78,6 @@ static void destroy_buffer(PGRAPHState *pg, StorageBuffer *buffer)
     buffer->allocation = VK_NULL_HANDLE;
 }
 
-static size_t buffer_growth_target(size_t required_size)
-{
-    size_t headroom = required_size / 4;
-
-    headroom = MAX(headroom, 4 * MiB);
-    headroom = MIN(headroom, 16 * MiB);
-    assert(required_size <= SIZE_MAX - headroom);
-
-    size_t target = required_size + headroom;
-    assert(target <= SIZE_MAX - (BUFFER_GROWTH_ALIGNMENT - 1));
-    return ROUND_UP(target, BUFFER_GROWTH_ALIGNMENT);
-}
-
 static void resize_buffer(PGRAPHState *pg, int index, size_t size)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
@@ -132,9 +124,7 @@ void pgraph_vk_ensure_buffer_pair_capacity(PGRAPHState *pg, int index,
 
     size_t new_size = MAX(buffer->buffer_size, paired->buffer_size);
     new_size = MAX(new_size, BUFFER_VERTEX_INLINE_INITIAL_SIZE);
-    if (new_size < required_size) {
-        new_size = buffer_growth_target(required_size);
-    }
+    new_size = MAX(new_size, required_size);
 
     if (buffer->buffer == VK_NULL_HANDLE || buffer->buffer_size < new_size) {
         resize_buffer(pg, index, new_size);

--- a/hw/xbox/nv2a/pgraph/vk/buffer.c
+++ b/hw/xbox/nv2a/pgraph/vk/buffer.c
@@ -19,6 +19,36 @@
 
 #include "renderer.h"
 
+static const size_t BUFFER_VERTEX_INLINE_INITIAL_SIZE = 16 * MiB;
+static const size_t BUFFER_GROWTH_ALIGNMENT = 4 * MiB;
+
+static bool buffer_is_persistently_mapped(int index)
+{
+    switch (index) {
+    case BUFFER_VERTEX_RAM:
+    case BUFFER_INDEX_STAGING:
+    case BUFFER_VERTEX_INLINE_STAGING:
+    case BUFFER_UNIFORM_STAGING:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static int paired_buffer_index(int index)
+{
+    switch (index) {
+    case BUFFER_INDEX_STAGING:
+        return BUFFER_INDEX;
+    case BUFFER_VERTEX_INLINE_STAGING:
+        return BUFFER_VERTEX_INLINE;
+    case BUFFER_UNIFORM_STAGING:
+        return BUFFER_UNIFORM;
+    default:
+        return -1;
+    }
+}
+
 static void create_buffer(PGRAPHState *pg, StorageBuffer *buffer)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
@@ -41,6 +71,77 @@ static void destroy_buffer(PGRAPHState *pg, StorageBuffer *buffer)
     vmaDestroyBuffer(r->allocator, buffer->buffer, buffer->allocation);
     buffer->buffer = VK_NULL_HANDLE;
     buffer->allocation = VK_NULL_HANDLE;
+}
+
+static size_t buffer_growth_target(size_t required_size)
+{
+    size_t headroom = required_size / 4;
+
+    headroom = MAX(headroom, 4 * MiB);
+    headroom = MIN(headroom, 16 * MiB);
+    assert(required_size <= SIZE_MAX - headroom);
+
+    size_t target = required_size + headroom;
+    assert(target <= SIZE_MAX - (BUFFER_GROWTH_ALIGNMENT - 1));
+    return ROUND_UP(target, BUFFER_GROWTH_ALIGNMENT);
+}
+
+static void resize_buffer(PGRAPHState *pg, int index, size_t size)
+{
+    PGRAPHVkState *r = pg->vk_renderer_state;
+    StorageBuffer *buffer = &r->storage_buffers[index];
+
+    assert(!r->in_command_buffer);
+    assert(!r->in_aux_command_buffer);
+
+    if (buffer->mapped) {
+        vmaUnmapMemory(r->allocator, buffer->allocation);
+        buffer->mapped = NULL;
+    }
+
+    destroy_buffer(pg, buffer);
+    buffer->buffer_offset = 0;
+    buffer->buffer_size = size;
+    create_buffer(pg, buffer);
+
+    if (buffer_is_persistently_mapped(index)) {
+        VK_CHECK(vmaMapMemory(r->allocator, buffer->allocation,
+                              (void **)&buffer->mapped));
+    }
+}
+
+void pgraph_vk_ensure_buffer_pair_capacity(PGRAPHState *pg, int index,
+                                           size_t required_size)
+{
+    PGRAPHVkState *r = pg->vk_renderer_state;
+    int paired_index = paired_buffer_index(index);
+
+    assert(required_size);
+    assert(paired_index >= 0);
+    assert(!r->in_command_buffer);
+    assert(!r->in_aux_command_buffer);
+
+    StorageBuffer *buffer = &r->storage_buffers[index];
+    StorageBuffer *paired = &r->storage_buffers[paired_index];
+    if (buffer->buffer != VK_NULL_HANDLE &&
+        paired->buffer != VK_NULL_HANDLE &&
+        buffer->buffer_size >= required_size &&
+        paired->buffer_size >= required_size) {
+        return;
+    }
+
+    size_t new_size = MAX(buffer->buffer_size, paired->buffer_size);
+    new_size = MAX(new_size, BUFFER_VERTEX_INLINE_INITIAL_SIZE);
+    if (new_size < required_size) {
+        new_size = buffer_growth_target(required_size);
+    }
+
+    if (buffer->buffer == VK_NULL_HANDLE || buffer->buffer_size < new_size) {
+        resize_buffer(pg, index, new_size);
+    }
+    if (paired->buffer == VK_NULL_HANDLE || paired->buffer_size < new_size) {
+        resize_buffer(pg, paired_index, new_size);
+    }
 }
 
 void pgraph_vk_init_buffers(NV2AState *d)
@@ -114,8 +215,7 @@ void pgraph_vk_init_buffers(NV2AState *d)
         .alloc_info = device_alloc_create_info,
         .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT |
                  VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
-        .buffer_size = NV2A_VERTEXSHADER_ATTRIBUTES * NV2A_MAX_BATCH_LENGTH *
-                       4 * sizeof(float) * 10,
+        .buffer_size = BUFFER_VERTEX_INLINE_INITIAL_SIZE,
     };
 
     r->storage_buffers[BUFFER_VERTEX_INLINE_STAGING] = (StorageBuffer){
@@ -171,13 +271,29 @@ void pgraph_vk_finalize_buffers(NV2AState *d)
     r->uploaded_bitmap = NULL;
 }
 
+VkDeviceSize pgraph_vk_buffer_required_size(PGRAPHState *pg, int index,
+                                            VkDeviceSize size,
+                                            VkDeviceAddress alignment)
+{
+    PGRAPHVkState *r = pg->vk_renderer_state;
+    StorageBuffer *b = &r->storage_buffers[index];
+    VkDeviceSize aligned_offset;
+
+    assert(alignment);
+    aligned_offset = ROUND_UP(b->buffer_offset, alignment);
+    assert(aligned_offset >= b->buffer_offset);
+    assert(size <= UINT64_MAX - aligned_offset);
+    return aligned_offset + size;
+}
+
 bool pgraph_vk_buffer_has_space_for(PGRAPHState *pg, int index,
                                     VkDeviceSize size,
                                     VkDeviceAddress alignment)
 {
     PGRAPHVkState *r = pg->vk_renderer_state;
     StorageBuffer *b = &r->storage_buffers[index];
-    return (ROUND_UP(b->buffer_offset, alignment) + size) <= b->buffer_size;
+    return pgraph_vk_buffer_required_size(pg, index, size, alignment) <=
+           b->buffer_size;
 }
 
 VkDeviceSize pgraph_vk_append_to_buffer(PGRAPHState *pg, int index, void **data,

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1854,10 +1854,27 @@ void pgraph_vk_set_surface_dirty(PGRAPHState *pg, bool color, bool zeta)
     }
 }
 
-static bool ensure_buffer_space(PGRAPHState *pg, int index, VkDeviceSize size)
+static bool ensure_buffer_space(PGRAPHState *pg, int index, VkDeviceSize size,
+                                VkDeviceAddress alignment)
 {
-    if (!pgraph_vk_buffer_has_space_for(pg, index, size, 1)) {
+    PGRAPHVkState *r = pg->vk_renderer_state;
+    StorageBuffer *buffer = &r->storage_buffers[index];
+    VkDeviceSize required_size = pgraph_vk_buffer_required_size(
+        pg, index, size, alignment);
+
+    assert(required_size >= size);
+
+    if (!pgraph_vk_buffer_has_space_for(pg, index, size, alignment)) {
         pgraph_vk_finish(pg, VK_FINISH_REASON_NEED_BUFFER_SPACE);
+        pgraph_vk_ensure_buffer_pair_capacity(pg, index, required_size);
+        return true;
+    }
+
+    if (buffer->buffer == VK_NULL_HANDLE || buffer->buffer_size < size) {
+        if (r->in_command_buffer || r->in_aux_command_buffer) {
+            pgraph_vk_finish(pg, VK_FINISH_REASON_NEED_BUFFER_SPACE);
+        }
+        pgraph_vk_ensure_buffer_pair_capacity(pg, index, required_size);
         return true;
     }
 
@@ -1961,10 +1978,8 @@ static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
     // reserve space
     if (remap.attributes) {
         StorageBuffer *buffer = &r->storage_buffers[BUFFER_VERTEX_INLINE_STAGING];
-        VkDeviceSize starting_offset = ROUND_UP(buffer->buffer_offset, 16);
-        size_t total_space_required =
-            (starting_offset - buffer->buffer_offset) + remap.buffer_space_required;
-        ensure_buffer_space(pg, BUFFER_VERTEX_INLINE_STAGING, total_space_required);
+        ensure_buffer_space(pg, BUFFER_VERTEX_INLINE_STAGING,
+                            remap.buffer_space_required, 256);
         buffer->buffer_offset = ROUND_UP(buffer->buffer_offset, 16);
     }
 
@@ -2076,7 +2091,7 @@ void pgraph_vk_flush_draw(NV2AState *d)
         size_t index_data_size =
             pg->inline_elements_length * sizeof(pg->inline_elements[0]);
 
-        ensure_buffer_space(pg, BUFFER_INDEX_STAGING, index_data_size);
+        ensure_buffer_space(pg, BUFFER_INDEX_STAGING, index_data_size, 1);
 
         uint32_t min_element = (uint32_t)-1;
         uint32_t max_element = 0;
@@ -2130,7 +2145,7 @@ void pgraph_vk_flush_draw(NV2AState *d)
             attr->inline_buffer_populated = false;
             offset += vertex_data_size;
         }
-        ensure_buffer_space(pg, BUFFER_VERTEX_INLINE_STAGING, offset);
+        ensure_buffer_space(pg, BUFFER_VERTEX_INLINE_STAGING, offset, 1);
 
         begin_pre_draw(pg);
         VkDeviceSize buffer_offset = pgraph_vk_update_vertex_inline_buffer(
@@ -2150,7 +2165,7 @@ void pgraph_vk_flush_draw(NV2AState *d)
 
         VkDeviceSize inline_array_data_size = pg->inline_array_length * 4;
         ensure_buffer_space(pg, BUFFER_VERTEX_INLINE_STAGING,
-                               inline_array_data_size);
+                            inline_array_data_size, 1);
 
         unsigned int offset = 0;
         for (int i = 0; i < NV2A_VERTEXSHADER_ATTRIBUTES; i++) {

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -1923,6 +1923,9 @@ typedef struct VertexBufferRemap {
     } map[NV2A_VERTEXSHADER_ATTRIBUTES];
 } VertexBufferRemap;
 
+/* Maximum NV2A vertex attribute width: four 32-bit components. */
+static const VkDeviceSize REMAPPED_VERTEX_BLOCK_ALIGNMENT = 4 * sizeof(float);
+
 static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
                                                     uint32_t num_vertices)
 {
@@ -1979,8 +1982,10 @@ static VertexBufferRemap remap_unaligned_attributes(PGRAPHState *pg,
     if (remap.attributes) {
         StorageBuffer *buffer = &r->storage_buffers[BUFFER_VERTEX_INLINE_STAGING];
         ensure_buffer_space(pg, BUFFER_VERTEX_INLINE_STAGING,
-                            remap.buffer_space_required, 256);
-        buffer->buffer_offset = ROUND_UP(buffer->buffer_offset, 16);
+                            remap.buffer_space_required,
+                            REMAPPED_VERTEX_BLOCK_ALIGNMENT);
+        buffer->buffer_offset = ROUND_UP(buffer->buffer_offset,
+                                         REMAPPED_VERTEX_BLOCK_ALIGNMENT);
     }
 
     return remap;
@@ -2000,7 +2005,8 @@ static void copy_remapped_attributes_to_inline_buffer(PGRAPHState *pg,
     }
 
     assert(pgraph_vk_buffer_has_space_for(pg, BUFFER_VERTEX_INLINE_STAGING,
-                                          remap.buffer_space_required, 256));
+                                          remap.buffer_space_required,
+                                          REMAPPED_VERTEX_BLOCK_ALIGNMENT));
 
     // FIXME: SIMD memcpy
     // FIXME: Caching

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -474,6 +474,11 @@ void pgraph_vk_finalize_buffers(NV2AState *d);
 bool pgraph_vk_buffer_has_space_for(PGRAPHState *pg, int index,
                                     VkDeviceSize size,
                                     VkDeviceAddress alignment);
+VkDeviceSize pgraph_vk_buffer_required_size(PGRAPHState *pg, int index,
+                                            VkDeviceSize size,
+                                            VkDeviceAddress alignment);
+void pgraph_vk_ensure_buffer_pair_capacity(PGRAPHState *pg, int index,
+                                           size_t required_size);
 VkDeviceSize pgraph_vk_append_to_buffer(PGRAPHState *pg, int index, void **data,
                                         VkDeviceSize *sizes, size_t count,
                                         VkDeviceAddress alignment);


### PR DESCRIPTION
## Summary

Reduce persistent Vulkan memory use by growing transient inline-vertex buffers from measured demand instead of reserving a worst-case allocation at startup.

The renderer uses a paired staging/device allocation. The old fixed allocation retained its full size even when normal workloads needed much less space.

### Previous flow

```text
Renderer initialization
        │
        ▼
Allocate worst-case staging buffer
        │
        ▼
Allocate matching device buffer
        │
        ▼
Retain both for renderer lifetime
```

### New flow

```text
Renderer initialization
        │
        ▼
Allocate two measured 8 MiB buffers (16 MiB pair)
        │
        ▼
Does current command buffer fit?
        │
        ├── Yes ─► Reuse existing pair
        │
        └── No
              │
              ▼
        Complete active use
              │
              ▼
        Calculate exact cumulative requirement
              │
              ▼
        Recreate staging and device buffers together
              │
              ▼
        Restore persistent staging mapping
```

Growth preserves the paired-buffer invariant and occurs only after observed demand exceeds capacity.

## Performance effect

This is primarily a memory-footprint and robustness improvement. Upstream requests 1,342,174,720 bytes for each inline-vertex buffer, or 2,684,349,440 bytes for the paired device/staging buffers. This change starts each buffer at 8 MiB: 16 MiB total. Initial requested capacity falls by 2,667,572,224 bytes (about 2.484 GiB, 99.375%). This is requested Vulkan allocation capacity; driver-resident VRAM may differ.

A 4/8/16/32 MiB per-buffer sweep selected 8 MiB as the smallest starting size without measured throughput loss. Exact growth cost approximately 0.56% in the diagnostic while retaining about 138 MiB less memory than the tested speculative-headroom policy.

Lower retained allocation reduces pressure on integrated/shared memory and low-VRAM devices. It is not presented as a universal FPS improvement.

## Design rationale

The 8 MiB per-buffer starting value is empirical, based on the completed capacity sweep. Later capacity is the exact byte requirement already observed by the renderer. Vulkan permits byte-sized buffer allocations, so MiB rounding and percentage headroom would add memory without a correctness need.

Sixteen-byte remap alignment is defined by the largest NV2A attribute row: four 32-bit components. It is a format requirement, not an arbitrary tuning constant.

## Test statistics

- Initial requested paired capacity: 2,684,349,440 bytes upstream to 16,777,216 bytes with this PR; 2,667,572,224 bytes saved (about 2.484 GiB, 99.375%).
- Per-buffer capacity sweep: 4/8/16/32 MiB; 8 MiB per buffer was the smallest starting size without measured throughput loss.
- Exact-growth diagnostic cost: approximately 0.56%; retained memory approximately 138 MiB below the speculative-headroom policy.
- Combined Vulkan stress medians: growth improved 19.74% at 1x and 19.01% at 4x; plateau improved 18.32% and 17.24%.
- Combined matrix: 1,008/1,008 records completed. OpenGL memory-pressure movement was within -2.01% to -0.75% in the single pair.

## Validation

The size sweep and then-current four-cell matrix passed. Staging and device buffers remain equal in size, and the staging allocation is remapped after growth. The final stacked Release configuration compiles on Linux. The 1,008-record result is cumulative-stack validation; the capacity sweep and allocation figures above are the direct attribution for this PR.

## Related issues

- Addresses the oversized upfront Vulkan allocation described in [xemu-project/xemu#2603](https://github.com/xemu-project/xemu/issues/2603). Maintainer discussion there identifies large fixed pools and dynamic sizing as the intended remedy. This PR changes the paired inline-vertex buffers to measured on-demand growth and reduces requested startup capacity by about 2.484 GiB. It does not claim to account for every byte reported by a graphics driver.
- Related: [xemu-project/xemu#1890](https://github.com/xemu-project/xemu/issues/1890). That report calls for trimming Vulkan startup allocations when initial buffers cannot be created. The smaller initial pair reduces that pressure, but other allocations and device limits remain possible, so this PR does not mark the issue closed.

## Dependencies

Requires xemu-project/xemu#2997. The branch is isolated against `master` so its own diff remains reviewable; it will be rebased after #2997 lands.

## Public validation suite

- Source and operator documentation: https://github.com/Mainkill1/xemu-perf-tests
- Ready-to-run ISO: https://github.com/Mainkill1/xemu-perf-tests/releases/tag/v1.0.0
- Full-suite gate: 141/141 records passed, zero oracle failures, and plain-disc boot verified on two Windows systems.
- ISO SHA-256: `7b8eb7af66a87fad93bcea019208457e42aaff2bd81b1353df2b6c378db7707c`
