### PR TITLE
ci: Run unit tests alongside build

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -1,0 +1,30 @@
+name: Unit tests
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: Run unit tests
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Download source package
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+      with:
+        name: src
+    - name: Extract source package
+      run: |
+        mkdir src
+        tar -xf xemu-*.tar.zst -C src --strip-components=2
+    - name: Install dependencies
+      run: |
+        sudo apt-get -qy update
+        pushd src
+        sudo apt-get -qy build-dep .
+        popd
+    - name: Configure
+      working-directory: src
+      run: ./configure --target-list=i386-softmmu --disable-werror
+    - name: Run unit tests
+      working-directory: src
+      run: make -j$(nproc) check-unit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,3 +76,8 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       pkg_version: ${{ needs.source.outputs.pkg_version }}
+
+  test:
+    name: Unit tests
+    needs: source
+    uses: ./.github/workflows/build-tests.yml


### PR DESCRIPTION
At the moment this is mainly to keep bot-generated CLs from breaking any tested QEMU bits, but I think generally having more unit tests on the Xbox-specific codebase would be good (I'm hopefully adding some in #3035).