### PR TITLE
meson: Track SDL3 with a git wrap

### DIFF
--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -38,6 +38,6 @@ implot
 genconfig
 curl-*
 json-*
-SDL3-*
+sdl3
 /dsp56300/*
 !/dsp56300/meson.build

--- a/subprojects/sdl3.wrap
+++ b/subprojects/sdl3.wrap
@@ -1,10 +1,11 @@
-[wrap-file]
-directory = SDL3-3.4.10
-source_url = https://github.com/libsdl-org/SDL/releases/download/release-3.4.10/SDL3-3.4.10.tar.gz
-source_filename = SDL3-3.4.10.tar.gz
-source_hash = 12b34280415ec8418c864408b93d008a20a6530687ee613d60bfbd20411f2785
-source_fallback_url = https://github.com/libsdl-org/SDL/releases/download/release-3.4.10/SDL3-3.4.10.tar.gz
+[wrap-git]
+url = https://github.com/libsdl-org/SDL
+revision = 8e37db5e797b6167f3a00d697d816a684bd259c7
+depth = 1
 method = cmake
 
 [provide]
 dependency_names = sdl3
+
+[update]
+tag_regex = ^release-\d+\.\d+\.\d+$


### PR DESCRIPTION
sdl3.wrap was a hand-written [wrap-file] pointing straight at upstream release tarballs. The bump script hands every [wrap-file] to `meson wrap update`, which needs a wrapdb_version field to work, so SDL3 was silently skipped on every run and had to be bumped by hand. WrapDB's own sdl3 package trails upstream, so pointing back at it is not the answer either.

A git wrap goes through the script's existing GitHub path, which already resolves the newest matching tag and rewrites the revision. SDL tags releases as release-X.Y.Z, which the default semver pattern does not match, so give the wrap a tag_regex like glslang and SPIRV-Reflect have.

The release tarball is a git export plus REVISION.txt, so the only build difference is that SDL's CMakeLists now takes its non-release path for the revision string it reports.

---

LLM: Opus 5